### PR TITLE
Issue #680 "Partitioning doesn't work for Wells"

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -18,6 +18,8 @@ Fixed
   into multiple models.
 - Fixed erronous default value for the ``out_of_bounds`` in
   :function:`imod.select.points.point_values`
+- Fixed bug where :class:`imod.mf6.Well` could not be assigned to the first cell
+  of an unstructured grid.
 
 Added
 ~~~~~

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -16,10 +16,18 @@ Fixed
   :class:`imod.mf6.SpecificStorage`, :class:`imod.mf6.StorageCoefficient`.
 - Fixed bug where simulations with :class:`imod.mf6.Well` were not partitioned
   into multiple models.
+- Fixed erronous default value for the ``out_of_bounds`` in
+  :function:`imod.select.points.point_values`
 
 Added
 ~~~~~
 - Added comment in Modflow6 exchanges file (GWFGWF) denoting column header.
+
+Changed
+~~~~~~~
+- :meth:`imod.mf6.Well.mask` masks with a 2D grid instead of returning a
+  deepcopy of the package.
+
 
 [0.15.0] - 2023-11-25
 ---------------------

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -14,6 +14,8 @@ Fixed
 ~~~~~
 - Made ``specific_yield`` optional argument in
   :class:`imod.mf6.SpecificStorage`, :class:`imod.mf6.StorageCoefficient`.
+- Fixed bug where simulations with :class:`imod.mf6.Well` were not partitioned
+  into multiple models.
 
 Added
 ~~~~~

--- a/imod/mf6/utilities/clip.py
+++ b/imod/mf6/utilities/clip.py
@@ -11,6 +11,7 @@ from imod.mf6.interfaces.ipackagebase import IPackageBase
 from imod.mf6.interfaces.ipointdatapackage import IPointDataPackage
 from imod.mf6.utilities.dataset import get_scalar_variables
 from imod.mf6.utilities.grid import get_active_domain_slice
+from imod.select.points import points_values
 from imod.typing import GridDataArray, ScalarDataset
 from imod.typing.grid import bounding_polygon, is_spatial_2D
 
@@ -51,12 +52,13 @@ def clip_by_grid(package: IPackageBase, active: xu.UgridDataArray) -> IPackageBa
 
 @typedispatch
 def clip_by_grid(
-    package: IPointDataPackage, active: xu.UgridDataArray
+    package: IPointDataPackage, active: GridDataArray
 ) -> IPointDataPackage:
-    """Clip PointDataPackage outside unstructured grid."""
-    points = np.column_stack((package.x, package.y))
+    """Clip PointDataPackage outside grid."""
 
-    is_inside_exterior = active.grid.locate_points(points) != -1
+    point_active = points_values(active, x=package.x, y=package.y)
+
+    is_inside_exterior = point_active == 1
     selection = package.dataset.loc[{"index": is_inside_exterior}]
 
     cls = type(package)

--- a/imod/mf6/utilities/clip.py
+++ b/imod/mf6/utilities/clip.py
@@ -59,8 +59,12 @@ def clip_by_grid(
     # Drop layer coordinate if present, otherwise a layer coordinate is assigned
     # which causes conflicts downstream when assigning wells and deriving
     # cellids.
-    active = active.drop("layer", errors="ignore")
-    point_active = points_values(active, x=package.x, y=package.y)
+    active = active.isel(layer=0, drop=True, missing_dims="ignore").drop(
+        "layer", errors="ignore"
+    )
+    point_active = points_values(
+        active, x=package.x, y=package.y, out_of_bounds="ignore"
+    )
 
     is_inside_exterior = point_active == 1
     selection = package.dataset.loc[{"index": is_inside_exterior}]

--- a/imod/mf6/utilities/clip.py
+++ b/imod/mf6/utilities/clip.py
@@ -56,6 +56,10 @@ def clip_by_grid(
 ) -> IPointDataPackage:
     """Clip PointDataPackage outside grid."""
 
+    # Drop layer coordinate if present, otherwise a layer coordinate is assigned
+    # which causes conflicts downstream when assigning wells and deriving
+    # cellids.
+    active = active.drop("layer", errors="ignore")
     point_active = points_values(active, x=package.x, y=package.y)
 
     is_inside_exterior = point_active == 1

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -492,7 +492,8 @@ class Well(BoundaryCondition, IPointDataPackage):
         grid-agnostic, instead this method clips the package based on the grid
         exterior.
         """
-        return clip_by_grid(self, target_grid)
+        target_grid_2d = target_grid.isel(layer=0, drop=True, missing_dims="ignore")
+        return clip_by_grid(self, target_grid_2d)
 
     def mask(self, domain: GridDataArray) -> "Well":
         """

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -45,8 +45,8 @@ def _assign_dims(arg) -> Dict:
         return ("index", arg)
 
 
-def mask_2D(package: Well, grid_2d: GridDataArray) -> Well:
-    point_active = points_values(grid_2d, x=package.x, y=package.y)
+def mask_2D(package: Well, domain_2d: GridDataArray) -> Well:
+    point_active = points_values(domain_2d, x=package.x, y=package.y)
 
     is_inside_exterior = point_active == 1
     selection = package.dataset.loc[{"index": is_inside_exterior}]

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import warnings
-from copy import deepcopy
 from typing import Dict, List, Union
 
 import numpy as np
@@ -18,7 +17,6 @@ from imod.mf6.boundary_condition import (
 )
 from imod.mf6.interfaces.ipointdatapackage import IPointDataPackage
 from imod.mf6.mf6_wel_adapter import Mf6Wel
-from imod.mf6.package import Package
 from imod.mf6.utilities.clip import clip_by_grid
 from imod.mf6.utilities.dataset import remove_inactive
 from imod.mf6.write_context import WriteContext

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -190,7 +190,7 @@ class Well(BoundaryCondition, IPointDataPackage):
         x_max=None,
         y_min=None,
         y_max=None,
-    ) -> "Well":
+    ) -> Well:
         """
         Clip a package by a bounding box (time, layer, y, x).
 
@@ -486,7 +486,7 @@ class Well(BoundaryCondition, IPointDataPackage):
 
         return Mf6Wel(**ds)
 
-    def regrid_like(self, target_grid: GridDataArray, *_) -> "Well":
+    def regrid_like(self, target_grid: GridDataArray, *_) -> Well:
         """
         The regrid_like method is irrelevant for this package as it is
         grid-agnostic, instead this method clips the package based on the grid
@@ -495,7 +495,7 @@ class Well(BoundaryCondition, IPointDataPackage):
         target_grid_2d = target_grid.isel(layer=0, drop=True, missing_dims="ignore")
         return clip_by_grid(self, target_grid_2d)
 
-    def mask(self, domain: GridDataArray) -> "Well":
+    def mask(self, domain: GridDataArray) -> Well:
         """
         Mask wells based on two-dimensional domain. For three-dimensional
         masking: Wells falling in inactive cells are automatically removed in

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -498,10 +498,10 @@ class Well(BoundaryCondition, IPointDataPackage):
 
     def mask(self, domain: GridDataArray) -> "Well":
         """
-        The Well package has no mask method implemented. Wells falling in
-        inactive cells are automatically removed in the call to write to
-        Modflow 6 package. You can verify this by calling the ``to_mf6_pkg``
-        method.
+        Mask wells based on two-dimensional domain. For three-dimensional
+        masking: Wells falling in inactive cells are automatically removed in
+        the call to write to Modflow 6 package. You can verify this by calling
+        the ``to_mf6_pkg`` method.
         """
 
         # Drop layer coordinate if present, otherwise a layer coordinate is assigned

--- a/imod/prepare/wells.py
+++ b/imod/prepare/wells.py
@@ -167,7 +167,7 @@ def assign_wells(
     wells_in_bounds["overlap"] = 1.0
     wells_in_bounds["k"] = 1.0
     wells_in_bounds["transmissivity"] = 1.0
-    columns = list(set(wells_in_bounds.columns).difference(df))
+    columns = list(set(wells_in_bounds.columns).difference(df.columns))
 
     indexes = ["id"]
     for dim in ["species", "time"]:

--- a/imod/select/points.py
+++ b/imod/select/points.py
@@ -104,7 +104,7 @@ def points_in_bounds(da, **points):
     if isinstance(da, xu.UgridDataArray):
         index = get_unstructured_cell2d_from_xy(da, **points)
         # xu.Ugrid2d.locate_points makes cells outside grid -1
-        in_bounds = index > 0
+        in_bounds = index > -1
         points.pop("x")
         points.pop("y")
 

--- a/imod/select/points.py
+++ b/imod/select/points.py
@@ -243,7 +243,7 @@ def points_indices(da, out_of_bounds="raise", **points):
     return indices
 
 
-def points_values(da, out_of_bounds="error", **points):
+def points_values(da, out_of_bounds="raise", **points):
     """
     Get values from specified points.
 

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -1,9 +1,9 @@
 from pathlib import Path
-from typing import Dict
 
 import numpy as np
 import pytest
 import xarray as xr
+from pytest_cases import case, parametrize_with_cases
 
 import imod
 from imod.mf6 import Modflow6Simulation
@@ -11,85 +11,94 @@ from imod.mf6.wel import Well
 from imod.typing.grid import zeros_like
 
 
-def setup_partitioning_arrays(idomain_top: xr.DataArray) -> Dict[str, xr.DataArray]:
-    result = {}
-    diagonal_submodel_labels_1 = zeros_like(idomain_top)
+@pytest.mark.usefixtures("transient_twri_model")
+@pytest.fixture(scope="function")
+def idomain_top(transient_twri_model):
+    idomain = transient_twri_model["GWF_1"].domain
+    return idomain.isel(layer=0)
 
-    """
-    a diagonal partition boundary
-    [0, 0, 0, 0],
-    [1, 0, 0, 0],
-    [1, 1, 0, 0],
-    [1, 1, 1, 0],
-    [1, 1, 1, 1],
-    """
-    for i in range(15):
-        for j in range(i):
-            diagonal_submodel_labels_1.values[i, j] = 1
-    result["diagonal_1"] = diagonal_submodel_labels_1
 
-    """
-    another diagonal boundary
-    [1, 1, 1, 1],
-    [1, 1, 1, 0],
-    [1, 1, 0, 0],
-    [1, 0, 0, 0],
-    """
-    diagonal_submodel_labels_2 = zeros_like(idomain_top)
-    for i in range(15):
-        for j in range(15 - i):
-            diagonal_submodel_labels_2.values[i, j] = 1
-    result["diagonal_2"] = diagonal_submodel_labels_2
+class PartitionArrayCases:
+    def case_diagonal_array_1(self, idomain_top):
+        diagonal_submodel_labels_1 = zeros_like(idomain_top)
 
-    """
-    4 square domains
-    [0, 0, 1, 1],
-    [0, 0, 1, 1],
-    [2, 2, 3, 3],
-    [2, 2, 3, 3],
-    """
-    four_squares = zeros_like(idomain_top)
-    four_squares.values[0:7, 0:7] = 0
-    four_squares.values[0:7, 7:] = 1
-    four_squares.values[7:, 0:7] = 2
-    four_squares.values[7:, 7:] = 3
-    result["four_squares"] = four_squares
+        """
+        a diagonal partition boundary
+        [0, 0, 0, 0],
+        [1, 0, 0, 0],
+        [1, 1, 0, 0],
+        [1, 1, 1, 0],
+        [1, 1, 1, 1],
+        """
+        for i in range(15):
+            for j in range(i):
+                diagonal_submodel_labels_1.values[i, j] = 1
+        return diagonal_submodel_labels_1
 
-    """
-    contains a single cell with 3 neighbors in another partitions
-    [0, 0, 1, 1],
-    [0, 0, 1, 1],
-    [0, 0, 0, 1],
-    [0, 0, 1, 1],
-    """
+    def case_diagonal_array_2(self, idomain_top):
+        """
+        another diagonal boundary
+        [1, 1, 1, 1],
+        [1, 1, 1, 0],
+        [1, 1, 0, 0],
+        [1, 0, 0, 0],
+        """
+        diagonal_submodel_labels_2 = zeros_like(idomain_top)
+        for i in range(15):
+            for j in range(15 - i):
+                diagonal_submodel_labels_2.values[i, j] = 1
+        return diagonal_submodel_labels_2
 
-    intrusion = zeros_like(idomain_top)
-    intrusion.values[0:15, 0:8] = 0
-    intrusion.values[0:15, 8:] = 1
-    intrusion.values[8, 8] = 0
-    result["intrusion"] = intrusion
+    def case_four_squares(self, idomain_top):
+        """
+        4 square domains
+        [0, 0, 1, 1],
+        [0, 0, 1, 1],
+        [2, 2, 3, 3],
+        [2, 2, 3, 3],
+        """
+        four_squares = zeros_like(idomain_top)
+        four_squares.values[0:7, 0:7] = 0
+        four_squares.values[0:7, 7:] = 1
+        four_squares.values[7:, 0:7] = 2
+        four_squares.values[7:, 7:] = 3
+        return four_squares
 
-    """
-    partition forms an island in another partition
-    [0, 0, 0, 0],
-    [0, 1, 1, 0],
-    [0, 1, 1, 0],
-    [0, 0, 0, 0],
-    """
-    island = zeros_like(idomain_top)
-    island.values[2:5, 2:5] = 1
-    result["island"] = island
+    @case(tags="intrusion")
+    def case_intrusion(self, idomain_top):
+        """
+        contains a single cell with 3 neighbors in another partitions
+        [0, 0, 1, 1],
+        [0, 0, 1, 1],
+        [0, 0, 0, 1],
+        [0, 0, 1, 1],
+        """
 
-    return result
+        intrusion = zeros_like(idomain_top)
+        intrusion.values[0:15, 0:8] = 0
+        intrusion.values[0:15, 8:] = 1
+        intrusion.values[8, 8] = 0
+        return intrusion
+
+    def case_island(self, idomain_top):
+        """
+        partition forms an island in another partition
+        [0, 0, 0, 0],
+        [0, 1, 1, 0],
+        [0, 1, 1, 0],
+        [0, 0, 0, 0],
+        """
+        island = zeros_like(idomain_top)
+        island.values[2:5, 2:5] = 1
+        return island
 
 
 @pytest.mark.usefixtures("transient_twri_model")
-@pytest.mark.parametrize(
-    "partition_name",
-    ["diagonal_1", "diagonal_2", "four_squares", "intrusion", "island"],
-)
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_structured(
-    tmp_path: Path, transient_twri_model: Modflow6Simulation, partition_name: str
+    tmp_path: Path,
+    transient_twri_model: Modflow6Simulation,
+    partition_array: xr.DataArray,
 ):
     simulation = transient_twri_model
 
@@ -104,10 +113,7 @@ def test_partitioning_structured(
     )
 
     # partition the simulation, run it, and save the (merged) results
-    idomain = simulation["GWF_1"].domain
-    partitioning_arrays = setup_partitioning_arrays(idomain.isel(layer=0))
-
-    split_simulation = simulation.split(partitioning_arrays[partition_name])
+    split_simulation = simulation.split(partition_array)
 
     split_simulation.write(tmp_path, binary=False)
     split_simulation.run()
@@ -122,17 +128,16 @@ def test_partitioning_structured(
 
 
 @pytest.mark.usefixtures("transient_twri_model")
-@pytest.mark.parametrize(
-    "partition_name",
-    ["diagonal_1", "diagonal_2", "four_squares", "intrusion", "island"],
-)
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_structured_with_inactive_cells(
-    tmp_path: Path, transient_twri_model: Modflow6Simulation, partition_name: str
+    tmp_path: Path,
+    transient_twri_model: Modflow6Simulation,
+    partition_array: xr.DataArray,
 ):
     simulation = transient_twri_model
     idomain = simulation["GWF_1"].domain
     idomain.loc[{"x": 32500, "y": slice(67500, 7500)}] = 0
-    for name, package in simulation["GWF_1"].items():
+    for _, package in simulation["GWF_1"].items():
         if not isinstance(package, Well):
             for arrayname in package.dataset.keys():
                 if "x" in package[arrayname].coords:
@@ -156,9 +161,7 @@ def test_partitioning_structured_with_inactive_cells(
     )
 
     # partition the simulation, run it, and save the (merged) results
-    partitioning_arrays = setup_partitioning_arrays(idomain.isel(layer=0))
-
-    split_simulation = simulation.split(partitioning_arrays[partition_name])
+    split_simulation = simulation.split(partition_array)
 
     split_simulation.write(tmp_path, binary=False)
     split_simulation.run()
@@ -173,12 +176,11 @@ def test_partitioning_structured_with_inactive_cells(
 
 
 @pytest.mark.usefixtures("transient_twri_model")
-@pytest.mark.parametrize(
-    "partition_name",
-    ["diagonal_1", "diagonal_2", "four_squares", "intrusion", "island"],
-)
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_structured_with_vpt_cells(
-    tmp_path: Path, transient_twri_model: Modflow6Simulation, partition_name: str
+    tmp_path: Path,
+    transient_twri_model: Modflow6Simulation,
+    partition_array: xr.DataArray,
 ):
     simulation = transient_twri_model
     idomain = simulation["GWF_1"].domain
@@ -209,9 +211,7 @@ def test_partitioning_structured_with_vpt_cells(
     )
 
     # partition the simulation, run it, and save the (merged) results
-    partitioning_arrays = setup_partitioning_arrays(idomain.isel(layer=0))
-
-    split_simulation = simulation.split(partitioning_arrays[partition_name])
+    split_simulation = simulation.split(partition_array)
 
     split_simulation.write(tmp_path, binary=False)
     split_simulation.run()
@@ -226,16 +226,16 @@ def test_partitioning_structured_with_vpt_cells(
 
 
 @pytest.mark.usefixtures("transient_twri_model")
+@parametrize_with_cases(
+    "partition_array", cases=PartitionArrayCases, has_tag="intrusion"
+)
 def test_partitioning_structured_geometry_auxiliary_variables(
-    transient_twri_model: Modflow6Simulation,
+    transient_twri_model: Modflow6Simulation, partition_array: xr.DataArray
 ):
     simulation = transient_twri_model
 
     # partition the simulation, run it, and save the (merged) results
-    idomain = simulation["GWF_1"].domain
-    partitioning_arrays = setup_partitioning_arrays(idomain.isel(layer=0))
-    partition_name = "intrusion"
-    split_simulation = simulation.split(partitioning_arrays[partition_name])
+    split_simulation = simulation.split(partition_array)
 
     np.testing.assert_almost_equal(
         split_simulation["split_exchanges"][0].dataset["cdist"].values, 5000.0
@@ -301,12 +301,11 @@ def test_partitioning_structured_geometry_auxiliary_variables(
 
 
 @pytest.mark.usefixtures("transient_twri_model")
-@pytest.mark.parametrize(
-    "partition_name",
-    ["diagonal_1", "diagonal_2", "four_squares", "intrusion", "island"],
-)
-def test_partitioning_structured_high_level_well(
-    tmp_path: Path, transient_twri_model: Modflow6Simulation, partition_name: str
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
+def test_partitioning_structured_one_high_level_well(
+    tmp_path: Path,
+    transient_twri_model: Modflow6Simulation,
+    partition_array: xr.DataArray,
 ):
     """
     In this test we include a high-level well package with 1 well in it to the
@@ -337,10 +336,7 @@ def test_partitioning_structured_high_level_well(
     )
 
     # partition the simulation, run it, and save the (merged) results
-    idomain = simulation["GWF_1"].domain
-    partitioning_arrays = setup_partitioning_arrays(idomain.isel(layer=0))
-
-    split_simulation = simulation.split(partitioning_arrays[partition_name])
+    split_simulation = simulation.split(partition_array)
 
     split_simulation.write(tmp_path, binary=False)
     split_simulation.run()

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
@@ -221,7 +221,9 @@ def test_partitioning_unstructured_with_well(
     simulation["GWF_1"]["rch"]["rate"] *= 100
 
     # Add well
-    well = imod.mf6.Well(x=500.0, y=0.0, screen_top=3.0, screen_bottom=2.0, rate=1.0)
+    well = imod.mf6.Well(
+        x=[500.0], y=[0.0], screen_top=[3.0], screen_bottom=[2.0], rate=[1.0]
+    )
     simulation["GWF_1"]["well"] = well
 
     # run the original example, so without partitioning, and save the simulation results

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
@@ -234,10 +234,12 @@ def test_partitioning_unstructured_with_well(
         orig_dir / "GWF_1/disv.disv.grb",
     )
 
-    orig_cbc = imod.mf6.open_cbc(
-        orig_dir / "GWF_1/GWF_1.cbc",
-        orig_dir / "GWF_1/disv.disv.grb",
-    )
+    # TODO:
+    # Uncomment when fixed: https://gitlab.com/deltares/imod/imod-python/-/issues/683
+    # orig_cbc = imod.mf6.open_cbc(
+    #     orig_dir / "GWF_1/GWF_1.cbc",
+    #     orig_dir / "GWF_1/disv.disv.grb",
+    # )
 
     # partition the simulation, run it, and save the (merged) results
     idomain = simulation["GWF_1"].domain
@@ -249,12 +251,16 @@ def test_partitioning_unstructured_with_well(
     split_simulation.run()
 
     head = split_simulation.open_head()
-    cbc = split_simulation.open_flow_budget()
+    # TODO:
+    # Uncomment when fixed: https://gitlab.com/deltares/imod/imod-python/-/issues/683
+    # cbc = split_simulation.open_flow_budget()
 
     # compare the head result of the original simulation with the result of the partitioned simulation
     np.testing.assert_allclose(
         head["head"].values, orig_head.values, rtol=1e-5, atol=1e-3
     )
-    np.testing.assert_allclose(
-        cbc["chd"].values, orig_cbc["chd"].values, rtol=1e-5, atol=1e-3
-    )
+    # TODO:
+    # Uncomment when fixed: https://gitlab.com/deltares/imod/imod-python/-/issues/683
+    # np.testing.assert_allclose(
+    #     cbc["chd"].values, orig_cbc["chd"].values, rtol=1e-5, atol=1e-3
+    # )

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
@@ -4,6 +4,8 @@ from typing import Dict
 import numpy as np
 import pytest
 import xarray as xr
+import xugrid as xu
+from pytest_cases import case, parametrize_with_cases
 
 import imod
 from imod.mf6 import Modflow6Simulation
@@ -11,32 +13,53 @@ from imod.mf6.wel import Well
 from imod.typing.grid import zeros_like
 
 
-def setup_partitioning_arrays(idomain_top: xr.DataArray) -> Dict[str, xr.DataArray]:
-    result = {}
-    two_parts = zeros_like(idomain_top)
+@pytest.mark.usefixtures("circle_model")
+@pytest.fixture(scope="function")
+def idomain_top(circle_model):
+    idomain = circle_model["GWF_1"].domain
+    return idomain.isel(layer=0)
 
-    two_parts.values[:108] = 0
-    two_parts.values[108:] = 1
 
-    result["two_parts"] = two_parts
+class PartitionArrayCases:
+    def case_two_parts(self, idomain_top) -> xu.UgridDataArray:
+        two_parts = zeros_like(idomain_top)
+        two_parts.values[:108] = 0
+        two_parts.values[108:] = 1
+        return two_parts
 
-    three_parts = zeros_like(idomain_top)
+    def case_three_parts(self, idomain_top) -> xu.UgridDataArray:
+        three_parts = zeros_like(idomain_top)
+        three_parts.values[:72] = 0
+        three_parts.values[72:144] = 1
+        three_parts.values[144:] = 2
+        return three_parts
 
-    three_parts.values[:72] = 0
-    three_parts.values[72:144] = 1
-    three_parts.values[144:] = 2
-    result["three_parts"] = three_parts
 
-    return result
+class WellCases:
+    def case_one_well(self):
+        return imod.mf6.Well(
+            x=[500.0], y=[0.0], screen_top=[3.0], screen_bottom=[2.0], rate=[1.0]
+        )
+
+    def case_all_wells(self, idomain_top):
+        x = idomain_top.ugrid.grid.face_x
+        y = idomain_top.ugrid.grid.face_y
+        size = len(x)
+
+        return imod.mf6.Well(
+            x=x,
+            y=y,
+            screen_top=size * [3.0],
+            screen_bottom=size * [2.0],
+            rate=size * [1.0],
+            minimum_k=1e-19,
+        )
 
 
 @pytest.mark.usefixtures("circle_model")
-@pytest.mark.parametrize(
-    "partition_name",
-    ["two_parts", "three_parts"],
-)
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_unstructured(
-    tmp_path: Path, circle_model: Modflow6Simulation, partition_name: str
+    tmp_path: Path, circle_model: Modflow6Simulation, partition_array: xu.UgridDataArray
 ):
     simulation = circle_model
     # increase the recharge to make the head gradient more pronounced
@@ -58,10 +81,7 @@ def test_partitioning_unstructured(
     )
 
     # partition the simulation, run it, and save the (merged) results
-    idomain = simulation["GWF_1"].domain
-    partitioning_arrays = setup_partitioning_arrays(idomain.isel(layer=0))
-
-    split_simulation = simulation.split(partitioning_arrays[partition_name])
+    split_simulation = simulation.split(partition_array)
 
     split_simulation.write(tmp_path, binary=False)
     split_simulation.run()
@@ -79,12 +99,9 @@ def test_partitioning_unstructured(
 
 
 @pytest.mark.usefixtures("circle_model")
-@pytest.mark.parametrize(
-    "partition_name",
-    ["two_parts", "three_parts"],
-)
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_unstructured_with_inactive_cells(
-    tmp_path: Path, circle_model: Modflow6Simulation, partition_name: str
+    tmp_path: Path, circle_model: Modflow6Simulation, partition_array: xu.UgridDataArray
 ):
     simulation = circle_model
 
@@ -127,9 +144,7 @@ def test_partitioning_unstructured_with_inactive_cells(
     #    )
 
     # partition the simulation, run it, and save the (merged) results
-    partitioning_arrays = setup_partitioning_arrays(idomain.isel(layer=0))
-
-    split_simulation = simulation.split(partitioning_arrays[partition_name])
+    split_simulation = simulation.split(partition_array)
 
     split_simulation.write(tmp_path, binary=False)
     split_simulation.run()
@@ -144,12 +159,9 @@ def test_partitioning_unstructured_with_inactive_cells(
 
 
 @pytest.mark.usefixtures("circle_model")
-@pytest.mark.parametrize(
-    "partition_name",
-    ["two_parts", "three_parts"],
-)
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_unstructured_with_vpt_cells(
-    tmp_path: Path, circle_model: Modflow6Simulation, partition_name: str
+    tmp_path: Path, circle_model: Modflow6Simulation, partition_array: xu.UgridDataArray
 ):
     simulation = circle_model
 
@@ -162,7 +174,7 @@ def test_partitioning_unstructured_with_vpt_cells(
     idomain.loc[{"mesh2d_nFaces": deactivated_cells}] = 0
 
     # The cells we just deactivated on idomain must be deactivated on package inputs too.
-    for name, package in simulation["GWF_1"].items():
+    for _, package in simulation["GWF_1"].items():
         if not isinstance(package, Well):
             for arrayname in package.dataset.keys():
                 if "mesh2d_nFaces" in package[arrayname].coords:
@@ -192,9 +204,7 @@ def test_partitioning_unstructured_with_vpt_cells(
     #    )
 
     # partition the simulation, run it, and save the (merged) results
-    partitioning_arrays = setup_partitioning_arrays(idomain.isel(layer=0))
-
-    split_simulation = simulation.split(partitioning_arrays[partition_name])
+    split_simulation = simulation.split(partition_array)
 
     split_simulation.write(tmp_path, binary=False)
     split_simulation.run()
@@ -209,21 +219,19 @@ def test_partitioning_unstructured_with_vpt_cells(
 
 
 @pytest.mark.usefixtures("circle_model")
-@pytest.mark.parametrize(
-    "partition_name",
-    ["two_parts", "three_parts"],
-)
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
+@parametrize_with_cases("well", cases=WellCases)
 def test_partitioning_unstructured_with_well(
-    tmp_path: Path, circle_model: Modflow6Simulation, partition_name: str
+    tmp_path: Path,
+    circle_model: Modflow6Simulation,
+    partition_array: xu.UgridDataArray,
+    well: imod.mf6.Well,
 ):
     simulation = circle_model
     # increase the recharge to make the head gradient more pronounced
     simulation["GWF_1"]["rch"]["rate"] *= 100
 
     # Add well
-    well = imod.mf6.Well(
-        x=[500.0], y=[0.0], screen_top=[3.0], screen_bottom=[2.0], rate=[1.0]
-    )
     simulation["GWF_1"]["well"] = well
 
     # run the original example, so without partitioning, and save the simulation results
@@ -244,10 +252,7 @@ def test_partitioning_unstructured_with_well(
     # )
 
     # partition the simulation, run it, and save the (merged) results
-    idomain = simulation["GWF_1"].domain
-    partitioning_arrays = setup_partitioning_arrays(idomain.isel(layer=0))
-
-    split_simulation = simulation.split(partitioning_arrays[partition_name])
+    split_simulation = simulation.split(partition_array)
 
     split_simulation.write(tmp_path, binary=False)
     split_simulation.run()

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
@@ -1,11 +1,9 @@
 from pathlib import Path
-from typing import Dict
 
 import numpy as np
 import pytest
-import xarray as xr
 import xugrid as xu
-from pytest_cases import case, parametrize_with_cases
+from pytest_cases import parametrize_with_cases
 
 import imod
 from imod.mf6 import Modflow6Simulation

--- a/imod/tests/test_mf6/test_utilities/test_clip_utilities.py
+++ b/imod/tests/test_mf6/test_utilities/test_clip_utilities.py
@@ -166,10 +166,11 @@ def test_clip_by_grid__structured_grid_full(
     """All wells are included within the structured grid bounds"""
     # Arrange
     idomain, _, _ = basic_dis
+    active = idomain.sel(layer=1, drop=True)
     wel = imod.mf6.Well(*well_high_lvl_test_data_stationary, print_flows=True)
 
     # Act
-    wel_clipped = clip_by_grid(wel, idomain)
+    wel_clipped = clip_by_grid(wel, active)
 
     # Assert
     assert isinstance(wel_clipped, imod.mf6.Well)
@@ -184,12 +185,13 @@ def test_clip_by_grid__structured_grid_clipped(
     """Half of the wells are included within the structured grid bounds"""
     # Arrange
     idomain, _, _ = basic_dis
+    active = idomain.sel(layer=1, drop=True)
     wel = imod.mf6.Well(*well_high_lvl_test_data_stationary, print_flows=True)
     # Clip grid so that xmax is set to 70.0 instead of 90.0
-    idomain_selected = idomain.where(idomain.x < 70.0, -1)
+    active_selected = active.where(idomain.x < 70.0, -1)
 
     # Act
-    wel_clipped = clip_by_grid(wel, idomain_selected)
+    wel_clipped = clip_by_grid(wel, active_selected)
 
     # Assert
     assert isinstance(wel_clipped, imod.mf6.Well)
@@ -204,11 +206,12 @@ def test_clip_by_grid__unstructured_grid_full(
     """All the wells are included within the unstructured grid bounds"""
     # Arrange
     idomain, _, _ = basic_dis
+    active = idomain.sel(layer=1, drop=True)
     wel = imod.mf6.Well(*well_high_lvl_test_data_stationary, print_flows=True)
-    idomain_ugrid = xu.UgridDataArray.from_structured(idomain)
+    active_ugrid = xu.UgridDataArray.from_structured(active)
 
     # Act
-    wel_clipped = clip_by_grid(wel, idomain_ugrid)
+    wel_clipped = clip_by_grid(wel, active_ugrid)
 
     # Assert
     assert isinstance(wel_clipped, imod.mf6.Well)
@@ -223,13 +226,14 @@ def test_clip_by_grid__unstructured_grid_clipped(
     """Half of the wells are included within the unstructured grid bounds"""
     # Arrange
     idomain, _, _ = basic_dis
+    active = idomain.sel(layer=1, drop=True)
     wel = imod.mf6.Well(*well_high_lvl_test_data_stationary, print_flows=True)
     # Clip grid so that xmax is set to 70.0 instead of 90.0
-    idomain_selected = idomain.sel(x=slice(None, 70.0))
-    idomain_ugrid = xu.UgridDataArray.from_structured(idomain_selected)
+    active_selected = active.sel(x=slice(None, 70.0))
+    active_ugrid = xu.UgridDataArray.from_structured(active_selected)
 
     # Act
-    wel_clipped = clip_by_grid(wel, idomain_ugrid)
+    wel_clipped = clip_by_grid(wel, active_ugrid)
 
     # Assert
     assert isinstance(wel_clipped, imod.mf6.Well)


### PR DESCRIPTION
In GitLab by @JoerivanEngelen on Dec 11, 2023, 13:18

Closes #680, #700 and #553

This PR fixes the following:
- Change behaviour Well.mask method so it masks in 2D grids instead deepcopying
- clip_by_grid should always operate on 2d grids, correct tests for that
- refactor test_mf6_partitioning to use pytest cases instead of pytest parametrization
- fix erronous default value for ``out_of_bounds`` in ``point_values``
- fix bug where well could not be assigned to the first cell in an unstructured grid