### PR TITLE
Issue #704 Update the artifacts download location

### DIFF
--- a/imod/data/sample_data.py
+++ b/imod/data/sample_data.py
@@ -22,7 +22,7 @@ except ImportError:
 
 REGISTRY = pooch.create(
     path=pooch.os_cache("imod"),
-    base_url="https://gitlab.com/deltares/imod/imod-artifacts/-/raw/main/",
+    base_url="https://github.com/Deltares/imod-artifacts/raw/main/",
     version=None,
     version_dev="main",
     env="IMOD_DATA_DIR",

--- a/imod/example_data/datasets.py
+++ b/imod/example_data/datasets.py
@@ -1,5 +1,0 @@
-import pooch
-
-REGISTRY = pooch.create(
-    path=pooch.os_cache("imod"), base_url="https://gitlab.com/deltares/imod/imod-python"
-)


### PR DESCRIPTION
As part of the GitHub migration the https://gitlab.com/deltares/imod/imod-artifacts has been moved to https://github.com/Deltares/imod-artifacts.

This commit updates the artifacts location. Furthermore the datasets.py file has been removed as it seems to be unused