### PR TITLE
Issue #718 Create separate tasks for running the unit tests and the examples

### DIFF
--- a/imod/tests/test_examples.py
+++ b/imod/tests/test_examples.py
@@ -7,13 +7,6 @@ from pathlib import Path
 import pytest
 
 
-def on_gitlab_ci():
-    """
-    Don't test the examples on CI: they run during building of documentation.
-    """
-    return os.environ.get("GITLAB_CI") is not None
-
-
 def get_examples():
     # Where are we? --> __file__
     # Move three up.
@@ -23,7 +16,7 @@ def get_examples():
     return examples
 
 
-@pytest.mark.skipif(on_gitlab_ci(), reason="Examples are run during docs build")
+@pytest.mark.example
 @pytest.mark.parametrize("example", get_examples())
 def test_example(example):
     subprocess.run([sys.executable, example], check=True)

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,16 +17,26 @@ docs =  { cmd = "make html", depends_on = ["install"], cwd = "docs" }
 install = "python -m pip install --no-deps --editable ."
 format = { depends_on = ["isort_format", "black_format", "ruff_format"] }
 lint = { depends_on = ["isort_lint", "black_lint", "ruff_lint"] }
-tests = { cmd = [
+tests = { depends_on = ["unittests", "examples"] }
+unittests = { cmd = [
     "NUMBA_DISABLE_JIT=1",
     "pytest",
+    "-m", "not example",
     "--cache-clear",
     "--verbose",
-    "--junitxml=report.xml",
+    "--junitxml=unittest_report.xml",
     "--cov=imod",
     "--cov-report=term",
     "--cov-report=html:coverage",
     "--cov-config=.coveragerc"
+], depends_on = ["install"], cwd = "imod/tests" }
+examples = { cmd = [
+    "NUMBA_DISABLE_JIT=1",
+    "pytest",
+    "-m", "example",
+    "--cache-clear",
+    "--verbose",
+    "--junitxml=examples_report.xml",
 ], depends_on = ["install"], cwd = "imod/tests" }
 
 black_lint = "black --check ."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,3 +159,8 @@ module = [
     "xugrid.*",
 ]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+markers = [
+    "example: marks test as example (deselect with '-m \"not example\"')",
+]


### PR DESCRIPTION
This commit splits the test task in a unit test task and an examples task.
This will allow us to run only a subset of the test suite. It will also allows to run the test in parallel on the CI servers