### PR TITLE
Draft: Issue #708 Refactor dataset initialization

### DIFF
--- a/imod/mf6/pkgbase.py
+++ b/imod/mf6/pkgbase.py
@@ -1,4 +1,5 @@
 import abc
+import inspect
 import numbers
 import pathlib
 
@@ -11,6 +12,7 @@ from imod.mf6.interfaces.ipackagebase import IPackageBase
 
 TRANSPORT_PACKAGES = ("adv", "dsp", "ssm", "mst", "ist", "src")
 EXCHANGE_PACKAGES = "gwfgwf"
+ARGS_TO_EXCLUDE = ["validate"]
 
 
 class PackageBase(IPackageBase, abc.ABC):
@@ -32,6 +34,17 @@ class PackageBase(IPackageBase, abc.ABC):
                     self.__dataset = xu.UgridDataset(grids=arg.ugrid.grid)
                     return
         self.__dataset = xr.Dataset()
+
+    def _get_variable_names(init_method):
+        """
+        Return variable names based on the arguments provided to the classes'
+        __init__ method. Removes argument names that need to be excluded.
+        """
+        variable_names = list(inspect.signature(init_method).parameters.keys())
+        for var_to_exclude in ARGS_TO_EXCLUDE:
+            if var_to_exclude in variable_names:
+                variable_names.remove(var_to_exclude)
+        return variable_names
 
     @property
     def dataset(self) -> xr.Dataset:

--- a/imod/mf6/pkgbase.py
+++ b/imod/mf6/pkgbase.py
@@ -9,6 +9,7 @@ import xugrid as xu
 
 import imod
 from imod.mf6.interfaces.ipackagebase import IPackageBase
+from imod.typing.grid import GridDataset
 
 TRANSPORT_PACKAGES = ("adv", "dsp", "ssm", "mst", "ist", "src")
 EXCHANGE_PACKAGES = "gwfgwf"
@@ -47,11 +48,11 @@ class PackageBase(IPackageBase, abc.ABC):
         return variable_names
 
     @property
-    def dataset(self) -> xr.Dataset:
+    def dataset(self) -> GridDataset:
         return self.__dataset
 
     @dataset.setter
-    def dataset(self, value: xr.Dataset) -> None:
+    def dataset(self, value: GridDataset) -> None:
         self.__dataset = value
 
     def __getitem__(self, key):

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -1,3 +1,5 @@
+import inspect
+
 import numpy as np
 
 from imod.mf6.auxiliary_variables import add_periodic_auxiliary_variable
@@ -15,6 +17,8 @@ from imod.schemata import (
     IndexesSchema,
     OtherCoordsSchema,
 )
+
+ARGS_TO_EXCLUDE = ["validate"]
 
 
 class River(BoundaryCondition):
@@ -144,6 +148,14 @@ class River(BoundaryCondition):
         validate: bool = True,
         repeat_stress=None,
     ):
+        locals_at_init = locals()
+        variable_names = list(inspect.signature(self.__init__).parameters.keys())
+        for var_to_exclude in ARGS_TO_EXCLUDE:
+            if var_to_exclude in variable_names:
+                variable_names.remove(var_to_exclude)
+        variables_to_merge = {name: locals_at_init[name] for name in variable_names}
+        xr.merge([variables_to_merge], join="exact")
+
         super().__init__(locals())
         self.dataset["stage"] = stage
         self.dataset["conductance"] = conductance

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -146,22 +146,15 @@ class River(BoundaryCondition):
     ):
         locals_at_init = locals()
         variable_names = self._get_variable_names(self.__init__)
+        if concentration is None:
+            variable_names.remove("concentration")
+            variable_names.remove("concentration_boundary_type")
         variables_to_merge = {name: locals_at_init[name] for name in variable_names}
-        xr.merge([variables_to_merge], join="exact")
 
-        super().__init__(locals())
-        self.dataset["stage"] = stage
-        self.dataset["conductance"] = conductance
-        self.dataset["bottom_elevation"] = bottom_elevation
+        super().__init__(variables_to_merge)
         if concentration is not None:
-            self.dataset["concentration"] = concentration
-            self.dataset["concentration_boundary_type"] = concentration_boundary_type
             add_periodic_auxiliary_variable(self)
-        self.dataset["print_input"] = print_input
-        self.dataset["print_flows"] = print_flows
-        self.dataset["save_flows"] = save_flows
-        self.dataset["observations"] = observations
-        self.dataset["repeat_stress"] = repeat_stress
+
         self._validate_init_schemata(validate)
 
     def _validate(self, schemata, **kwargs):

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -1,5 +1,3 @@
-import inspect
-
 import numpy as np
 
 from imod.mf6.auxiliary_variables import add_periodic_auxiliary_variable
@@ -17,8 +15,6 @@ from imod.schemata import (
     IndexesSchema,
     OtherCoordsSchema,
 )
-
-ARGS_TO_EXCLUDE = ["validate"]
 
 
 class River(BoundaryCondition):
@@ -149,10 +145,7 @@ class River(BoundaryCondition):
         repeat_stress=None,
     ):
         locals_at_init = locals()
-        variable_names = list(inspect.signature(self.__init__).parameters.keys())
-        for var_to_exclude in ARGS_TO_EXCLUDE:
-            if var_to_exclude in variable_names:
-                variable_names.remove(var_to_exclude)
+        variable_names = self._get_variable_names(self.__init__)
         variables_to_merge = {name: locals_at_init[name] for name in variable_names}
         xr.merge([variables_to_merge], join="exact")
 


### PR DESCRIPTION
The changeset is incomplete, as it is not rolled out for all packages yet. Therefore tests will fail, hence the draft status. This to make the review process more focused, reviewers are asked to provide feedback on the approach.

Changes:
- Variable names are inferred based on what is provided to locals(). This makes it possible to avoid having to manually assign variables in the __init__ of each specific package.
- I had to add one function to work around this issue: https://github.com/Deltares/xugrid/issues/179
- Grids are merged with an exact join, this to avoid that xarray joins variable coordinates in an unwanted way when dataarrays are inconsistent, which causes issues like https://github.com/Deltares/imod-python/issues/674
- Refactored the riv unit tests to use pytest cases, so that tests (without the xr.merge) are run for both unstructured and structured data.