### PR TITLE
Issue #534 Test if hfb not written to binary

### DIFF
--- a/imod/tests/test_mf6/test_mf6_hfb_adapter.py
+++ b/imod/tests/test_mf6/test_mf6_hfb_adapter.py
@@ -118,5 +118,13 @@ def test_hfb_writing_one_layer(barrier, tmp_path):
     hfb.write("hfb", None, write_context)
 
     # Assert
-    data = np.loadtxt(tmp_path / "hfb" / "hfb.dat")
+    hfb_bin_path = tmp_path / "hfb" / "hfb.bin"
+    hfb_txt_path = tmp_path / "hfb" / "hfb.dat"
+
+    # Test if not written to binary file
+    assert not hfb_bin_path.exists()
+    # Test if text file exists
+    assert hfb_txt_path.exists()
+
+    data = np.loadtxt(hfb_txt_path)
     np.testing.assert_almost_equal(data, expected_hfb_data)

--- a/imod/tests/test_mf6/test_mf6_hfb_adapter.py
+++ b/imod/tests/test_mf6/test_mf6_hfb_adapter.py
@@ -99,7 +99,7 @@ def test_hfb_render(barrier):
 
 
 @parametrize_with_cases("barrier", cases=GridBarriers)
-def test_hfb_writing_one_layer__unstructured(barrier, tmp_path):
+def test_hfb_writing_one_layer(barrier, tmp_path):
     # Arrange
     hfb = Mf6HorizontalFlowBarrier(**barrier)
     write_context = WriteContext(tmp_path)

--- a/imod/tests/test_mf6/test_mf6_hfb_adapter.py
+++ b/imod/tests/test_mf6/test_mf6_hfb_adapter.py
@@ -121,9 +121,7 @@ def test_hfb_writing_one_layer(barrier, tmp_path):
     hfb_bin_path = tmp_path / "hfb" / "hfb.bin"
     hfb_txt_path = tmp_path / "hfb" / "hfb.dat"
 
-    # Test if not written to binary file
     assert not hfb_bin_path.exists()
-    # Test if text file exists
     assert hfb_txt_path.exists()
 
     data = np.loadtxt(hfb_txt_path)


### PR DESCRIPTION
Close https://github.com/Deltares/imod-python/issues/534

I noticed that the ``test_hfb_writing_one_layer`` would fail if the HFB is written accidently to binary. This adds explicit assertions if not written to binary files. In the case a binary file is written as ``.dat`` file, still an error is thrown with in ``np.loadtxt``, such as:

```
ValueError: could not convert string '\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00ü©ñÒMbP?\x01\x00\x00\x00\x02\x00\x0 to float64 at row 0, column 1.
```

This should point us quickly enough to the source of the error.