### PR TITLE
#Issue 729 Fix broken build status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. image:: https://img.shields.io/badge/lifecycle-maturing-blue
    :target: https://www.tidyverse.org/lifecycle/
-.. image:: https://dpcbuild.deltares.nl/app/rest/builds/buildType:id:iMOD6_IMODPython_Windows_Build/statusIcon.svg
+.. image:: https://dpcbuild.deltares.nl/app/rest/builds/buildType:id:iMOD6_IMODPython_Windows_Tests/statusIcon.svg
    :target: https://github.com/Deltares/imod-python/commits/master/
 .. image:: https://img.shields.io/pypi/l/imod
    :target: https://choosealicense.com/licenses/mit/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ iMOD Python: make massive MODFLOW models
 
 .. image:: https://img.shields.io/badge/lifecycle-maturing-blue
    :target: https://www.tidyverse.org/lifecycle/
-.. image:: https://dpcbuild.deltares.nl/app/rest/builds/buildType:id:iMOD6_IMODPython_Windows_Build/statusIcon.svg
+.. image:: https://dpcbuild.deltares.nl/app/rest/builds/buildType:id:iMOD6_IMODPython_Windows_Tests/statusIcon.svg
    :target: https://github.com/Deltares/imod-python/commits/master/
 .. image:: https://img.shields.io/pypi/l/imod
    :target: https://choosealicense.com/licenses/mit/


### PR DESCRIPTION
The refactoring of the build pipelines resulted in some of the stages being renamed.
The build status badge however was still pointing to the old name and therefor wasn't working

This commit fixes that