### PR TITLE
Issue #740 Fix incorrect arguments provided to the clip_box method of the well package

### DIFF
--- a/imod/mf6/gwfgwf.py
+++ b/imod/mf6/gwfgwf.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional, Tuple
 
+import cftime
 import numpy as np
 import xarray as xr
 
@@ -91,8 +92,8 @@ class GWFGWF(Package):
 
     def clip_box(
         self,
-        time_min: Optional[str] = None,
-        time_max: Optional[str] = None,
+        time_min: Optional[cftime.datetime | np.datetime64 | str] = None,
+        time_max: Optional[cftime.datetime | np.datetime64 | str] = None,
         layer_min: Optional[int] = None,
         layer_max: Optional[int] = None,
         x_min: Optional[float] = None,

--- a/imod/mf6/gwfgwf.py
+++ b/imod/mf6/gwfgwf.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 from imod.mf6.auxiliary_variables import add_periodic_auxiliary_variable
 from imod.mf6.package import Package
+from imod.typing import GridDataArray
 
 
 class GWFGWF(Package):
@@ -90,14 +91,16 @@ class GWFGWF(Package):
 
     def clip_box(
         self,
-        time_min=None,
-        time_max=None,
-        layer_min=None,
-        layer_max=None,
-        x_min=None,
-        x_max=None,
-        y_min=None,
-        y_max=None,
-        state_for_boundary=None,
+        time_min: Optional[str] = None,
+        time_max: Optional[str] = None,
+        layer_min: Optional[int] = None,
+        layer_max: Optional[int] = None,
+        x_min: Optional[float] = None,
+        x_max: Optional[float] = None,
+        y_min: Optional[float] = None,
+        y_max: Optional[float] = None,
+        top: Optional[GridDataArray] = None,
+        bottom: Optional[GridDataArray] = None,
+        state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         raise NotImplementedError("this package cannot be clipped")

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from enum import Enum
 from typing import Optional, Tuple
 
+import cftime
 import geopandas as gpd
 import numpy as np
 import shapely.wkt
@@ -518,8 +519,8 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
 
     def clip_box(
         self,
-        time_min: Optional[str] = None,
-        time_max: Optional[str] = None,
+        time_min: Optional[cftime.datetime | np.datetime64 | str] = None,
+        time_max: Optional[cftime.datetime | np.datetime64 | str] = None,
         layer_min: Optional[int] = None,
         layer_max: Optional[int] = None,
         x_min: Optional[float] = None,

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -4,7 +4,7 @@ import textwrap
 import typing
 from copy import deepcopy
 from enum import Enum
-from typing import Tuple
+from typing import Optional, Tuple
 
 import geopandas as gpd
 import numpy as np
@@ -518,15 +518,17 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
 
     def clip_box(
         self,
-        time_min=None,
-        time_max=None,
-        layer_min=None,
-        layer_max=None,
-        x_min=None,
-        x_max=None,
-        y_min=None,
-        y_max=None,
-        *args,
+        time_min: Optional[str] = None,
+        time_max: Optional[str] = None,
+        layer_min: Optional[int] = None,
+        layer_max: Optional[int] = None,
+        x_min: Optional[float] = None,
+        x_max: Optional[float] = None,
+        y_min: Optional[float] = None,
+        y_max: Optional[float] = None,
+        top: Optional[GridDataArray] = None,
+        bottom: Optional[GridDataArray] = None,
+        state_for_boundary: Optional[GridDataArray] = None,
     ) -> "HorizontalFlowBarrierBase":
         """
         Clip a package by a bounding box (time, layer, y, x).
@@ -550,6 +552,9 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
         x_max: optional, float
         y_min: optional, float
         y_max: optional, float
+        top: optional, GridDataArray
+        bottom: optional, GridDataArray
+        state_for_boundary: optional, GridDataArray
 
         Returns
         -------

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -397,8 +397,8 @@ class Modflow6Model(collections.UserDict, abc.ABC):
 
     def _clip_box_packages(
         self,
-        time_min: Optional[str] = None,
-        time_max: Optional[str] = None,
+        time_min: Optional[cftime.datetime | np.datetime64 | str] = None,
+        time_max: Optional[cftime.datetime | np.datetime64 | str] = None,
         layer_min: Optional[int] = None,
         layer_max: Optional[int] = None,
         x_min: Optional[float] = None,

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -383,7 +383,14 @@ class Modflow6Model(collections.UserDict, abc.ABC):
         state_for_boundary :
         """
         clipped = self._clip_box_packages(
-            time_min, time_max, layer_min, layer_max, x_min, x_max, y_min, y_max
+            time_min,
+            time_max,
+            layer_min,
+            layer_max,
+            x_min,
+            x_max,
+            y_min,
+            y_max,
         )
 
         return clipped
@@ -398,6 +405,7 @@ class Modflow6Model(collections.UserDict, abc.ABC):
         x_max: Optional[float] = None,
         y_min: Optional[float] = None,
         y_max: Optional[float] = None,
+        state_for_boundary: Optional[GridDataArray] = None,
     ):
         """
         Clip a model by a bounding box (time, layer, y, x).
@@ -426,6 +434,9 @@ class Modflow6Model(collections.UserDict, abc.ABC):
         -------
         clipped : Modflow6Model
         """
+
+        top, bottom, idomain = self.__get_domain_geometry()
+
         clipped = type(self)(**self._options)
         for key, pkg in self.items():
             clipped[key] = pkg.clip_box(
@@ -437,6 +448,9 @@ class Modflow6Model(collections.UserDict, abc.ABC):
                 x_max=x_max,
                 y_min=y_min,
                 y_max=y_max,
+                top=top,
+                bottom=bottom,
+                state_for_boundary=state_for_boundary,
             )
 
         return clipped

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -348,8 +348,8 @@ class Modflow6Model(collections.UserDict, abc.ABC):
 
     def clip_box(
         self,
-        time_min: Optional[str] = None,
-        time_max: Optional[str] = None,
+        time_min: Optional[cftime.datetime | np.datetime64 | str] = None,
+        time_max: Optional[cftime.datetime | np.datetime64 | str] = None,
         layer_min: Optional[int] = None,
         layer_max: Optional[int] = None,
         x_min: Optional[float] = None,

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional
 
+import cftime
+import numpy as np
+
 from imod.mf6 import ConstantHead
 from imod.mf6.clipped_boundary_condition_creator import create_clipped_boundary
 from imod.mf6.model import Modflow6Model, initialize_template
@@ -61,8 +64,8 @@ class GroundwaterFlowModel(Modflow6Model):
 
     def clip_box(
         self,
-        time_min: Optional[str] = None,
-        time_max: Optional[str] = None,
+        time_min: Optional[cftime.datetime | np.datetime64 | str] = None,
+        time_max: Optional[cftime.datetime | np.datetime64 | str] = None,
         layer_min: Optional[int] = None,
         layer_max: Optional[int] = None,
         x_min: Optional[float] = None,

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import copy
 import numbers
@@ -401,16 +403,18 @@ class Package(PackageBase, abc.ABC):
 
     def clip_box(
         self,
-        time_min=None,
-        time_max=None,
-        layer_min=None,
-        layer_max=None,
-        x_min=None,
-        x_max=None,
-        y_min=None,
-        y_max=None,
-        state_for_boundary=None,
-    ) -> "Package":
+        time_min: Optional[str] = None,
+        time_max: Optional[str] = None,
+        layer_min: Optional[int] = None,
+        layer_max: Optional[int] = None,
+        x_min: Optional[float] = None,
+        x_max: Optional[float] = None,
+        y_min: Optional[float] = None,
+        y_max: Optional[float] = None,
+        top: Optional[GridDataArray] = None,
+        bottom: Optional[GridDataArray] = None,
+        state_for_boundary: Optional[GridDataArray] = None,
+    ) -> Package:
         """
         Clip a package by a bounding box (time, layer, y, x).
 
@@ -433,6 +437,10 @@ class Package(PackageBase, abc.ABC):
         x_max: optional, float
         y_min: optional, float
         y_max: optional, float
+        top: optional, GridDataArray
+        bottom: optional, GridDataArray
+        state_for_boundary: optional, GridDataArray
+
 
         Returns
         -------

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -403,8 +403,8 @@ class Package(PackageBase, abc.ABC):
 
     def clip_box(
         self,
-        time_min: Optional[str] = None,
-        time_max: Optional[str] = None,
+        time_min: Optional[cftime.datetime | np.datetime64 | str] = None,
+        time_max: Optional[cftime.datetime | np.datetime64 | str] = None,
         layer_min: Optional[int] = None,
         layer_max: Optional[int] = None,
         x_min: Optional[float] = None,

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -8,6 +8,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+import cftime
 import jinja2
 import numpy as np
 import tomli
@@ -755,8 +756,8 @@ class Modflow6Simulation(collections.UserDict):
 
     def clip_box(
         self,
-        time_min: Optional[str] = None,
-        time_max: Optional[str] = None,
+        time_min: Optional[cftime.datetime | np.datetime64 | str] = None,
+        time_max: Optional[cftime.datetime | np.datetime64 | str] = None,
         layer_min: Optional[int] = None,
         layer_max: Optional[int] = None,
         x_min: Optional[float] = None,

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -764,7 +764,7 @@ class Modflow6Simulation(collections.UserDict):
         y_min: Optional[float] = None,
         y_max: Optional[float] = None,
         states_for_boundary: Optional[dict[str, GridDataArray]] = None,
-    ) -> "Modflow6Simulation":
+    ) -> Modflow6Simulation:
         """
         Clip a simulation by a bounding box (time, layer, y, x).
 

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -195,15 +195,18 @@ class Well(BoundaryCondition, IPointDataPackage):
 
     def clip_box(
         self,
-        time_min=None,
-        time_max=None,
-        z_min=None,
-        z_max=None,
-        x_min=None,
-        x_max=None,
-        y_min=None,
-        y_max=None,
-    ) -> Well:
+        time_min: Optional[str] = None,
+        time_max: Optional[str] = None,
+        layer_min: Optional[int] = None,
+        layer_max: Optional[int] = None,
+        x_min: Optional[float] = None,
+        x_max: Optional[float] = None,
+        y_min: Optional[float] = None,
+        y_max: Optional[float] = None,
+        top: Optional[GridDataArray] = None,
+        bottom: Optional[GridDataArray] = None,
+        state_for_boundary: Optional[GridDataArray] = None,
+    ) -> Package:
         """
         Clip a package by a bounding box (time, layer, y, x).
 
@@ -220,12 +223,15 @@ class Well(BoundaryCondition, IPointDataPackage):
         ----------
         time_min: optional
         time_max: optional
-        z_min: optional, float
-        z_max: optional, float
+        layer_min: optional, int
+        layer_max: optional, int
         x_min: optional, float
         x_max: optional, float
         y_min: optional, float
         y_max: optional, float
+        top: optional, GridDataArray
+        bottom: optional, GridDataArray
+        state_for_boundary: optional, GridDataArray
 
         Returns
         -------
@@ -236,6 +242,9 @@ class Well(BoundaryCondition, IPointDataPackage):
         new = super().clip_box(time_min=time_min, time_max=time_max)
 
         ds = new.dataset
+
+        z_max = None if layer_max is None else top.isel(layer=layer_max)
+        z_min = None if layer_min is None else bottom.isel(layer=layer_min)
 
         # Initiate array of True with right shape to deal with case no spatial
         # selection needs to be done.
@@ -640,14 +649,17 @@ class WellDisStructured(DisStructuredBoundaryCondition):
 
     def clip_box(
         self,
-        time_min=None,
-        time_max=None,
-        layer_min=None,
-        layer_max=None,
-        x_min=None,
-        x_max=None,
-        y_min=None,
-        y_max=None,
+        time_min: Optional[str] = None,
+        time_max: Optional[str] = None,
+        layer_min: Optional[int] = None,
+        layer_max: Optional[int] = None,
+        x_min: Optional[float] = None,
+        x_max: Optional[float] = None,
+        y_min: Optional[float] = None,
+        y_max: Optional[float] = None,
+        top: Optional[GridDataArray] = None,
+        bottom: Optional[GridDataArray] = None,
+        state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         """
         Clip a package by a bounding box (time, layer, y, x).
@@ -668,9 +680,12 @@ class WellDisStructured(DisStructuredBoundaryCondition):
         layer_min: optional, int
         layer_max: optional, int
         x_min: optional, float
-        x_min: optional, float
+        x_max: optional, float
+        y_min: optional, float
         y_max: optional, float
-        y_max: optional, float
+        top: optional, GridDataArray
+        bottom: optional, GridDataArray
+        state_for_boundary: optional, GridDataArray
 
         Returns
         -------
@@ -791,14 +806,17 @@ class WellDisVertices(DisVerticesBoundaryCondition):
 
     def clip_box(
         self,
-        time_min=None,
-        time_max=None,
-        layer_min=None,
-        layer_max=None,
-        x_min=None,
-        x_max=None,
-        y_min=None,
-        y_max=None,
+        time_min: Optional[str] = None,
+        time_max: Optional[str] = None,
+        layer_min: Optional[int] = None,
+        layer_max: Optional[int] = None,
+        x_min: Optional[float] = None,
+        x_max: Optional[float] = None,
+        y_min: Optional[float] = None,
+        y_max: Optional[float] = None,
+        top: Optional[GridDataArray] = None,
+        bottom: Optional[GridDataArray] = None,
+        state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         """
         Clip a package by a bounding box (time, layer, y, x).
@@ -819,9 +837,12 @@ class WellDisVertices(DisVerticesBoundaryCondition):
         layer_min: optional, int
         layer_max: optional, int
         x_min: optional, float
-        x_min: optional, float
+        x_max: optional, float
+        y_min: optional, float
         y_max: optional, float
-        y_max: optional, float
+        top: optional, GridDataArray
+        bottom: optional, GridDataArray
+        state_for_boundary: optional, GridDataArray
 
         Returns
         -------

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -246,7 +246,9 @@ class Well(BoundaryCondition, IPointDataPackage):
         sliced : Package
         """
         if (layer_max or layer_min) and (top is None or bottom is None):
-            raise ValueError("When clipping by layer both the top and bottom should be defined")
+            raise ValueError(
+                "When clipping by layer both the top and bottom should be defined"
+            )
 
         if top is not None:
             if not isinstance(top, GridDataArray) or "layer" not in top.coords:
@@ -262,10 +264,14 @@ class Well(BoundaryCondition, IPointDataPackage):
 
         # if z is a grid select the the values at the well locations and drop the dimensions
         if (z_max is not None) and ("x" in z_max.coords or "y" in z_max.coords):
-            z_max = z_max.sel(x=ds["x"], y=ds["y"], method="nearest").drop_vars(lambda x: x.coords)
+            z_max = z_max.sel(x=ds["x"], y=ds["y"], method="nearest").drop_vars(
+                lambda x: x.coords
+            )
 
         if (z_min is not None) and ("x" in z_min.coords or "y" in z_min.coords):
-            z_min = z_min.sel(x=ds["x"], y=ds["y"], method="nearest").drop_vars(lambda x: x.coords)
+            z_min = z_min.sel(x=ds["x"], y=ds["y"], method="nearest").drop_vars(
+                lambda x: x.coords
+            )
 
         if z_max is not None:
             ds["screen_top"] = ds["screen_top"].clip(None, z_max)

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -233,7 +233,12 @@ class TestGroundwaterFlowModel:
         # Arrange.
         state_for_boundary = None
 
+        discretization_mock = MagicMock(spec_set=Package)
+        discretization_mock._pkg_id = "dis"
+        discretization_mock.clip_box.return_value = discretization_mock
+
         model = GroundwaterFlowModel()
+        model["dis"] = discretization_mock
 
         # Act.
         clipped = model.clip_box(state_for_boundary=state_for_boundary)

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -162,9 +162,15 @@ def test_clip_box__high_lvl_stationary(
     assert dict(ds.dims) == {"index": 4, "species": 2}
 
 
-def test_clip_box__high_lvl_transient(well_high_lvl_test_data_transient):
+@pytest.mark.parametrize(
+    "parameterizable_basic_dis",
+    [BasicDisSettings(nlay=10, zstop=-10.0)],
+    indirect=True,
+)
+def test_clip_box__high_lvl_transient(well_high_lvl_test_data_transient, parameterizable_basic_dis):
     # Arrange
     wel = imod.mf6.Well(*well_high_lvl_test_data_transient)
+    _, top, bottom = parameterizable_basic_dis
 
     # Act & Assert
     # Test clipping x & y without specified time
@@ -172,9 +178,9 @@ def test_clip_box__high_lvl_transient(well_high_lvl_test_data_transient):
     assert dict(ds.dims) == {"index": 3, "time": 5, "species": 2}
 
     # Test clipping with z
-    ds = wel.clip_box(z_max=-2.0).dataset
+    ds = wel.clip_box(layer_max=2, top=top, bottom=bottom).dataset
     assert dict(ds.dims) == {"index": 4, "time": 5, "species": 2}
-    ds = wel.clip_box(z_min=-8.0).dataset
+    ds = wel.clip_box(layer_min=7, top=top, bottom=bottom).dataset
     assert dict(ds.dims) == {"index": 4, "time": 5, "species": 2}
 
     # Test clipping with specified time

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -167,7 +167,9 @@ def test_clip_box__high_lvl_stationary(
     [BasicDisSettings(nlay=10, zstop=-10.0)],
     indirect=True,
 )
-def test_clip_box__high_lvl_transient(well_high_lvl_test_data_transient, parameterizable_basic_dis):
+def test_clip_box__high_lvl_transient(
+    well_high_lvl_test_data_transient, parameterizable_basic_dis
+):
     # Arrange
     wel = imod.mf6.Well(*well_high_lvl_test_data_transient)
     _, top, bottom = parameterizable_basic_dis

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -9,6 +9,7 @@ import xarray as xr
 from pytest_cases import parametrize_with_cases
 
 import imod
+from imod.mf6.utilities.grid import broadcast_to_full_domain
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.tests.fixtures.flow_basic_fixture import BasicDisSettings
@@ -195,6 +196,16 @@ class ClipBoxCases:
         return clip_arguments, expected_dims, does_not_raise()
 
     @staticmethod
+    def case_clip_top_is_layered_griddataarray(parameterizable_basic_dis):
+        idomain, top, bottom = parameterizable_basic_dis
+
+        top, bottom = broadcast_to_full_domain(idomain, top, bottom)
+        clip_arguments = {"layer_max": 2, "bottom": bottom, "top": top}
+
+        expected_dims = {"index": 4, "species": 2}
+        return clip_arguments, expected_dims, does_not_raise()
+
+    @staticmethod
     def case_clip_missing_top(parameterizable_basic_dis):
         _, _, bottom = parameterizable_basic_dis
         clip_arguments = {"layer_max": 2, "bottom": bottom}
@@ -213,7 +224,7 @@ class ClipBoxCases:
 
 @pytest.mark.parametrize(
     "parameterizable_basic_dis",
-    [BasicDisSettings(nlay=10, zstop=-10.0)],
+    [BasicDisSettings(nlay=10, zstop=-10.0,  xstart=50.0, xstop=100.0, ystart=50.0, ystop=100.0, nrow=10, ncol=10)],
     indirect=True,
 )
 @parametrize_with_cases(

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -9,6 +9,7 @@ import xarray as xr
 import imod
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
+from imod.tests.fixtures.flow_basic_fixture import BasicDisSettings
 
 
 def test_to_mf6_pkg__high_lvl_stationary(basic_dis, well_high_lvl_test_data_stationary):
@@ -137,9 +138,17 @@ def test_to_mf6_pkg__high_lvl_transient(basic_dis, well_high_lvl_test_data_trans
     np.testing.assert_equal(mf6_ds["rate"].values, rate_expected)
 
 
-def test_clip_box__high_lvl_stationary(well_high_lvl_test_data_stationary):
+@pytest.mark.parametrize(
+    "parameterizable_basic_dis",
+    [BasicDisSettings(nlay=10, zstop=-10.0)],
+    indirect=True,
+)
+def test_clip_box__high_lvl_stationary(
+    well_high_lvl_test_data_stationary, parameterizable_basic_dis
+):
     # Arrange
     wel = imod.mf6.Well(*well_high_lvl_test_data_stationary)
+    _, top, bottom = parameterizable_basic_dis
 
     # Act & Assert
     # Test clipping x & y without specified time
@@ -147,9 +156,9 @@ def test_clip_box__high_lvl_stationary(well_high_lvl_test_data_stationary):
     assert dict(ds.dims) == {"index": 3, "species": 2}
 
     # Test clipping with z
-    ds = wel.clip_box(z_max=-2.0).dataset
+    ds = wel.clip_box(layer_max=2, top=top, bottom=bottom).dataset
     assert dict(ds.dims) == {"index": 4, "species": 2}
-    ds = wel.clip_box(z_min=-8.0).dataset
+    ds = wel.clip_box(layer_min=7, top=top, bottom=bottom).dataset
     assert dict(ds.dims) == {"index": 4, "species": 2}
 
 

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -253,7 +253,7 @@ def test_clip_box__high_lvl_transient(
     # Test clipping with z
     ds = wel.clip_box(layer_max=2, top=top, bottom=bottom).dataset
     assert dict(ds.dims) == {"index": 4, "time": 5, "species": 2}
-    ds = wel.clip_box(layer_min=7, top=top, bottom=bottom).dataset
+    ds = wel.clip_box(layer_min=5, top=top, bottom=bottom).dataset
     assert dict(ds.dims) == {"index": 4, "time": 5, "species": 2}
 
     # Test clipping with specified time

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -163,7 +163,7 @@ class ClipBoxCases:
     @staticmethod
     def case_clip_layer_min(parameterizable_basic_dis):
         _, top, bottom = parameterizable_basic_dis
-        clip_arguments = {"layer_min": 7, "bottom": bottom, "top": top}
+        clip_arguments = {"layer_min": 5, "bottom": bottom, "top": top}
 
         expected_dims = {"index": 4, "species": 2}
         return clip_arguments, expected_dims, does_not_raise()

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -224,7 +224,18 @@ class ClipBoxCases:
 
 @pytest.mark.parametrize(
     "parameterizable_basic_dis",
-    [BasicDisSettings(nlay=10, zstop=-10.0,  xstart=50.0, xstop=100.0, ystart=50.0, ystop=100.0, nrow=10, ncol=10)],
+    [
+        BasicDisSettings(
+            nlay=10,
+            zstop=-10.0,
+            xstart=50.0,
+            xstop=100.0,
+            ystart=50.0,
+            ystop=100.0,
+            nrow=10,
+            ncol=10,
+        )
+    ],
     indirect=True,
 )
 @parametrize_with_cases(

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -6,6 +6,7 @@ from contextlib import nullcontext as does_not_raise
 import numpy as np
 import pytest
 import xarray as xr
+import xugrid as xu
 from pytest_cases import parametrize_with_cases
 
 import imod
@@ -187,19 +188,47 @@ class ClipBoxCases:
         return clip_arguments, expected_dims, does_not_raise()
 
     @staticmethod
-    def case_clip_top_is_non_layered_griddataarray(parameterizable_basic_dis):
-        _, top, bottom = parameterizable_basic_dis
+    def case_clip_top_is_non_layered_structuredgrid(parameterizable_basic_dis):
+        idomain, top, bottom = parameterizable_basic_dis
+        top, bottom = broadcast_to_full_domain(idomain, top, bottom)
         top = top.isel(layer=0).drop_vars("layer")
+
         clip_arguments = {"layer_max": 2, "bottom": bottom, "top": top}
 
         expected_dims = {"index": 4, "species": 2}
         return clip_arguments, expected_dims, does_not_raise()
 
     @staticmethod
-    def case_clip_top_is_layered_griddataarray(parameterizable_basic_dis):
+    def case_clip_top_is_layered_structuredgrid(parameterizable_basic_dis):
         idomain, top, bottom = parameterizable_basic_dis
 
         top, bottom = broadcast_to_full_domain(idomain, top, bottom)
+        clip_arguments = {"layer_max": 2, "bottom": bottom, "top": top}
+
+        expected_dims = {"index": 4, "species": 2}
+        return clip_arguments, expected_dims, does_not_raise()
+
+    @staticmethod
+    def case_clip_top_is_non_layered_unstructuredgrid(parameterizable_basic_dis):
+        idomain, top, bottom = parameterizable_basic_dis
+        top, bottom = broadcast_to_full_domain(idomain, top, bottom)
+        top = xu.UgridDataArray.from_structured(top)
+        bottom = xu.UgridDataArray.from_structured(bottom)
+
+        top = top.isel(layer=0).drop_vars("layer")
+
+        clip_arguments = {"layer_max": 2, "bottom": bottom, "top": top}
+
+        expected_dims = {"index": 4, "species": 2}
+        return clip_arguments, expected_dims, does_not_raise()
+
+    @staticmethod
+    def case_clip_top_is_layered_unstructuredgrid(parameterizable_basic_dis):
+        idomain, top, bottom = parameterizable_basic_dis
+        top, bottom = broadcast_to_full_domain(idomain, top, bottom)
+        top = xu.UgridDataArray.from_structured(top)
+        bottom = xu.UgridDataArray.from_structured(bottom)
+
         clip_arguments = {"layer_max": 2, "bottom": bottom, "top": top}
 
         expected_dims = {"index": 4, "species": 2}


### PR DESCRIPTION
In this commit the wrong arguments provided to the well package is addressed. 

The Well package is a grid agnostic package. That means that the layer_min and layer_max arguments from the clip_box method has no meaning to it. 

To still conform to this method signature the top and bottom of a grid is provided. Those are then used to retrieve a z_min and z_max
