### PR TITLE
model is now regridded to a coarser grid. The dx and dy are now set a…

### DIFF
--- a/examples/mf6/different_ways_to_regrid_models.py
+++ b/examples/mf6/different_ways_to_regrid_models.py
@@ -1,6 +1,6 @@
 """
-TWRI regridding
-===============
+Diffferent ways to regrid models
+================================
 
 This example focuses on regridding. It uses the TWRI model from modflow6 (`Harbaugh, 2005`_).
 More information about this model can be found in an example dedicated to building this model ( ex01_twri.py)
@@ -47,12 +47,12 @@ heterogeneous_k.sel(layer=1).plot(y="y", yincrease=False, ax=ax)
 # x axis and y axis of  15*5000 = 75000 on both axes, but the new grid that is  75020 on the x axis and  75015 on the y axis
 
 nlay = 3
-nrow = 45
-ncol = 20
+nrow = 21
+ncol = 12
 shape = (nlay, nrow, ncol)
 
-dx = 3751.0
-dy = -1667.0
+dx = 6251
+dy = -3572
 xmin = 0.0
 xmax = dx * ncol
 ymin = 0.0
@@ -76,9 +76,7 @@ new_simulation = simulation.regrid_like("regridded_twri", target_grid=target_gri
 # Let's plot the k-field. This is the regridded output, and it should should somewhat resemble the original k-field plotted earlier.
 regridded_k_1 = new_simulation["GWF_1"]["npf"]["k"]
 fig, ax = plt.subplots()
-
 regridded_k_1.sel(layer=1).plot(y="y", yincrease=False, ax=ax)
-
 # %%
 # A second way to regrid  twri  is to regrid the groundwater flow model.
 

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -688,6 +688,15 @@ class Package(PackageBase, abc.ABC):
 
         new_package = self.__class__(**new_package_data)
 
+        # set dx and dy if present in target_grid
+        if "dx" in target_grid.coords:
+            new_package.dataset = new_package.dataset.assign_coords(
+                {"dx": target_grid.coords["dx"].values[()]}
+            )
+        if "dy" in target_grid.coords:
+            new_package.dataset = new_package.dataset.assign_coords(
+                {"dy": target_grid.coords["dy"].values[()]}
+            )
         return new_package
 
     def skip_masking_dataarray(self, array_name: str) -> bool:


### PR DESCRIPTION
fixes #596 , 
The example is now regridded to a coarser grid. The example filename was renamed. 
dx and dy are now correctly set as those of the target grid. 
Added test for the assignment of dx, dy