### PR TITLE
Issue #748 Fix failing transport model examples i.c.w. the MODFLOW6 nightly build

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -25,6 +25,11 @@ Changed
   advice doing development installations with pixi from now on. `See the
   documentation. <https://deltares.github.io/imod-python/installation.html>`_
 
+Added
+~~~~~
+- Added support for coupling a GroundwaterFlowModel and Transport Model i.c.w.
+  the 6.4.3 release of MODFLOW. Using an older version of iMOD Python
+  with this version of MODFLOW will result in an error.
 
 [0.15.1] - 2023-12-22
 ---------------------

--- a/imod/mf6/__init__.py
+++ b/imod/mf6/__init__.py
@@ -13,6 +13,7 @@ from imod.mf6.dsp import Dispersion
 from imod.mf6.evt import Evapotranspiration
 from imod.mf6.ghb import GeneralHeadBoundary
 from imod.mf6.gwfgwf import GWFGWF
+from imod.mf6.gwfgwt import GWFGWT
 from imod.mf6.hfb import (
     HorizontalFlowBarrierBase,
     HorizontalFlowBarrierHydraulicCharacteristic,

--- a/imod/mf6/exchangebase.py
+++ b/imod/mf6/exchangebase.py
@@ -15,26 +15,28 @@ class ExchangeBase(Package):
 
     @property
     def model_name1(self):
+        if "model_name_1" not in self.dataset:
+            raise ValueError("model_name_1 not present in dataset")
         return self.dataset["model_name_1"].values[()].take(0)
 
     @property
     def model_name2(self):
+        if "model_name_2" not in self.dataset:
+            raise ValueError("model_name_2 not present in dataset")
         return self.dataset["model_name_2"].values[()].take(0)
 
     def package_name(self) -> str:
         return f"{self.model_name1}_{self.model_name2}"
-
-    def _filename(self) -> str:
-        return f"{self.package_name()}.{self._pkg_id}"
 
     def get_specification(self) -> Tuple[str, str, str, str]:
         """
         Returns a tuple containing the exchange type, the exchange file name, and the model names. This can be used
         to write the exchange information in the simulation .nam input file
         """
+        filename = f"{self.package_name()}.{self._pkg_id}"
         return (
             self._exchange_type.value,
-            self._filename(),
+            filename,
             self.model_name1,
             self.model_name2,
         )

--- a/imod/mf6/exchangebase.py
+++ b/imod/mf6/exchangebase.py
@@ -11,20 +11,21 @@ class ExchangeType(Enum):
 
 class ExchangeBase(Package):
     _keyword_map: Dict[str, str] = {}
+    _exchange_type: ExchangeType
 
     @property
-    def model_name_1(self):
+    def model_name1(self):
         return self.dataset["model_name_1"].values[()].take(0)
 
     @property
-    def model_name_2(self):
+    def model_name2(self):
         return self.dataset["model_name_2"].values[()].take(0)
 
-    def packagename(self) -> str:
-        return f"{self.dataset['model_name_1'].values[()]}_{self.dataset['model_name_2'].values[()]}"
+    def package_name(self) -> str:
+        return f"{self.model_name1}_{self.model_name2}"
 
     def _filename(self) -> str:
-        return f"{self.packagename()}.{self._pkg_id}"
+        return f"{self.package_name()}.{self._pkg_id}"
 
     def get_specification(self) -> Tuple[str, str, str, str]:
         """
@@ -34,6 +35,6 @@ class ExchangeBase(Package):
         return (
             self._exchange_type.value,
             self._filename(),
-            self.model_name_1,
-            self.model_name_2,
+            self.model_name1,
+            self.model_name2,
         )

--- a/imod/mf6/exchangebase.py
+++ b/imod/mf6/exchangebase.py
@@ -1,26 +1,26 @@
-from enum import Enum
 from typing import Dict, Tuple
 
 from imod.mf6.package import Package
 
-
-class ExchangeType(Enum):
-    GWFGWF = "GWF6-GWF6"
-    GWFGWT = "GWF6-GWT6"
+_pkg_id_to_type = {"gwfgwf": "GWF6-GWF6", "gwfgwt": "GWF6-GWT6"}
 
 
 class ExchangeBase(Package):
+    """
+    Base class for all the exchanges.
+    This class enables writing the exchanges to file in a uniform way.
+    """
+
     _keyword_map: Dict[str, str] = {}
-    _exchange_type: ExchangeType
 
     @property
-    def model_name1(self):
+    def model_name1(self) -> str:
         if "model_name_1" not in self.dataset:
             raise ValueError("model_name_1 not present in dataset")
         return self.dataset["model_name_1"].values[()].take(0)
 
     @property
-    def model_name2(self):
+    def model_name2(self) -> str:
         if "model_name_2" not in self.dataset:
             raise ValueError("model_name_2 not present in dataset")
         return self.dataset["model_name_2"].values[()].take(0)
@@ -35,7 +35,7 @@ class ExchangeBase(Package):
         """
         filename = f"{self.package_name()}.{self._pkg_id}"
         return (
-            self._exchange_type.value,
+            _pkg_id_to_type[self._pkg_id],
             filename,
             self.model_name1,
             self.model_name2,

--- a/imod/mf6/exchangebase.py
+++ b/imod/mf6/exchangebase.py
@@ -1,0 +1,39 @@
+from enum import Enum
+from typing import Dict, Tuple
+
+from imod.mf6.package import Package
+
+
+class ExchangeType(Enum):
+    GWFGWF = "GWF6-GWF6"
+    GWFGWT = "GWF6-GWT6"
+
+
+class ExchangeBase(Package):
+    _keyword_map: Dict[str, str] = {}
+
+    @property
+    def model_name_1(self):
+        return self.dataset["model_name_1"].values[()].take(0)
+
+    @property
+    def model_name_2(self):
+        return self.dataset["model_name_2"].values[()].take(0)
+
+    def packagename(self) -> str:
+        return f"{self.dataset['model_name_1'].values[()]}_{self.dataset['model_name_2'].values[()]}"
+
+    def _filename(self) -> str:
+        return f"{self.packagename()}.{self._pkg_id}"
+
+    def get_specification(self) -> Tuple[str, str, str, str]:
+        """
+        Returns a tuple containing the exchange type, the exchange file name, and the model names. This can be used
+        to write the exchange information in the simulation .nam input file
+        """
+        return (
+            self._exchange_type.value,
+            self._filename(),
+            self.model_name_1,
+            self.model_name_2,
+        )

--- a/imod/mf6/gwfgwf.py
+++ b/imod/mf6/gwfgwf.py
@@ -1,23 +1,24 @@
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 import cftime
 import numpy as np
 import xarray as xr
 
 from imod.mf6.auxiliary_variables import add_periodic_auxiliary_variable
+from imod.mf6.exchangebase import ExchangeBase, ExchangeType
 from imod.mf6.package import Package
 from imod.typing import GridDataArray
 
 
-class GWFGWF(Package):
+class GWFGWF(ExchangeBase):
     """
     This package is for writing an exchange file, used for splitting up a model
     into different submodels (that can be solved in parallel). It (usually)
     is not instantiated by users, but created by the "split" method of the
     simulation class."""
 
-    _keyword_map: Dict[str, str] = {}
     _auxiliary_data = {"auxiliary_data": "variable"}
+    _exchange_type = ExchangeType.GWFGWF
     _pkg_id = "gwfgwf"
     _template = Package._initialize_template(_pkg_id)
 
@@ -71,24 +72,6 @@ class GWFGWF(Package):
         self.dataset["variablecv"] = variablecv
         self.dataset["xt3d"] = xt3d
         self.dataset["newton"] = newton
-
-    def filename(self) -> str:
-        return f"{self.packagename()}.{self._pkg_id}"
-
-    def packagename(self) -> str:
-        return f"{self.dataset['model_name_1'].values[()]}_{self.dataset['model_name_2'].values[()]}"
-
-    def get_specification(self) -> Tuple[str, str, str, str]:
-        """
-        Returns a tuple containing the exchange type, the exchange file name, and the model names. This can be used
-        to write the exchange information in the simulation .nam input file
-        """
-        return (
-            "GWF6-GWF6",
-            self.filename(),
-            self.dataset["model_name_1"].values[()].take(0),
-            self.dataset["model_name_2"].values[()].take(0),
-        )
 
     def clip_box(
         self,

--- a/imod/mf6/gwfgwf.py
+++ b/imod/mf6/gwfgwf.py
@@ -5,7 +5,7 @@ import numpy as np
 import xarray as xr
 
 from imod.mf6.auxiliary_variables import add_periodic_auxiliary_variable
-from imod.mf6.exchangebase import ExchangeBase, ExchangeType
+from imod.mf6.exchangebase import ExchangeBase
 from imod.mf6.package import Package
 from imod.typing import GridDataArray
 
@@ -18,7 +18,6 @@ class GWFGWF(ExchangeBase):
     simulation class."""
 
     _auxiliary_data = {"auxiliary_data": "variable"}
-    _exchange_type = ExchangeType.GWFGWF
     _pkg_id = "gwfgwf"
     _template = Package._initialize_template(_pkg_id)
 

--- a/imod/mf6/gwfgwt.py
+++ b/imod/mf6/gwfgwt.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+import cftime
+import numpy as np
+
+from imod.mf6.exchangebase import ExchangeBase, ExchangeType
+from imod.mf6.package import Package
+from imod.typing import GridDataArray
+
+
+class GWFGWT(ExchangeBase):
+    _exchange_type = ExchangeType.GWFGWT
+    _pkg_id = "gwfgwt"
+    _template = Package._initialize_template(_pkg_id)
+
+    def __init__(self, model_id1: str, model_id2: str):
+        super().__init__(locals())
+        self.dataset["model_name_1"] = model_id1
+        self.dataset["model_name_2"] = model_id2
+
+    def clip_box(
+        self,
+        time_min: Optional[cftime.datetime | np.datetime64 | str] = None,
+        time_max: Optional[cftime.datetime | np.datetime64 | str] = None,
+        layer_min: Optional[int] = None,
+        layer_max: Optional[int] = None,
+        x_min: Optional[float] = None,
+        x_max: Optional[float] = None,
+        y_min: Optional[float] = None,
+        y_max: Optional[float] = None,
+        top: Optional[GridDataArray] = None,
+        bottom: Optional[GridDataArray] = None,
+        state_for_boundary: Optional[GridDataArray] = None,
+    ) -> Package:
+        """
+        The GWF-GWT exchange does not have any spatial coordinates that can be clipped.
+        """
+        pass

--- a/imod/mf6/gwfgwt.py
+++ b/imod/mf6/gwfgwt.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Optional
 
 import cftime
@@ -35,4 +36,4 @@ class GWFGWT(ExchangeBase):
         """
         The GWF-GWT exchange does not have any spatial coordinates that can be clipped.
         """
-        pass
+        return deepcopy(self)

--- a/imod/mf6/gwfgwt.py
+++ b/imod/mf6/gwfgwt.py
@@ -4,13 +4,12 @@ from typing import Optional
 import cftime
 import numpy as np
 
-from imod.mf6.exchangebase import ExchangeBase, ExchangeType
+from imod.mf6.exchangebase import ExchangeBase
 from imod.mf6.package import Package
 from imod.typing import GridDataArray
 
 
 class GWFGWT(ExchangeBase):
-    _exchange_type = ExchangeType.GWFGWT
     _pkg_id = "gwfgwt"
     _template = Package._initialize_template(_pkg_id)
 

--- a/imod/mf6/pkgbase.py
+++ b/imod/mf6/pkgbase.py
@@ -10,7 +10,7 @@ import imod
 from imod.mf6.interfaces.ipackagebase import IPackageBase
 
 TRANSPORT_PACKAGES = ("adv", "dsp", "ssm", "mst", "ist", "src")
-EXCHANGE_PACKAGES = "gwfgwf"
+EXCHANGE_PACKAGES = ("gwfgwf", "gwfgwt")
 
 
 class PackageBase(IPackageBase, abc.ABC):

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -282,7 +282,7 @@ class Modflow6Simulation(collections.UserDict):
                 for exchange in value:
                     if isinstance(exchange, imod.mf6.exchangebase.ExchangeBase):
                         exchange.write(
-                            exchange.packagename(), globaltimes, write_context
+                            exchange.package_name(), globaltimes, write_context
                         )
 
         if status_info.has_errors():

--- a/imod/tests/fixtures/package_instance_creation.py
+++ b/imod/tests/fixtures/package_instance_creation.py
@@ -299,6 +299,7 @@ GRIDLESS_PACKAGES = [
             },
         ),
     ),
+    imod.mf6.GWFGWT("model_name1", "model_name2"),
 ]
 
 

--- a/imod/tests/test_mf6/test_exchangebase.py
+++ b/imod/tests/test_mf6/test_exchangebase.py
@@ -2,11 +2,11 @@ from contextlib import nullcontext as does_not_raise
 
 import pytest
 
-from imod.mf6.exchangebase import ExchangeBase, ExchangeType
+from imod.mf6.exchangebase import ExchangeBase, _pkg_id_to_type
 
 
 class DummyExchange(ExchangeBase):
-    _exchange_type = ExchangeType.GWFGWT
+    _pkg_id = "gwfgwt"
 
     def __init__(self, model_id1: str = None, model_id2: str = None):
         super().__init__()
@@ -63,7 +63,7 @@ def test_get_specification():
     ) = exchange.get_specification()
 
     # Assert
-    assert spec_exchange_type is DummyExchange._exchange_type.value
+    assert spec_exchange_type is _pkg_id_to_type[DummyExchange._pkg_id]
     assert model_name1 in spec_filename
     assert model_name2 in spec_filename
     assert DummyExchange._pkg_id in spec_filename

--- a/imod/tests/test_mf6/test_exchangebase.py
+++ b/imod/tests/test_mf6/test_exchangebase.py
@@ -1,0 +1,71 @@
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from imod.mf6.exchangebase import ExchangeBase, ExchangeType
+
+
+class DummyExchange(ExchangeBase):
+    _exchange_type = ExchangeType.GWFGWT
+
+    def __init__(self, model_id1: str = None, model_id2: str = None):
+        super().__init__()
+        if model_id1:
+            self.dataset["model_name_1"] = model_id1
+        if model_id2:
+            self.dataset["model_name_2"] = model_id2
+
+
+def test_package_name_construct_name():
+    # Arrange.
+    model_name1 = "testmodel1"
+    model_name2 = "testmodel2"
+    exchange = DummyExchange(model_name1, model_name2)
+
+    # Act.
+    package_name = exchange.package_name()
+
+    # Assert.
+    assert model_name1 in package_name
+    assert model_name2 in package_name
+
+
+@pytest.mark.parametrize(
+    ("model_name1", "model_name2", "expectation"),
+    (
+        [None, None, pytest.raises(ValueError)],
+        ["testmodel1", None, pytest.raises(ValueError)],
+        [None, "testmodel2", pytest.raises(ValueError)],
+        ["testmodel1", "testmodel2", does_not_raise()],
+    ),
+)
+def test_package_name_missing_name(model_name1, model_name2, expectation):
+    # Arrange
+    exchange = DummyExchange(model_name1, model_name2)
+
+    # Act/Assert
+    with expectation:
+        exchange.package_name()
+
+
+def test_get_specification():
+    # Arrange.
+    model_name1 = "testmodel1"
+    model_name2 = "testmodel2"
+    exchange = DummyExchange(model_name1, model_name2)
+
+    # Act.
+    (
+        spec_exchange_type,
+        spec_filename,
+        spec_model_name1,
+        spec_model_name2,
+    ) = exchange.get_specification()
+
+    # Assert
+    assert spec_exchange_type is DummyExchange._exchange_type.value
+    assert model_name1 in spec_filename
+    assert model_name2 in spec_filename
+    assert DummyExchange._pkg_id in spec_filename
+    assert spec_model_name1 == model_name1
+    assert spec_model_name2 == model_name2

--- a/imod/tests/test_mf6/test_mf6_gwfgwf.py
+++ b/imod/tests/test_mf6/test_mf6_gwfgwf.py
@@ -169,7 +169,7 @@ def test_option_xt3d_propagated(circle_model, xt3d_option, tmp_path):
     label_array = get_label_array(circle_model, 3)
     split_simulation = circle_model.split(label_array)
 
-    # check that the created exchagnes have the same newton option
+    # check that the created exchanges have the same newton option
     for exchange in split_simulation["split_exchanges"]:
         assert exchange.dataset["xt3d"].values[()] == xt3d_option
         textrep = exchange.render(tmp_path, "gwfgwf", [], False)
@@ -185,7 +185,7 @@ def test_option_variablecv_propagated(circle_model, variablecv_option: bool, tmp
     label_array = get_label_array(circle_model, 3)
     split_simulation = circle_model.split(label_array)
 
-    # check that the created exchagnes have the same variablecv option
+    # check that the created exchanges have the same variablecv option
     for exchange in split_simulation["split_exchanges"]:
         assert exchange.dataset["variablecv"].values[()] == variablecv_option
         textrep = exchange.render(tmp_path, "gwfgwf", [], False)
@@ -202,7 +202,7 @@ def test_option_dewatered_propagated(circle_model, dewatered_option: bool, tmp_p
     label_array = get_label_array(circle_model, 3)
     split_simulation = circle_model.split(label_array)
 
-    # check that the created exchagnes have the same dewatered option
+    # check that the created exchanges have the same dewatered option
     for exchange in split_simulation["split_exchanges"]:
         assert exchange.dataset["dewatered"].values[()] == dewatered_option
         textrep = exchange.render(tmp_path, "gwfgwf", [], False)
@@ -219,7 +219,7 @@ def test_save_flows_propagated(circle_model, budget_option: bool, tmp_path):
     label_array = get_label_array(circle_model, 3)
     split_simulation = circle_model.split(label_array)
 
-    # check that the created exchagnes have the same dewatered option
+    # check that the created exchanges have the same dewatered option
     for exchange in split_simulation["split_exchanges"]:
         assert exchange.dataset["save_flows"].values[()] == budget_option
         textrep = exchange.render(tmp_path, "gwfgwf", [], False)

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -448,7 +448,8 @@ class TestModflow6Simulation:
         transient_twri_model.write(tmp_path, True, True, True)
 
         # Assert
-        assert Path.exists(tmp_path / sample_gwfgwf_structured._filename())
+        _, filename, _, _ = sample_gwfgwf_structured.get_specification()
+        assert Path.exists(tmp_path / filename)
 
     @pytest.mark.usefixtures("split_transient_twri_model")
     def test_prevent_split_after_split(

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -448,7 +448,7 @@ class TestModflow6Simulation:
         transient_twri_model.write(tmp_path, True, True, True)
 
         # Assert
-        assert Path.exists(tmp_path / sample_gwfgwf_structured.filename())
+        assert Path.exists(tmp_path / sample_gwfgwf_structured._filename())
 
     @pytest.mark.usefixtures("split_transient_twri_model")
     def test_prevent_split_after_split(


### PR DESCRIPTION
Fixes #748

# Description
The unit tests and examples were failing when run against the latest MODFLOW6 nightly. This is caused by a change on the MODFLOW6 side were any gwf-gwt exchanges has to have an actual  existing file (even though it is emty).
The precious behaviour was that just mentioning the gwf-gwt exchanges in the nam file was enough.

This commit adds the gwfgwt package. It uses the same logic as the gwfgwf exchanges in terms of how it is written to disk.
Any common methods between the different type of exchanges has been moved to the newly created ExchangeBase class

**Note**
I didn't add any unit tests for the simulation class. The reason for this is twofold:
- I moved code around, no major functional changes
- We have to refactor they way the gwf-gwt exchanges are being created the moment we start working on the multimodel support for gwt, making any unit tests I add obsolete

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
