### PR TITLE
Issue #774: Fix assert_equal_content in test_rasterio_ascii

### DIFF
--- a/imod/tests/test_formats/test_rasterio.py
+++ b/imod/tests/test_formats/test_rasterio.py
@@ -101,11 +101,10 @@ def test_rasterio_ascii(test_da, tmp_path, value, nodata, dtype, precision, digi
     def assert_equal_content(path_a, path_b):
         assert Path(path_a).exists()
         assert Path(path_b).exists()
-        with open(path_a, "r") as f:
-            content_a = f.read()
-        with open(path_b, "r") as f:
-            content_b = f.read()
-        assert content_a == content_b
+        ds_a = xr.open_dataset(path_a, engine="rasterio")
+        ds_b = xr.open_dataset(path_b, engine="rasterio")
+
+        xr.testing.assert_identical(ds_a, ds_b)
 
     da = xr.full_like(test_da, value)
     profile = {


### PR DESCRIPTION
Fixes #774 

# Description
Build in https://github.com/Deltares/imod-python/pull/760 fails for test_rasterio_ascii

``test_rasterio_ascii`` doesn't work for GDAL 3.8.3 compared to 3.7.3. 

Previously it was tested if files are exactly identical. This defeats the purpose, more important is that GDAL can read the file and interprets the file equal as if it were written with GDAL. Replacing ``assert_equal_content`` with the changes fixes things.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
