### PR TITLE
Issue #757 Create nightly pipeline

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -70,6 +70,8 @@ object Examples : BuildType({
     vcs {
         root(DslContext.settingsRoot, "+:. => imod-python")
         root(AbsoluteId("iMOD6_IMODPython_MetaSwapLookupTable"), ". => lookup_table")
+
+        cleanCheckout = true
     }
 
     steps {
@@ -137,6 +139,8 @@ object Lint : BuildType({
 
     vcs {
         root(DslContext.settingsRoot, "+:. => imod-python")
+
+        cleanCheckout = true
     }
 
     steps {
@@ -241,6 +245,8 @@ object UnitTests : BuildType({
 
     vcs {
         root(DslContext.settingsRoot, "+:. => imod-python")
+
+        cleanCheckout = true
     }
 
     steps {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -2,7 +2,6 @@ import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.CustomChart.Serie
 import jetbrains.buildServer.configs.kotlin.CustomChart.SeriesKey
 import jetbrains.buildServer.configs.kotlin.buildFeatures.*
-import jetbrains.buildServer.configs.kotlin.buildSteps.exec
 import jetbrains.buildServer.configs.kotlin.buildSteps.powerShell
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.projectFeatures.ProjectReportTab
@@ -169,6 +168,13 @@ object UnitTestsTemplate : Template({
         }
     }
 
+    features {
+        xmlReport {
+            reportType = XmlReport.XmlReportType.JUNIT
+            rules = "imod-python/imod/tests/*report.xml"
+        }
+    }
+
     requirements {
         equals("env.OS", "Windows_NT")
     }
@@ -199,6 +205,13 @@ object ExamplesTemplate : Template({
         }
     }
 
+    features {
+        xmlReport {
+            reportType = XmlReport.XmlReportType.JUNIT
+            rules = "imod-python/imod/tests/*report.xml"
+        }
+    }
+
     requirements {
         equals("env.OS", "Windows_NT")
     }
@@ -208,13 +221,6 @@ object Examples : BuildType({
     name = "Examples"
 
     templates(ExamplesTemplate, GitHubIntegrationTemplate)
-
-    features {
-        xmlReport {
-            reportType = XmlReport.XmlReportType.JUNIT
-            rules = "imod-python/imod/tests/*report.xml"
-        }
-    }
 
     dependencies {
         dependency(AbsoluteId("MetaSWAP_Modflow_Modflow6Release642")) {
@@ -296,13 +302,6 @@ object UnitTests : BuildType({
 
     templates(UnitTestsTemplate, GitHubIntegrationTemplate)
 
-    features {
-        xmlReport {
-            reportType = XmlReport.XmlReportType.JUNIT
-            rules = "imod-python/imod/tests/*report.xml"
-        }
-    }
-
     dependencies {
         dependency(AbsoluteId("MetaSWAP_Modflow_Modflow6Release642")) {
             snapshot {
@@ -338,13 +337,6 @@ object NightlyUnitTests : BuildType({
     name = "UnitTests"
 
     templates(UnitTestsTemplate)
-
-    features {
-        xmlReport {
-            reportType = XmlReport.XmlReportType.JUNIT
-            rules = "imod-python/imod/tests/*report.xml"
-        }
-    }
 
     dependencies {
         snapshot(NightlyLint) {
@@ -419,13 +411,6 @@ object NightlyExamples : BuildType({
     name = "Examples"
 
     templates(ExamplesTemplate)
-
-    features {
-        xmlReport {
-            reportType = XmlReport.XmlReportType.JUNIT
-            rules = "imod-python/imod/tests/*report.xml"
-        }
-    }
 
     dependencies {
         snapshot(NightlyLint) {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -41,8 +41,10 @@ project {
     buildType(Lint)
     buildType(Tests)
 
+    template(GitHubIntegrationTemplate)
     template(LintTemplate)
     template(UnitTestsTemplate)
+    template(ExamplesTemplate)
 
     features {
         buildTypeCustomChart {
@@ -66,6 +68,31 @@ project {
 
     subProject(Nightly)
 }
+
+object GitHubIntegrationTemplate : Template({
+    name = "GitHubIntegrationTemplate"
+
+    features {
+        commitStatusPublisher {
+            vcsRootExtId = "${DslContext.settingsRoot.id}"
+            publisher = github {
+                githubUrl = "https://api.github.com"
+                authType = personalToken {
+                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
+                }
+            }
+        }
+        pullRequests {
+            vcsRootExtId = "${DslContext.settingsRoot.id}"
+            provider = github {
+                authType = token {
+                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
+                }
+                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
+            }
+        }
+    }
+})
 
 object LintTemplate : Template({
     name = "LintTemplate"
@@ -180,30 +207,12 @@ object ExamplesTemplate : Template({
 object Examples : BuildType({
     name = "Examples"
 
-    templates(LintTemplate)
+    templates(ExamplesTemplate, GitHubIntegrationTemplate)
 
     features {
-        commitStatusPublisher {
-            vcsRootExtId = "${DslContext.settingsRoot.id}"
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
-                }
-            }
-        }
         xmlReport {
             reportType = XmlReport.XmlReportType.JUNIT
             rules = "imod-python/imod/tests/*report.xml"
-        }
-        pullRequests {
-            vcsRootExtId = "${DslContext.settingsRoot.id}"
-            provider = github {
-                authType = token {
-                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
-                }
-                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
-            }
         }
     }
 
@@ -226,28 +235,7 @@ object Examples : BuildType({
 object Lint : BuildType({
     name = "Lint"
 
-    templates(LintTemplate)
-
-    features {
-        commitStatusPublisher {
-            vcsRootExtId = "${DslContext.settingsRoot.id}"
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
-                }
-            }
-        }
-        pullRequests {
-            vcsRootExtId = "${DslContext.settingsRoot.id}"
-            provider = github {
-                authType = token {
-                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
-                }
-                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
-            }
-        }
-    }
+    templates(LintTemplate, GitHubIntegrationTemplate)
 })
 
 object Tests : BuildType({
@@ -306,30 +294,12 @@ object Tests : BuildType({
 object UnitTests : BuildType({
     name = "UnitTests"
 
-    templates(UnitTestsTemplate)
+    templates(UnitTestsTemplate, GitHubIntegrationTemplate)
 
     features {
-        commitStatusPublisher {
-            vcsRootExtId = "${DslContext.settingsRoot.id}"
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
-                }
-            }
-        }
         xmlReport {
             reportType = XmlReport.XmlReportType.JUNIT
             rules = "imod-python/imod/tests/*report.xml"
-        }
-        pullRequests {
-            vcsRootExtId = "${DslContext.settingsRoot.id}"
-            provider = github {
-                authType = token {
-                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
-                }
-                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
-            }
         }
     }
 
@@ -362,18 +332,6 @@ object NightlyLint : BuildType({
     name = "Lint"
 
     templates(LintTemplate)
-
-    features {
-        commitStatusPublisher {
-            vcsRootExtId = "iMOD6_IMODPython_ImodPython"
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
-                }
-            }
-        }
-    }
 })
 
 object NightlyUnitTests : BuildType({
@@ -460,7 +418,7 @@ object NightlyTests : BuildType({
 object NightlyExamples : BuildType({
     name = "Examples"
 
-    templates(LintTemplate)
+    templates(ExamplesTemplate)
 
     features {
         xmlReport {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -217,6 +217,33 @@ object ExamplesTemplate : Template({
     }
 })
 
+object Lint : BuildType({
+    name = "Lint"
+
+    templates(LintTemplate, GitHubIntegrationTemplate)
+})
+
+object UnitTests : BuildType({
+    name = "UnitTests"
+
+    templates(UnitTestsTemplate, GitHubIntegrationTemplate)
+
+    dependencies {
+        dependency(AbsoluteId("MetaSWAP_Modflow_Modflow6Release642")) {
+            snapshot {
+                onDependencyFailure = FailureAction.FAIL_TO_START
+            }
+
+            artifacts {
+                artifactRules = "+:MODFLOW6.zip!** => modflow6"
+            }
+        }
+        snapshot(Lint) {
+            onDependencyFailure = FailureAction.FAIL_TO_START
+        }
+    }
+})
+
 object Examples : BuildType({
     name = "Examples"
 
@@ -236,12 +263,6 @@ object Examples : BuildType({
             onDependencyFailure = FailureAction.FAIL_TO_START
         }
     }
-})
-
-object Lint : BuildType({
-    name = "Lint"
-
-    templates(LintTemplate, GitHubIntegrationTemplate)
 })
 
 object Tests : BuildType({
@@ -297,27 +318,6 @@ object Tests : BuildType({
     }
 })
 
-object UnitTests : BuildType({
-    name = "UnitTests"
-
-    templates(UnitTestsTemplate, GitHubIntegrationTemplate)
-
-    dependencies {
-        dependency(AbsoluteId("MetaSWAP_Modflow_Modflow6Release642")) {
-            snapshot {
-                onDependencyFailure = FailureAction.FAIL_TO_START
-            }
-
-            artifacts {
-                artifactRules = "+:MODFLOW6.zip!** => modflow6"
-            }
-        }
-        snapshot(Lint) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
-        }
-    }
-})
-
 object Nightly : Project({
     name = "Nightly"
 
@@ -337,6 +337,27 @@ object NightlyUnitTests : BuildType({
     name = "UnitTests"
 
     templates(UnitTestsTemplate)
+
+    dependencies {
+        snapshot(NightlyLint) {
+            onDependencyFailure = FailureAction.FAIL_TO_START
+        }
+        dependency(AbsoluteId("iMOD6_Modflow6buildWin64")) {
+            snapshot {
+                onDependencyFailure = FailureAction.FAIL_TO_START
+            }
+
+            artifacts {
+                artifactRules = "+:MODFLOW6.zip!** => modflow6"
+            }
+        }
+    }
+})
+
+object NightlyExamples : BuildType({
+    name = "Examples"
+
+    templates(ExamplesTemplate)
 
     dependencies {
         snapshot(NightlyLint) {
@@ -402,27 +423,6 @@ object NightlyTests : BuildType({
 
             artifacts {
                 artifactRules = "+:coverage.zip => ."
-            }
-        }
-    }
-})
-
-object NightlyExamples : BuildType({
-    name = "Examples"
-
-    templates(ExamplesTemplate)
-
-    dependencies {
-        snapshot(NightlyLint) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
-        }
-        dependency(AbsoluteId("iMOD6_Modflow6buildWin64")) {
-            snapshot {
-                onDependencyFailure = FailureAction.FAIL_TO_START
-            }
-
-            artifacts {
-                artifactRules = "+:MODFLOW6.zip!** => modflow6"
             }
         }
     }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -281,15 +281,6 @@ object Tests : BuildType({
         showDependenciesChanges = true
     }
 
-    triggers {
-        finishBuildTrigger {
-            buildType = "iMOD6_Modflow6buildWin64"
-            successfulOnly = true
-        }
-        vcs {
-        }
-    }
-
     features {
         pullRequests {
             vcsRootExtId = "${DslContext.settingsRoot.id}"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -79,14 +79,14 @@ object LintTemplate : Template({
     }
 
     steps {
-        exec {
-            name = "Static code analysis"
-            id = "Static_code_analysis"
-            workingDir = "imod-python"
-            path = "pixi"
-            arguments = "run --frozen lint"
-            formatStderrAsError = true
-            param("script.content", "pixi run lint")
+        script {
+                name = "Static code analysis"
+                id = "Static_code_analysis"
+                workingDir = "imod-python"
+                scriptContent = """
+                    pixi run --frozen lint
+                """.trimIndent()
+                formatStderrAsError = true
         }
     }
 


### PR DESCRIPTION
Fixes #757

# Description
This commit adds a nightly pipeline.
The goal of the nightly pipeline is to build or repository against the latest development branch of MODFLOW.
This will allow us to catch breaking changes early on.

The pipeline file has been refactored to prevent code duplication. This has been accomplished by using templates.
The new nightly pipeline is added as a new subproject of the main project

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
