### PR TITLE
Issue #785 Fix pipeline

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -281,6 +281,11 @@ object Tests : BuildType({
         showDependenciesChanges = true
     }
 
+    triggers {
+        vcs {
+        }
+    }
+
     features {
         pullRequests {
             vcsRootExtId = "${DslContext.settingsRoot.id}"


### PR DESCRIPTION
Fixes #785

 Due to a recent refactor of the pipeline a trigger is missing from the pipeline script. As a result builds are not started automatically.
This commit restores the trigger

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
