### PR TITLE
Issue #747 transport exchange options

### DIFF
--- a/imod/mf6/gwtgwt.py
+++ b/imod/mf6/gwtgwt.py
@@ -61,15 +61,11 @@ class GWTGWT(ExchangeBase):
 
     def set_options(
         self,
-        print_input: Optional[bool] = None,
-        print_flows: Optional[bool] = None,
         save_flows: Optional[bool] = None,
         adv_scheme: Optional[str] = None,
         dsp_xt3d_off: Optional[bool] = None,
         dsp_xt3d_rhs: Optional[bool] = None,
     ):
-        self.dataset["print_input"] = print_input
-        self.dataset["print_flows"] = print_flows
         self.dataset["save_flows"] = save_flows
         self.dataset["adv_scheme"] = adv_scheme
         self.dataset["dsp_xt3d_off"] = dsp_xt3d_off

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1016,7 +1016,7 @@ class Modflow6Simulation(collections.UserDict):
             self["split_exchanges"] = []
         self["split_exchanges"].extend(exchanges_list)
 
-    def _set_flow_exchange_options(self)-> None:
+    def _set_flow_exchange_options(self) -> None:
         # collect some options that we will auto-set
         for exchange in self["split_exchanges"]:
             if isinstance(exchange, GWFGWF):
@@ -1030,31 +1030,28 @@ class Modflow6Simulation(collections.UserDict):
                     newton=model_1.is_use_newton(),
                 )
 
-    def _set_transport_exchange_options(self) -> None:      
+    def _set_transport_exchange_options(self) -> None:
         for exchange in self["split_exchanges"]:
             if isinstance(exchange, GWTGWT):
                 model_name_1 = exchange.dataset["model_name_1"].values[()]
-                model_name_2 = exchange.dataset["model_name_2"].values[()]                
                 model_1 = self[model_name_1]
-                model_2 = self[model_name_2]                
                 advection_key = model_1._get_pkgkey("adv")
                 dispersion_key = model_1._get_pkgkey("dsp")
-                
+
                 scheme = None
                 xt3d_off = None
                 xt3d_rhs = None
                 if advection_key is not None:
-                    scheme  = model_1[advection_key].dataset["scheme"].values[()]
+                    scheme = model_1[advection_key].dataset["scheme"].values[()]
                 if dispersion_key is not None:
-                    xt3d_off  = model_1[dispersion_key].dataset["xt3d_off"].values[()]
-                    xt3d_rhs  = model_1[dispersion_key].dataset["xt3d_rhs"].values[()]                
+                    xt3d_off = model_1[dispersion_key].dataset["xt3d_off"].values[()]
+                    xt3d_rhs = model_1[dispersion_key].dataset["xt3d_rhs"].values[()]
                 exchange.set_options(
-                    save_flows = model_1["oc"].is_budget_output,
-                    adv_scheme = scheme,
-                    dsp_xt3d_off = xt3d_off,
-                    dsp_xt3d_rhs = xt3d_rhs,           
+                    save_flows=model_1["oc"].is_budget_output,
+                    adv_scheme=scheme,
+                    dsp_xt3d_off=xt3d_off,
+                    dsp_xt3d_rhs=xt3d_rhs,
                 )
-
 
     def _filter_inactive_cells_from_exchanges(self) -> None:
         for ex in self["split_exchanges"]:

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -962,7 +962,8 @@ class Modflow6Simulation(collections.UserDict):
                     tpt_model_name, flow_model_name, model.domain.layer
                 )
         new_simulation._add_modelsplit_exchanges(exchanges)
-        new_simulation._set_exchange_options()
+        new_simulation._set_flow_exchange_options()
+        new_simulation._set_transport_exchange_options()
 
         new_simulation._filter_inactive_cells_from_exchanges()
         return new_simulation
@@ -1015,7 +1016,7 @@ class Modflow6Simulation(collections.UserDict):
             self["split_exchanges"] = []
         self["split_exchanges"].extend(exchanges_list)
 
-    def _set_exchange_options(self):
+    def _set_flow_exchange_options(self)-> None:
         # collect some options that we will auto-set
         for exchange in self["split_exchanges"]:
             if isinstance(exchange, GWFGWF):
@@ -1028,9 +1029,32 @@ class Modflow6Simulation(collections.UserDict):
                     xt3d=model_1["npf"].get_xt3d_option(),
                     newton=model_1.is_use_newton(),
                 )
-            elif isinstance(exchange, GWTGWT):
-                # TODO: issue #747
-                continue
+
+    def _set_transport_exchange_options(self) -> None:      
+        for exchange in self["split_exchanges"]:
+            if isinstance(exchange, GWTGWT):
+                model_name_1 = exchange.dataset["model_name_1"].values[()]
+                model_name_2 = exchange.dataset["model_name_2"].values[()]                
+                model_1 = self[model_name_1]
+                model_2 = self[model_name_2]                
+                advection_key = model_1._get_pkgkey("adv")
+                dispersion_key = model_1._get_pkgkey("dsp")
+                
+                scheme = None
+                xt3d_off = None
+                xt3d_rhs = None
+                if advection_key is not None:
+                    scheme  = model_1[advection_key].dataset["scheme"].values[()]
+                if dispersion_key is not None:
+                    xt3d_off  = model_1[dispersion_key].dataset["xt3d_off"].values[()]
+                    xt3d_rhs  = model_1[dispersion_key].dataset["xt3d_rhs"].values[()]                
+                exchange.set_options(
+                    save_flows = model_1["oc"].is_budget_output,
+                    adv_scheme = scheme,
+                    dsp_xt3d_off = xt3d_off,
+                    dsp_xt3d_rhs = xt3d_rhs,           
+                )
+
 
     def _filter_inactive_cells_from_exchanges(self) -> None:
         for ex in self["split_exchanges"]:


### PR DESCRIPTION
Fixes #747 

# Description
assigns the advection scheme and dispersion xt3d options to the gwtgwt package. They are written into the options block of said file. 

- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
