### PR TITLE
fixing test

### DIFF
--- a/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
@@ -128,15 +128,15 @@ def test_split_flow_and_transport_model_evaluate_output(
     # Compare
     np.testing.assert_allclose(
         head.sel(time=2000)["head"].values,
-        original_head.sel(time=200).values,
+        original_head.sel(time=2000).values,
         rtol=1e-4,
-        atol=1e-4,
+        atol=1e-6,
     )
     np.testing.assert_allclose(
         conc.sel(time=2000)["concentration"].values,
-        original_conc.sel(time=200).values,
+        original_conc.sel(time=2000).values,
         rtol=1e-4,
-        atol=0.011,
+        atol=1e-6,
     )
 
 


### PR DESCRIPTION
Fixes #823 

# Description
Fixes a typo in the 1d transport model splitting test. Now that it's fixed tolerances for the comparison could be made much stricter

# Checklist

- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
