### PR TITLE
Issue #826 Remove black in favor of ruff

### DIFF
--- a/imod/mf6/out/cbc.py
+++ b/imod/mf6/out/cbc.py
@@ -117,13 +117,10 @@ def read_cbc_headers(
         while f.tell() < filesize:
             header = read_common_cbc_header(f)
             if header["imeth"] == 1:
+                # Multiply by -1 because ndim3 is stored as a negative for some reason.
+                # (ndim3 is the integer size of the third dimension)
                 datasize = (
-                    # Multiply by -1 because ndim3 is stored as a negative for some reason.
-                    # (ndim3 is the integer size of the third dimension)
-                    header["ndim1"]
-                    * header["ndim2"]
-                    * header["ndim3"]
-                    * -1
+                    header["ndim1"] * header["ndim2"] * header["ndim3"] * -1
                 ) * 8
                 header["pos"] = f.tell()
                 key = header["text"]

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -546,10 +546,8 @@ class Package(PackageBase, IPackage, abc.ABC):
                 if da.values[()] is not None:
                     if is_scalar(da.values[()]):
                         masked[var] = da.values[()]  # For scalars, such as options
-                    else:
-                        masked[var] = (
-                            da  # For example for arrays with only a layer dimension
-                        )
+                    else:  # For example for arrays with only a layer dimension
+                        masked[var] = da
                 else:
                     masked[var] = None
 

--- a/imod/msw/landuse.py
+++ b/imod/msw/landuse.py
@@ -160,12 +160,12 @@ class LanduseOptions(MetaSwapPackage):
         self.dataset["start_sprinkling_season"] = start_sprinkling_season
         self.dataset["end_sprinkling_season"] = end_sprinkling_season
         self.dataset["interception_option"] = interception_option
-        self.dataset["interception_capacity_per_LAI_Rutter"] = (
-            interception_capacity_per_LAI
-        )
-        self.dataset["interception_capacity_per_LAI_VonHoyningen"] = (
-            interception_capacity_per_LAI
-        )
+        self.dataset[
+            "interception_capacity_per_LAI_Rutter"
+        ] = interception_capacity_per_LAI
+        self.dataset[
+            "interception_capacity_per_LAI_VonHoyningen"
+        ] = interception_capacity_per_LAI
         self.dataset["interception_intercept"] = interception_intercept
 
         self._pkgcheck()

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -100,9 +100,9 @@ class MetaSwapModel(Model):
         super().__init__()
 
         self.simulation_settings = copy(DEFAULT_SETTINGS)
-        self.simulation_settings["unsa_svat_path"] = (
-            self._render_unsaturated_database_path(unsaturated_database)
-        )
+        self.simulation_settings[
+            "unsa_svat_path"
+        ] = self._render_unsaturated_database_path(unsaturated_database)
 
     def _render_unsaturated_database_path(self, unsaturated_database):
         # Force to Path object

--- a/imod/tests/test_code_checks.py
+++ b/imod/tests/test_code_checks.py
@@ -30,8 +30,8 @@ def test_check_modules():
     paths = glob(test_directory + "/../**/*.py")
     ok = True
     for path in paths:
-        if test_directory in os.path.realpath(
-            path
+        if (
+            test_directory in os.path.realpath(path)
         ):  # if it's a test we don't care. this very file contains print statements itself.
             continue
         try:

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -302,9 +302,9 @@ def test_to_mf6_remove_invalid_edges(
 ):
     # Arrange.
     idomain, top, bottom = parameterizable_basic_dis
-    idomain.loc[{"x": idomain.coords["x"][-1]}] = (
-        inactivity_marker  # make cells inactive
-    )
+    idomain.loc[
+        {"x": idomain.coords["x"][-1]}
+    ] = inactivity_marker  # make cells inactive
     k = ones_like(top)
 
     barrier_y = [0.0, 2.0]

--- a/imod/tests/test_mf6/test_mf6_uzf.py
+++ b/imod/tests/test_mf6/test_mf6_uzf.py
@@ -93,12 +93,8 @@ def test_to_sparsedata(test_data):
     layer = bin_data.isel(time=0)["layer"].values
     struct_array = uzf._to_struct_array(arrdict, layer)
     expected_iuzno = np.array([1, 2, 3, 4, 5, 6])
-    assert struct_array.dtype[0] == np.dtype(
-        "int32"
-    )  # pylint: disable=unsubscriptable-object
-    assert struct_array.dtype[1] == np.dtype(
-        "float64"
-    )  # pylint: disable=unsubscriptable-object
+    assert struct_array.dtype[0] == np.dtype("int32")  # pylint: disable=unsubscriptable-object
+    assert struct_array.dtype[1] == np.dtype("float64")  # pylint: disable=unsubscriptable-object
     assert np.all(struct_array["iuzno"] == expected_iuzno)
     assert len(struct_array.dtype) == 8
     assert len(struct_array) == 6

--- a/imod/tests/test_mf6/test_mf6_uzf_model.py
+++ b/imod/tests/test_mf6/test_mf6_uzf_model.py
@@ -111,9 +111,9 @@ def uzf_model():
     )
     uds["extinction_depth"] = ones_shape_time * -10.0
 
-    uds["simulate_groundwater_seepage"] = (
-        False  # Model doesn't converge if set to True....
-    )
+    uds[
+        "simulate_groundwater_seepage"
+    ] = False  # Model doesn't converge if set to True....
 
     gwf_model["uzf"] = imod.mf6.UnsaturatedZoneFlow(**uds)
 

--- a/imod/wq/pkgbase.py
+++ b/imod/wq/pkgbase.py
@@ -138,9 +138,7 @@ class Package(abc.ABC):
         rendered : str
             The rendered runfile part for a single boundary condition system.
         """
-        d = {
-            k: v.values for k, v in self.dataset.data_vars.items()
-        }  # pylint: disable=no-member
+        d = {k: v.values for k, v in self.dataset.data_vars.items()}  # pylint: disable=no-member
         if hasattr(self, "_keywords"):
             for key in self._keywords.keys():
                 self._replace_keyword(d, key)

--- a/imod/wq/pkggroup.py
+++ b/imod/wq/pkggroup.py
@@ -48,9 +48,7 @@ class PackageGroup(collections.UserDict, abc.ABC):
         d["n_systems"] = len(self.keys())
         d["n_max_active"] = sum(
             [
-                v._max_active_n(
-                    self._cellcount_varname, nlayer, nrow, ncol
-                )  # pylint:disable=no-member
+                v._max_active_n(self._cellcount_varname, nlayer, nrow, ncol)  # pylint:disable=no-member
                 for v in self.values()
             ]
         )

--- a/pixi.toml
+++ b/pixi.toml
@@ -15,8 +15,8 @@ repository = "https://github.com/Deltares/imod-python.git"
 [tasks]
 docs =  { cmd = "make html", depends_on = ["install"], cwd = "docs" }
 install = "python -m pip install --no-deps --editable ."
-format = { depends_on = ["sort_format", "black_format", "ruff_format"] }
-lint = { depends_on = ["sort_lint", "black_lint", "ruff_lint"] }
+format = { depends_on = ["sort_format", "ruff_format"] }
+lint = { depends_on = ["sort_lint", "ruff_lint"] }
 tests = { depends_on = ["unittests", "examples"] }
 unittests = { cmd = [
     "NUMBA_DISABLE_JIT=1",
@@ -40,8 +40,6 @@ examples = { cmd = [
 ], depends_on = ["install"], cwd = "imod/tests" }
 pypi-publish = { cmd = "rm --recursive --force dist && python -m build && twine check dist/* && twine upload dist/*" }
 
-black_lint = "black --check ."
-black_format = "black ."
 sort_lint = "ruff check --select I ."
 sort_format = "ruff check --select I --fix ."
 mypy_lint = { cmd ="mypy", depends_on = ["install"]}


### PR DESCRIPTION
Fixes #826

This commit replaces the black linter/formatter in favor of the ruff linter/formatter.
The ruff and black formatter are 99% compatible but they vary just slightly.
This causes issues when calling the `pixi run format` task because they counteract each other.

A full list of differences between black and ruff can be found at:
https://docs.astral.sh/ruff/formatter/black/

The changes to review are in the pixi.toml file. All other changes are made by the ruff formatter.

- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
