### PR TITLE
Issue #797 loading conc multispecies

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -33,6 +33,9 @@ Changed
   development install are adviced to run ``pip uninstall imod`` and ``pip
   install -e .`` again. This does not affect users who installed with ``pip
   install imod``, ``mamba install imod`` or ``conda install imod``.
+- :meth:`imod.mf6.Modflow6Simulation.open_concentration` and
+  :meth:`imod.mf6.Modflow6Simulation.open_transport_budget` raise a
+  ``ValueError`` if ``species_ls`` is provided with incorrect length.
 
 Added
 ~~~~~

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -39,6 +39,11 @@ Added
 - Added support for coupling a GroundwaterFlowModel and Transport Model i.c.w.
   the 6.4.3 release of MODFLOW. Using an older version of iMOD Python
   with this version of MODFLOW will result in an error.
+- :meth:`imod.mf6.Modflow6Simulation.split` supports splitting transport models,
+  including multi-species simulations.
+- :meth:`imod.mf6.Modflow6Simulation.open_concentration` and
+  :meth:`imod.mf6.Modflow6Simulation.open_transport_budget` support opening
+  split multi-species simulations.
 
 [0.15.1] - 2023-12-22
 ---------------------

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -586,9 +586,7 @@ class Modflow6Simulation(collections.UserDict):
         if output in ["head", "budget-flow"]:
             return self._open_single_output(modelnames, output, **settings)
         elif output in ["concentration", "budget-transport"]:
-            return self._concat_species(
-                output, **settings
-            )
+            return self._concat_species(output, **settings)
         else:
             raise RuntimeError(
                 f"Unexpected error when opening {output} for {modelnames}"
@@ -609,7 +607,7 @@ class Modflow6Simulation(collections.UserDict):
                 return self._merge_budgets(modelnames, output, **settings)
             else:
                 return self._merge_states(modelnames, output, **settings)
-            
+
     def _merge_states(
         self, modelnames: list[str], output: str, **settings
     ) -> GridDataArray:
@@ -664,12 +662,10 @@ class Modflow6Simulation(collections.UserDict):
 
         return merge_partitions(cbc_per_partition)
 
-    def _concat_species(
-        self, output: str, **settings
-    ) -> GridDataArray | GridDataset:
-        
+    def _concat_species(self, output: str, **settings) -> GridDataArray | GridDataset:
+
         # groupby flow model, to somewhat enforce consistent transport model
-        # ordening:        
+        # ordening:
         # F1Ta1 F1Tb1 F2Ta2 F2Tb2 -> F1: [Ta1, Tb1], F2: [Ta2, Tb2]
         # F1Ta1 F2Tb1 F1Ta1 F2Tb2 -> F1: [Ta1, Tb1], F2: [Ta2, Tb2]
         gb_flow_model = groupby_flow_model(self)
@@ -681,18 +677,20 @@ class Modflow6Simulation(collections.UserDict):
 
         if is_split(self):
             # [[Ta_1, Tb_1], [Ta_2, Tb_2]] -> [Ta, Tb]
-            unpartitioned_modelnames = [tpt_name.rpartition("_")[0] for tpt_name in all_tpt_names[0]]
+            unpartitioned_modelnames = [
+                tpt_name.rpartition("_")[0] for tpt_name in all_tpt_names[0]
+            ]
         else:
-            # [[Ta, Tb]] -> [Ta, Tb] 
+            # [[Ta, Tb]] -> [Ta, Tb]
             unpartitioned_modelnames = all_tpt_names[0]
-        
+
         species_ls = settings.pop("species_ls", unpartitioned_modelnames)
 
         if len(species_ls) != len(tpt_names_per_species):
             raise ValueError(
                 "species_ls does not equal the number of transport models, "
                 f"expected length {len(tpt_names_per_species)}, received {species_ls}"
-                )
+            )
 
         # Concatenate species
         outputs = []

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -433,6 +433,7 @@ class Modflow6Simulation(collections.UserDict):
             species_ls=species_ls,
             simulation_start_time=simulation_start_time,
             time_unit=time_unit,
+            merge_to_dataset=True,
         )
 
     def open_flow_budget(
@@ -501,6 +502,7 @@ class Modflow6Simulation(collections.UserDict):
             flowja=flowja,
             simulation_start_time=simulation_start_time,
             time_unit=time_unit,
+            merge_to_dataset=True,
         )
 
     def open_concentration(
@@ -627,8 +629,7 @@ class Modflow6Simulation(collections.UserDict):
 
         cbc_per_partition = []
         for modelname in modelnames:
-            cbc_dict = self._open_output_single_model(modelname, output, **settings)
-            cbc = merge_with_dictionary(cbc_dict)
+            cbc = self._open_output_single_model(modelname, output, **settings)
             # Merge and assign exchange budgets to dataset
             # FUTURE: Refactor to insert these exchange budgets in horizontal
             # flows.
@@ -655,10 +656,6 @@ class Modflow6Simulation(collections.UserDict):
         concentrations = []
         for modelname, species in zip(modelnames, species_ls):
             conc = self._open_output_single_model(modelname, output, **settings)
-            if not isinstance(conc, GridDataArray):
-                raise RuntimeError(
-                    f"Type error. Expected GridDataArray but got {type(conc)}"
-                )
             conc = conc.assign_coords(species=species)
             concentrations.append(conc)
         return concat(concentrations, dim="species")
@@ -668,11 +665,9 @@ class Modflow6Simulation(collections.UserDict):
     ) -> GridDataset:
         budgets = []
         for modelname, species in zip(modelnames, species_ls):
-            budget_dict = self._open_output_single_model(modelname, output, **settings)
-            budget = merge_with_dictionary(budget_dict)
+            budget = self._open_output_single_model(modelname, output, **settings)
             budget = budget.assign_coords(species=species)
             budgets.append(budget)
-
         return concat(budgets, dim="species")
 
     def _open_output_single_model(

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -576,6 +576,12 @@ class Modflow6Simulation(collections.UserDict):
         """
         modeltype = OUTPUT_MODEL_MAPPING[output]
         modelnames = self.get_models_of_type(modeltype._model_id).keys()
+        if len(modelnames) == 0:
+            modeltype = OUTPUT_MODEL_MAPPING[output]
+            raise ValueError(
+                f"Could not find any models of appropriate type for {output}, "
+                f"make sure a model of type {modeltype} is assigned to simulation."
+            )
 
         if output in ["head", "budget-flow"]:
             return self._open_single_output(modelnames, output, **settings)
@@ -660,7 +666,8 @@ class Modflow6Simulation(collections.UserDict):
 
     def _concat_species(
         self, output: str, **settings
-    ) -> GridDataArray:
+    ) -> GridDataArray | GridDataset:
+        
         # groupby flow model, to somewhat enforce consistent transport model
         # ordening:        
         # F1Ta1 F1Tb1 F2Ta2 F2Tb2 -> F1: [Ta1, Tb1], F2: [Ta2, Tb2]

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -592,7 +592,13 @@ class Modflow6Simulation(collections.UserDict):
                 f"Unexpected error when opening {output} for {modelnames}"
             )
 
-    def _open_single_output(self, modelnames, output, **settings):
+    def _open_single_output(
+        self, modelnames: list[str], output: str, **settings
+    ) -> GridDataArray | GridDataset:
+        """
+        Open single output, e.g. concentration of single species, or heads. This
+        can be output of partitioned models that need to be merged.
+        """
         if len(modelnames) == 0:
             modeltype = OUTPUT_MODEL_MAPPING[output]
             raise ValueError(
@@ -663,7 +669,6 @@ class Modflow6Simulation(collections.UserDict):
         return merge_partitions(cbc_per_partition)
 
     def _concat_species(self, output: str, **settings) -> GridDataArray | GridDataset:
-
         # groupby flow model, to somewhat enforce consistent transport model
         # ordening:
         # F1Ta1 F1Tb1 F2Ta2 F2Tb2 -> F1: [Ta1, Tb1], F2: [Ta2, Tb2]
@@ -702,9 +707,9 @@ class Modflow6Simulation(collections.UserDict):
 
     def _open_single_output_single_model(
         self, modelname: str, output: str, **settings
-    ) -> GridDataArray | dict[str, GridDataArray]:
+    ) -> GridDataArray | GridDataset:
         """
-        Opens output of single model
+        Opens single output of single model
 
         Parameters
         ----------

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -116,7 +116,7 @@ def test_simulation_open_flow_budget(circle_model, tmp_path):
 
     budget = simulation.open_flow_budget()
 
-    assert isinstance(budget, dict)
+    assert isinstance(budget, xu.UgridDataset)
     assert sorted(budget.keys()) == [
         "chd",
         "flow-horizontal-face",

--- a/imod/tests/test_mf6/test_mf6_transport_model.py
+++ b/imod/tests/test_mf6/test_mf6_transport_model.py
@@ -112,12 +112,12 @@ def test_transport_balance_loading(tmp_path, flow_transport_simulation):
     flow_transport_simulation.run()
 
     balance_notime = flow_transport_simulation.open_transport_budget(
-        species_ls=["a", "b", "d"]
+        species_ls=["a", "b", "c", "d"]
     )
     assert balance_notime.coords["time"].dtype == float
 
     balance_time = flow_transport_simulation.open_transport_budget(
-        species_ls=["a", "b", "d"], simulation_start_time="2000-01-31", time_unit="s"
+        species_ls=["a", "b", "c", "d"], simulation_start_time="2000-01-31", time_unit="s"
     )
     assert balance_time.coords["time"].dtype == np.dtype("datetime64[ns]")
 
@@ -125,3 +125,20 @@ def test_transport_balance_loading(tmp_path, flow_transport_simulation):
         balance_notime.sel(species="a")["ssm"].values
         == balance_time.sel(species="a")["ssm"].values
     )
+
+@pytest.mark.usefixtures("flow_transport_simulation")
+def test_transport_output_wrong_species(tmp_path, flow_transport_simulation):
+    flow_transport_simulation.write(tmp_path)
+    flow_transport_simulation.run()
+
+    with pytest.raises(ValueError):
+        # Should be ["a", "b", "c", "d"]
+        flow_transport_simulation.open_transport_budget(
+            species_ls=["a", "b"]
+        )
+
+    with pytest.raises(ValueError):
+        # Should be ["a", "b", "c", "d"]
+        flow_transport_simulation.open_concentration(
+            species_ls=["a", "b"]
+        )

--- a/imod/tests/test_mf6/test_mf6_transport_model.py
+++ b/imod/tests/test_mf6/test_mf6_transport_model.py
@@ -117,7 +117,9 @@ def test_transport_balance_loading(tmp_path, flow_transport_simulation):
     assert balance_notime.coords["time"].dtype == float
 
     balance_time = flow_transport_simulation.open_transport_budget(
-        species_ls=["a", "b", "c", "d"], simulation_start_time="2000-01-31", time_unit="s"
+        species_ls=["a", "b", "c", "d"],
+        simulation_start_time="2000-01-31",
+        time_unit="s",
     )
     assert balance_time.coords["time"].dtype == np.dtype("datetime64[ns]")
 
@@ -126,6 +128,7 @@ def test_transport_balance_loading(tmp_path, flow_transport_simulation):
         == balance_time.sel(species="a")["ssm"].values
     )
 
+
 @pytest.mark.usefixtures("flow_transport_simulation")
 def test_transport_output_wrong_species(tmp_path, flow_transport_simulation):
     flow_transport_simulation.write(tmp_path)
@@ -133,12 +136,8 @@ def test_transport_output_wrong_species(tmp_path, flow_transport_simulation):
 
     with pytest.raises(ValueError):
         # Should be ["a", "b", "c", "d"]
-        flow_transport_simulation.open_transport_budget(
-            species_ls=["a", "b"]
-        )
+        flow_transport_simulation.open_transport_budget(species_ls=["a", "b"])
 
     with pytest.raises(ValueError):
         # Should be ["a", "b", "c", "d"]
-        flow_transport_simulation.open_concentration(
-            species_ls=["a", "b"]
-        )
+        flow_transport_simulation.open_concentration(species_ls=["a", "b"])

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
@@ -83,6 +83,7 @@ def test_split_flow_and_transport_model(tmp_path, flow_transport_simulation):
 
     assert_simulation_can_run(new_simulation, "dis", tmp_path)
 
+
 @pytest.mark.usefixtures("flow_transport_simulation")
 def test_split_flow_and_transport_model_evaluate_output(
     tmp_path, flow_transport_simulation
@@ -163,6 +164,7 @@ def test_split_flow_and_transport_model_evaluate_output_with_species(
         rtol=1e-4,
         atol=1e-6,
     )
+
 
 @pytest.mark.usefixtures("flow_transport_simulation")
 @pytest.mark.parametrize("advection_scheme", ["TVD", "upstream", "central"])

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
@@ -4,7 +4,6 @@ import pytest
 from imod.mf6.adv import Advection
 from imod.mf6.dsp import Dispersion
 from imod.mf6.multimodel.modelsplitter import create_partition_info, slice_model
-from imod.mf6.simulation import Modflow6Simulation
 from imod.tests.fixtures.mf6_modelrun_fixture import assert_simulation_can_run
 from imod.typing.grid import zeros_like
 

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured_discharge.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured_discharge.py
@@ -139,8 +139,8 @@ def test_specific_discharge_results(
     head_diff = original_heads.isel(layer=0, time=-1) - split_head.isel(
         layer=0, time=-1
     )
-    veldif_x = original_balances_x_v2["data-spdis"] - split_balances_x_v2["npf-qx"]
-    veldif_y = original_balances_y_v2["data-spdis"] - split_balances_y_v2["npf-qy"]
+    veldif_x = original_balances_x_v2["npf-qx"] - split_balances_x_v2["npf-qx"]
+    veldif_y = original_balances_y_v2["npf-qy"] - split_balances_y_v2["npf-qy"]
 
     # Assert results are close for head and specific discharge
     assert np.abs(head_diff["head"].values).max() < 1e-5


### PR DESCRIPTION
Fixes #797 and #750 

# Description
- Implements loading of multispecies concs and transport budgets
- Refactors code to follow following hierarchy: ``_concat_species -> _open_single_output -> _open_single_output_single_model``
- An error is thrown if provided ``species_ls`` does not have the appropriate length
- Add some tests

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
