### PR TITLE
Issue #836 Make MyPy stricter by enabling follow_imports

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -4,6 +4,8 @@ import jetbrains.buildServer.configs.kotlin.CustomChart.SeriesKey
 import jetbrains.buildServer.configs.kotlin.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.powerShell
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.failureConditions.failOnMetricChange
 import jetbrains.buildServer.configs.kotlin.projectFeatures.ProjectReportTab
 import jetbrains.buildServer.configs.kotlin.projectFeatures.projectReportTab
 import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
@@ -267,6 +269,18 @@ object MyPy : BuildType({
     name = "MyPy"
 
     templates(MyPyTemplate, GitHubIntegrationTemplate)
+
+    failureConditions {
+        nonZeroExitCode = false
+        testFailure = false
+        failOnMetricChange {
+            metric = BuildFailureOnMetric.MetricType.TEST_FAILED_COUNT
+            threshold = 26
+            units = BuildFailureOnMetric.MetricUnit.DEFAULT_UNIT
+            comparison = BuildFailureOnMetric.MetricComparison.MORE
+            compareTo = value()
+        }
+    }
 })
 
 object UnitTests : BuildType({

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -275,7 +275,7 @@ object MyPy : BuildType({
         testFailure = false
         failOnMetricChange {
             metric = BuildFailureOnMetric.MetricType.TEST_FAILED_COUNT
-            threshold = 7
+            threshold = 2
             units = BuildFailureOnMetric.MetricUnit.DEFAULT_UNIT
             comparison = BuildFailureOnMetric.MetricComparison.MORE
             compareTo = value()

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -275,7 +275,7 @@ object MyPy : BuildType({
         testFailure = false
         failOnMetricChange {
             metric = BuildFailureOnMetric.MetricType.TEST_FAILED_COUNT
-            threshold = 26
+            threshold = 7
             units = BuildFailureOnMetric.MetricUnit.DEFAULT_UNIT
             comparison = BuildFailureOnMetric.MetricComparison.MORE
             compareTo = value()

--- a/imod/mf6/auxiliary_variables.py
+++ b/imod/mf6/auxiliary_variables.py
@@ -37,8 +37,8 @@ def expand_transient_auxiliary_variables(package: IPackage) -> None:
     be split in several dataarrays- one for each species.
     """
 
-    if len(package.auxiliary_data_fields()) > 0:
-        for aux_var_name, aux_var_dimensions in package.auxiliary_data_fields().items():
+    if len(package.auxiliary_data_fields) > 0:
+        for aux_var_name, aux_var_dimensions in package.auxiliary_data_fields.items():
             if aux_var_name in list(package.dataset.keys()):
                 aux_coords = (
                     package.dataset[aux_var_name].coords[aux_var_dimensions].values
@@ -54,7 +54,7 @@ def remove_expanded_auxiliary_variables_from_dataset(package: IPackage) -> None:
     Removes the data arrays created by :meth:expand_transient_auxiliary_variables(...) but does not
     remove the auxiliary dataarray used as source for :meth:expand_transient_auxiliary_variables(...)
     """
-    for aux_var_name, aux_var_dimensions in package.auxiliary_data_fields().items():
+    for aux_var_name, aux_var_dimensions in package.auxiliary_data_fields.items():
         if aux_var_dimensions in package.dataset.coords:
             for species in package.dataset.coords[aux_var_dimensions].values:
                 if species in list(package.dataset.keys()):

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -409,7 +409,7 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
 
         barrier_dataset["print_input"] = self.dataset["print_input"]
 
-        return Mf6HorizontalFlowBarrier(**barrier_dataset.to_dict())
+        return Mf6HorizontalFlowBarrier(**barrier_dataset)
 
     def is_empty(self) -> bool:
         if super().is_empty():

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -409,7 +409,7 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
 
         barrier_dataset["print_input"] = self.dataset["print_input"]
 
-        return Mf6HorizontalFlowBarrier(**barrier_dataset)
+        return Mf6HorizontalFlowBarrier(**barrier_dataset.data_vars)
 
     def is_empty(self) -> bool:
         if super().is_empty():

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -409,7 +409,7 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
 
         barrier_dataset["print_input"] = self.dataset["print_input"]
 
-        return Mf6HorizontalFlowBarrier(**barrier_dataset)
+        return Mf6HorizontalFlowBarrier(**barrier_dataset.to_dict())
 
     def is_empty(self) -> bool:
         if super().is_empty():

--- a/imod/mf6/interfaces/ipackage.py
+++ b/imod/mf6/interfaces/ipackage.py
@@ -1,5 +1,4 @@
 import abc
-from typing import Dict
 
 from imod.mf6.interfaces.ipackagebase import IPackageBase
 
@@ -11,5 +10,5 @@ class IPackage(IPackageBase, metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def auxiliary_data_fields(self) -> Dict[str, str]:
+    def auxiliary_data_fields(self) -> dict[str, str]:
         raise NotImplementedError

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -6,7 +6,7 @@ import inspect
 import pathlib
 from copy import deepcopy
 from pathlib import Path
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, cast
 
 import cftime
 import jinja2
@@ -270,7 +270,9 @@ class Modflow6Model(collections.UserDict, abc.ABC):
                 ):
                     top, bottom, idomain = self.__get_domain_geometry()
                     k = self.__get_k()
-                    mf6_pkg = pkg.to_mf6_pkg(idomain, top, bottom, k, validate)
+                    mf6_pkg = cast(
+                        imod.mf6.HorizontalFlowBarrierBase | imod.mf6.Well, pkg
+                    ).to_mf6_pkg(idomain, top, bottom, k, validate)
                     mf6_pkg.write(
                         pkgname=pkg_name,
                         globaltimes=globaltimes,

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -6,7 +6,7 @@ import inspect
 import pathlib
 from copy import deepcopy
 from pathlib import Path
-from typing import Optional, Tuple, Union, cast
+from typing import Optional, Tuple, Union
 
 import cftime
 import jinja2
@@ -251,7 +251,7 @@ class Modflow6Model(collections.UserDict, abc.ABC):
                 if isinstance(pkg, imod.mf6.Well):
                     top, bottom, idomain = self.__get_domain_geometry()
                     k = self.__get_k()
-                    mf6_pkg = pkg.to_mf6_pkg(
+                    mf6_well_pkg = pkg.to_mf6_pkg(
                         idomain,
                         top,
                         bottom,
@@ -260,20 +260,16 @@ class Modflow6Model(collections.UserDict, abc.ABC):
                         pkg_write_context.is_partitioned,
                     )
 
-                    mf6_pkg.write(
+                    mf6_well_pkg.write(
                         pkgname=pkg_name,
                         globaltimes=globaltimes,
                         write_context=pkg_write_context,
                     )
-                elif isinstance(
-                    pkg, imod.mf6.HorizontalFlowBarrierBase | imod.mf6.Well
-                ):
+                elif isinstance(pkg, imod.mf6.HorizontalFlowBarrierBase):
                     top, bottom, idomain = self.__get_domain_geometry()
                     k = self.__get_k()
-                    mf6_pkg = cast(
-                        imod.mf6.HorizontalFlowBarrierBase | imod.mf6.Well, pkg
-                    ).to_mf6_pkg(idomain, top, bottom, k, validate)
-                    mf6_pkg.write(
+                    mf6_hfb_pkg = pkg.to_mf6_pkg(idomain, top, bottom, k, validate)
+                    mf6_hfb_pkg.write(
                         pkgname=pkg_name,
                         globaltimes=globaltimes,
                         write_context=pkg_write_context,

--- a/imod/mf6/npf.py
+++ b/imod/mf6/npf.py
@@ -19,7 +19,9 @@ def _dataarray_to_bool(griddataarray: GridDataArray) -> bool:
         return False
 
     if griddataarray.values.size != 1:
-        raise ValueError("Dataarray is not a single value. Unable to convert to boolean")
+        raise ValueError(
+            "Dataarray is not a single value. Unable to convert to boolean"
+        )
     return griddataarray.values.item()
 
 

--- a/imod/mf6/npf.py
+++ b/imod/mf6/npf.py
@@ -11,6 +11,15 @@ from imod.schemata import (
     IdentityNoDataSchema,
     IndexesSchema,
 )
+from imod.typing import GridDataArray
+
+
+def _dataarray_to_bool(griddataarray: GridDataArray) -> bool:
+    if griddataarray is None or griddataarray.values is None:
+        return False
+
+    assert griddataarray.values.size == 1
+    return griddataarray.values.item()
 
 
 class NodePropertyFlow(Package):
@@ -400,7 +409,7 @@ class NodePropertyFlow(Package):
         """
         Returns the xt3d option value for this object.
         """
-        return self.dataset["xt3d_option"].values[()]
+        return _dataarray_to_bool(self.dataset["xt3d_option"])
 
     def set_xt3d_option(self, is_xt3d_used: bool, is_rhs: bool) -> None:
         """
@@ -414,11 +423,11 @@ class NodePropertyFlow(Package):
         """
         Returns the VariableCV option value for this object.
         """
-        return self.dataset["variable_vertical_conductance"].values[()]
+        return _dataarray_to_bool(self.dataset["variable_vertical_conductance"])
 
     @property
     def is_dewatered(self) -> bool:
         """
         Returns the "dewatered" option value for this object. Used only when variable_vertical_conductance is true
         """
-        return self.dataset["dewatered"].values[()]
+        return _dataarray_to_bool(self.dataset["dewatered"])

--- a/imod/mf6/npf.py
+++ b/imod/mf6/npf.py
@@ -20,8 +20,14 @@ def _dataarray_to_bool(griddataarray: GridDataArray) -> bool:
 
     if griddataarray.values.size != 1:
         raise ValueError(
-            "Dataarray is not a single value. Unable to convert to boolean"
+            "DataArray is not a single value"
         )
+
+    if griddataarray.values.dtype != bool:
+        raise ValueError(
+            "DataArray is not a boolean"
+        )
+
     return griddataarray.values.item()
 
 

--- a/imod/mf6/npf.py
+++ b/imod/mf6/npf.py
@@ -18,7 +18,7 @@ def _dataarray_to_bool(griddataarray: GridDataArray) -> bool:
     if griddataarray is None or griddataarray.values is None:
         return False
 
-    if griddataarray.values.size == 1:
+    if griddataarray.values.size != 1:
         raise ValueError("Dataarray is not a single value. Unable to convert to boolean")
     return griddataarray.values.item()
 

--- a/imod/mf6/npf.py
+++ b/imod/mf6/npf.py
@@ -18,7 +18,8 @@ def _dataarray_to_bool(griddataarray: GridDataArray) -> bool:
     if griddataarray is None or griddataarray.values is None:
         return False
 
-    assert griddataarray.values.size == 1
+    if griddataarray.values.size == 1:
+        raise ValueError("Dataarray is not a single value. Unable to convert to boolean")
     return griddataarray.values.item()
 
 

--- a/imod/mf6/oc.py
+++ b/imod/mf6/oc.py
@@ -137,6 +137,10 @@ class OutputControl(Package):
         if filepath is None:
             filepath = directory / f"{modelname}.{ext}"
         else:
+            if not isinstance(filepath, str | Path):
+                raise ValueError(
+                    f"{varname} should be of type str or Path. However it is of type {type(filepath)}"
+                )
             filepath = Path(filepath)
 
         if filepath.is_absolute():
@@ -191,6 +195,10 @@ class OutputControl(Package):
         for datavar in ("head_file", "concentration_file", "budget_file"):
             path = self.dataset[datavar].values[()]
             if path is not None:
+                if not isinstance(path, str):
+                    raise ValueError(
+                        f"{path} should be of type str. However it is of type {type(path)}"
+                    )
                 filepath = Path(path)
                 filepath.parent.mkdir(parents=True, exist_ok=True)
         return

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -323,7 +323,7 @@ class Package(PackageBase, IPackage, abc.ABC):
 
     def copy(self) -> Any:
         # All state should be contained in the dataset.
-        return type(self)(**self.dataset.copy())
+        return type(self)(**self.dataset.copy().to_dict())
 
     @staticmethod
     def _clip_repeat_stress(
@@ -711,6 +711,7 @@ class Package(PackageBase, IPackage, abc.ABC):
         typename = type(self).__name__
         return f"<div>{typename}</div>{self.dataset._repr_html_()}"
 
+    @property
     def auxiliary_data_fields(self) -> dict[str, str]:
         if hasattr(self, "_auxiliary_data"):
             return self._auxiliary_data

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -601,7 +601,7 @@ class Modflow6Simulation(collections.UserDict):
         """
         exchange_names = [
             cast(str, key)
-            for key in cbc.items()
+            for key in cbc.keys()
             if ("gwf-gwf" in key) or ("gwt-gwt" in key)
         ]
         exchange_budgets = cbc[exchange_names].to_array().sum(dim="variable")

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -6,7 +6,7 @@ import pathlib
 import subprocess
 import warnings
 from pathlib import Path
-from typing import Any, Callable, DefaultDict, Optional, Union
+from typing import Any, Callable, DefaultDict, Optional, Union, cast
 
 import cftime
 import jinja2
@@ -31,7 +31,6 @@ from imod.mf6.multimodel.exchange_creator_unstructured import (
 from imod.mf6.multimodel.modelsplitter import create_partition_info, slice_model
 from imod.mf6.out import open_cbc, open_conc, open_hds
 from imod.mf6.package import Package
-from imod.mf6.pkgbase import PackageBase
 from imod.mf6.statusinfo import NestedStatusInfo
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
@@ -187,7 +186,7 @@ class Modflow6Simulation(collections.UserDict):
                     write_context.root_directory / pathlib.Path(f"{key}", f"{key}.nam")
                 ).as_posix()
                 models.append((value.model_id(), model_name_file, key))
-            elif isinstance(value, PackageBase):
+            elif isinstance(value, Package):
                 if value._pkg_id == "tdis":
                     d["tdis6"] = f"{key}.tdis"
                 elif value._pkg_id == "ims":
@@ -281,7 +280,7 @@ class Modflow6Simulation(collections.UserDict):
                         write_context=model_write_context,
                     )
                 )
-            elif isinstance(value, PackageBase):
+            elif isinstance(value, Package):
                 if value._pkg_id == "ims":
                     ims_write_context = write_context.copy_with_new_write_directory(
                         write_context.simulation_directory
@@ -601,7 +600,9 @@ class Modflow6Simulation(collections.UserDict):
         cbc[[gwf-gwf_1, gwf-gwf_3]] to cbc[gwf-gwf]
         """
         exchange_names = [
-            key for key in cbc.keys() if ("gwf-gwf" in key) or ("gwt-gwt" in key)
+            cast(str, key)
+            for key in cbc.items()
+            if ("gwf-gwf" in key) or ("gwt-gwt" in key)
         ]
         exchange_budgets = cbc[exchange_names].to_array().sum(dim="variable")
         cbc = cbc.drop_vars(exchange_names)
@@ -651,7 +652,8 @@ class Modflow6Simulation(collections.UserDict):
         concentrations = []
         for modelname, species in zip(modelnames, species_ls):
             conc = self._open_output_single_model(modelname, output, **settings)
-            if not isinstance(conc, GridDataArray):
+            # Bug in mypy when using unions in isInstance
+            if not isinstance(conc, GridDataArray):  # type: ignore
                 raise RuntimeError(
                     f"Type error. Expected GridDataArray but got {type(conc)}"
                 )

--- a/imod/mf6/utilities/schemata.py
+++ b/imod/mf6/utilities/schemata.py
@@ -1,8 +1,11 @@
+from typing import Tuple
+
 from imod.schemata import BaseSchema
 
 
 def filter_schemata_dict(
-    schemata_dict: dict[str, list[BaseSchema]], schema_types: tuple[type[BaseSchema]]
+    schemata_dict: dict[str, list[BaseSchema] | Tuple[BaseSchema, ...]],
+    schema_types: tuple[type[BaseSchema], ...],
 ) -> dict[str, list[BaseSchema]]:
     """
     Filter schemata dict with a tuple of schema types. Keys which do not have

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -556,14 +556,14 @@ class Well(BoundaryCondition, IPointDataPackage):
         ds["cellid"] = self.__create_cellid(wells_assigned, active)
 
         ds_vars = self.__create_dataset_vars(wells_assigned, wells_df, ds["cellid"])
-        ds = ds.assign(**ds_vars)
+        ds = ds.assign(**ds_vars.data_vars)
 
         ds = remove_inactive(ds, active)
 
         # TODO: make options like "save_flows" configurable. Issue github #623
         ds["save_flows"] = True
 
-        return Mf6Wel(**ds)
+        return Mf6Wel(**ds.data_vars)
 
     def regrid_like(self, target_grid: GridDataArray, *_) -> Well:
         """
@@ -585,7 +585,7 @@ class Well(BoundaryCondition, IPointDataPackage):
         # Drop layer coordinate if present, otherwise a layer coordinate is assigned
         # which causes conflicts downstream when assigning wells and deriving
         # cellids.
-        domain_2d = domain.isel(layer=0, drop=True, missing_dims="ignore").drop(
+        domain_2d = domain.isel(layer=0, drop=True, missing_dims="ignore").drop_vars(
             "layer", errors="ignore"
         )
         return mask_2D(self, domain_2d)

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -265,7 +265,8 @@ class Well(BoundaryCondition, IPointDataPackage):
             )
 
         if top is not None:
-            if not isinstance(top, GridDataArray) or "layer" not in top.coords:
+            # Bug in mypy when using unions in isInstance
+            if not isinstance(top, GridDataArray) or "layer" not in top.coords:  # type: ignore
                 top = create_layered_top(bottom, top)
 
         # The super method will select in the time dimension without issues.
@@ -562,7 +563,7 @@ class Well(BoundaryCondition, IPointDataPackage):
         # TODO: make options like "save_flows" configurable. Issue github #623
         ds["save_flows"] = True
 
-        return Mf6Wel(**ds)
+        return Mf6Wel(**ds.to_dict())
 
     def regrid_like(self, target_grid: GridDataArray, *_) -> Well:
         """

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -131,11 +131,11 @@ class Well(BoundaryCondition, IPointDataPackage):
     """
 
     @property
-    def x(self) -> npt.NDArray[float]:
+    def x(self) -> npt.NDArray[np.float64]:
         return self.dataset["x"].values
 
     @property
-    def y(self) -> npt.NDArray[float]:
+    def y(self) -> npt.NDArray[np.float64]:
         return self.dataset["y"].values
 
     _pkg_id = "wel"
@@ -180,7 +180,7 @@ class Well(BoundaryCondition, IPointDataPackage):
         repeat_stress: Optional[xr.DataArray] = None,
     ):
         if id is None:
-            id = np.arange(len(x)).astype(str)
+            id = list(np.arange(len(x)).astype(str))
 
         dict_dataset = {
             "screen_top": _assign_dims(screen_top),
@@ -555,7 +555,7 @@ class Well(BoundaryCondition, IPointDataPackage):
         ds["cellid"] = self.__create_cellid(wells_assigned, active)
 
         ds_vars = self.__create_dataset_vars(wells_assigned, wells_df, ds["cellid"])
-        ds = ds.assign(**dict(ds_vars.items()))
+        ds = ds.assign(**ds_vars.to_dict())
 
         ds = remove_inactive(ds, active)
 

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -556,14 +556,14 @@ class Well(BoundaryCondition, IPointDataPackage):
         ds["cellid"] = self.__create_cellid(wells_assigned, active)
 
         ds_vars = self.__create_dataset_vars(wells_assigned, wells_df, ds["cellid"])
-        ds = ds.assign(**ds_vars.to_dict())
+        ds = ds.assign(**ds_vars)
 
         ds = remove_inactive(ds, active)
 
         # TODO: make options like "save_flows" configurable. Issue github #623
         ds["save_flows"] = True
 
-        return Mf6Wel(**ds.to_dict())
+        return Mf6Wel(**ds)
 
     def regrid_like(self, target_grid: GridDataArray, *_) -> Well:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,13 @@ convention = "numpy"
 "test_examples.py" = ["F401"]
 
 [tool.mypy]
-files = "imod/mf6/**.py"
-follow_imports = "skip"
+files = ["imod/mf6/**.py"]
+follow_imports = "silent"
+warn_unused_configs = true
+
+[[tool.mypy.overrides]]
+module = 'mf6'
+follow_imports = "normal"
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
Fixes #836

In this commit the settings of MyPy are made stricter by enabling the follow_imports flag. By enabling this flag, information about type hints from modules being imported are also taken into account when performing the static code analyzes

In the pipeline a threshold has been added to the MyPy step which tolerates 2 errors. These 2 errors have to do with mypy errors with regard to the regridder. Those errors are better handled in a separate story. Once resolved the threshold can be set to 0

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
