### PR TITLE
Issue #679 fix split and dump for partitioned models

### DIFF
--- a/imod/mf6/__init__.py
+++ b/imod/mf6/__init__.py
@@ -14,6 +14,7 @@ from imod.mf6.evt import Evapotranspiration
 from imod.mf6.ghb import GeneralHeadBoundary
 from imod.mf6.gwfgwf import GWFGWF
 from imod.mf6.gwfgwt import GWFGWT
+from imod.mf6.gwtgwt import GWTGWT
 from imod.mf6.hfb import (
     HorizontalFlowBarrierBase,
     HorizontalFlowBarrierHydraulicCharacteristic,

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -815,7 +815,7 @@ class Modflow6Simulation(collections.UserDict):
                     directory
                 ).as_posix()
             elif key in ["gwtgwf_exchanges","split_exchanges"]:
-                toml_content[key] = defaultdict(list)
+                toml_content[key] = collections.defaultdict(list)
                 for exchange_package in self[key]:
                     exchange_type, filename, _, _ = exchange_package.get_specification()
                     exchange_class_short = type(exchange_package).__name__

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -814,7 +814,7 @@ class Modflow6Simulation(collections.UserDict):
                 toml_content[cls_name][key] = model_toml_path.relative_to(
                     directory
                 ).as_posix()
-            elif key == "split_exchanges":
+            elif key in ["gwtgwf_exchanges","split_exchanges"]:
                 toml_content[key] = {}
                 for exchange_package in self[key]:
                     exchange_type, filename, _, _ = exchange_package.get_specification()
@@ -857,7 +857,7 @@ class Modflow6Simulation(collections.UserDict):
         simulation = Modflow6Simulation(name=toml_path.stem)
         for key, entry in toml_content.items():
            
-            if key != "split_exchanges":
+            if not key in ["gwtgwf_exchanges", "split_exchanges"]:
                 item_cls = classes[key]
                 for name, filename in entry.items():
                     path = toml_path.parent / filename

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -814,6 +814,17 @@ class Modflow6Simulation(collections.UserDict):
                 toml_content[cls_name][key] = model_toml_path.relative_to(
                     directory
                 ).as_posix()
+            elif key == "split_exchanges":
+                toml_content[key] = {}
+                for exchange_package in self[key]:
+                    exchange_type, filename, _, _ = exchange_package.get_specification()
+                    exchange_class_short = type(exchange_package).__name__
+                    if not exchange_class_short in toml_content[key].keys():
+                         toml_content[key][exchange_class_short]=[]
+                    path = f"{filename}.nc"
+                    exchange_package.dataset.to_netcdf(directory / path)
+                    toml_content[key][exchange_class_short].append(path)
+
             else:
                 path = f"{key}.nc"
                 value.dataset.to_netcdf(directory / path)
@@ -833,6 +844,9 @@ class Modflow6Simulation(collections.UserDict):
                 GroundwaterTransportModel,
                 imod.mf6.TimeDiscretization,
                 imod.mf6.Solution,
+                imod.mf6.GWFGWF,
+                imod.mf6.GWFGWT,
+                imod.mf6.GWTGWT
             )
         }
 
@@ -842,10 +856,19 @@ class Modflow6Simulation(collections.UserDict):
 
         simulation = Modflow6Simulation(name=toml_path.stem)
         for key, entry in toml_content.items():
-            item_cls = classes[key]
-            for name, filename in entry.items():
-                path = toml_path.parent / filename
-                simulation[name] = item_cls.from_file(path)
+           
+            if key != "split_exchanges":
+                item_cls = classes[key]
+                for name, filename in entry.items():
+                    path = toml_path.parent / filename
+                    simulation[name] = item_cls.from_file(path)
+            else:
+                simulation[key] = []
+                for exchange_class, exchange_list in entry.items():
+                    item_cls = classes[exchange_class]
+                    for filename in exchange_list:
+                        path = toml_path.parent / filename
+                        simulation[key].append(item_cls.from_file(path))
 
         return simulation
 

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -815,12 +815,10 @@ class Modflow6Simulation(collections.UserDict):
                     directory
                 ).as_posix()
             elif key in ["gwtgwf_exchanges","split_exchanges"]:
-                toml_content[key] = {}
+                toml_content[key] = defaultdict(list)
                 for exchange_package in self[key]:
                     exchange_type, filename, _, _ = exchange_package.get_specification()
                     exchange_class_short = type(exchange_package).__name__
-                    if not exchange_class_short in toml_content[key].keys():
-                         toml_content[key][exchange_class_short]=[]
                     path = f"{filename}.nc"
                     exchange_package.dataset.to_netcdf(directory / path)
                     toml_content[key][exchange_class_short].append(path)

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
@@ -1,3 +1,4 @@
+from filecmp import dircmp
 from pathlib import Path
 
 import numpy as np
@@ -45,10 +46,15 @@ def test_split_dump(
     submodel_labels = submodel_labels.sel(layer=0, drop=True)
 
     split_simulation = simulation.split(submodel_labels)
-    split_simulation.write(tmp_path/"split/trash") # a write is necessary before the dump to generate the gwtgwf packages
+    split_simulation.write(tmp_path/"split/original") # a write is necessary before the dump to generate the gwtgwf packages
     split_simulation.dump(tmp_path/"split")
     reloaded_split = Modflow6Simulation.from_file(tmp_path/"split/1d_tpt_benchmark_partioned.toml")
-    assert_simulation_can_run(reloaded_split,  "dis", tmp_path/"reloaded")
+    reloaded_split.write(tmp_path/"split/reloaded")
+    
+    diff = dircmp(tmp_path/"split/original", tmp_path/"split/reloaded")
+    assert len(diff.diff_files) == 0
+    assert len(diff.left_only) == 0
+    assert len(diff.right_only) == 0    
 
 @pytest.mark.usefixtures("flow_transport_simulation")
 def test_split_flow_and_transport_model(tmp_path: Path, flow_transport_simulation: Modflow6Simulation):

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
@@ -1,13 +1,15 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 
 from imod.mf6.adv import Advection
 from imod.mf6.dsp import Dispersion
 from imod.mf6.multimodel.modelsplitter import create_partition_info, slice_model
+from imod.mf6.simulation import Modflow6Simulation
 from imod.tests.fixtures.mf6_modelrun_fixture import assert_simulation_can_run
 from imod.typing.grid import zeros_like
-from pathlib import Path
-from imod.mf6.simulation import Modflow6Simulation
+
 
 def test_slice_model_structured(flow_transport_simulation: Modflow6Simulation):
     # Arrange.
@@ -43,7 +45,7 @@ def test_split_dump(
     submodel_labels = submodel_labels.sel(layer=0, drop=True)
 
     split_simulation = simulation.split(submodel_labels)
-    split_simulation.write(tmp_path/"split/trash")
+    split_simulation.write(tmp_path/"split/trash") # a write is necessary before the dump to generate the gwtgwf packages
     split_simulation.dump(tmp_path/"split")
     reloaded_split = Modflow6Simulation.from_file(tmp_path/"split/1d_tpt_benchmark_partioned.toml")
     assert_simulation_can_run(reloaded_split,  "dis", tmp_path/"reloaded")

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -10,8 +10,9 @@ from pytest_cases import case, parametrize_with_cases
 import imod
 from imod.mf6 import Modflow6Simulation
 from imod.mf6.wel import Well
-from imod.typing.grid import zeros_like
 from imod.tests.fixtures.mf6_modelrun_fixture import assert_simulation_can_run
+from imod.typing.grid import zeros_like
+
 
 @pytest.mark.usefixtures("transient_twri_model")
 @pytest.fixture(scope="function")

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -13,7 +13,6 @@ from imod.mf6.wel import Well
 from imod.tests.fixtures.mf6_modelrun_fixture import assert_simulation_can_run
 from imod.typing.grid import zeros_like
 
-
 @pytest.mark.usefixtures("transient_twri_model")
 @pytest.fixture(scope="function")
 def idomain_top(transient_twri_model):
@@ -229,6 +228,10 @@ def test_split_dump(
     split_simulation = simulation.split(partition_array)
     split_simulation.dump(tmp_path/"split")
     reloaded_split = imod.mf6.Modflow6Simulation.from_file(tmp_path/"split/ex01-twri_partioned.toml")
+
+    split_simulation.write(tmp_path/"split/original")
+    reloaded_split.write(tmp_path/"split/reloaded")
+
     assert_simulation_can_run(reloaded_split,  "dis", tmp_path/"reloaded")
 
 @pytest.mark.usefixtures("transient_twri_model")

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -217,6 +217,20 @@ def test_partitioning_structured(
         head["head"].values, original_head.values, rtol=1e-4, atol=1e-4
     )
 
+@pytest.mark.usefixtures("transient_twri_model")
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
+def test_partitioning_structured_split_dump(
+    tmp_path: Path,
+    transient_twri_model: Modflow6Simulation,
+    partition_array: xr.DataArray,
+):
+    simulation = transient_twri_model
+
+    # Partition the simulation, run it, and save the (merged) results
+    split_simulation = simulation.split(partition_array)
+
+    split_simulation.dump(tmp_path)
+    split_simulation.run()
 
 @pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -11,7 +11,7 @@ import imod
 from imod.mf6 import Modflow6Simulation
 from imod.mf6.wel import Well
 from imod.typing.grid import zeros_like
-
+from imod.tests.fixtures.mf6_modelrun_fixture import assert_simulation_can_run
 
 @pytest.mark.usefixtures("transient_twri_model")
 @pytest.fixture(scope="function")
@@ -219,18 +219,16 @@ def test_partitioning_structured(
 
 @pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
-def test_partitioning_structured_split_dump(
+def test_split_dump(
     tmp_path: Path,
     transient_twri_model: Modflow6Simulation,
     partition_array: xr.DataArray,
 ):
     simulation = transient_twri_model
-
-    # Partition the simulation, run it, and save the (merged) results
     split_simulation = simulation.split(partition_array)
-
-    split_simulation.dump(tmp_path)
-    split_simulation.run()
+    split_simulation.dump(tmp_path/"split")
+    reloaded_split = imod.mf6.Modflow6Simulation.from_file(tmp_path/"split/ex01-twri_partioned.toml")
+    assert_simulation_can_run(reloaded_split,  "dis", tmp_path/"reloaded")
 
 @pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -1,3 +1,4 @@
+from filecmp import dircmp
 from pathlib import Path
 
 import geopandas as gpd
@@ -10,8 +11,8 @@ from pytest_cases import case, parametrize_with_cases
 import imod
 from imod.mf6 import Modflow6Simulation
 from imod.mf6.wel import Well
-from imod.tests.fixtures.mf6_modelrun_fixture import assert_simulation_can_run
 from imod.typing.grid import zeros_like
+
 
 @pytest.mark.usefixtures("transient_twri_model")
 @pytest.fixture(scope="function")
@@ -218,7 +219,7 @@ def test_partitioning_structured(
     )
 
 @pytest.mark.usefixtures("transient_twri_model")
-@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases, glob="*four_squares")
 def test_split_dump(
     tmp_path: Path,
     transient_twri_model: Modflow6Simulation,
@@ -232,7 +233,11 @@ def test_split_dump(
     split_simulation.write(tmp_path/"split/original")
     reloaded_split.write(tmp_path/"split/reloaded")
 
-    assert_simulation_can_run(reloaded_split,  "dis", tmp_path/"reloaded")
+    diff = dircmp(tmp_path/"split/original", tmp_path/"split/reloaded")
+    assert len(diff.diff_files) == 0
+    assert len(diff.left_only) == 0
+    assert len(diff.right_only) == 0    
+
 
 @pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)


### PR DESCRIPTION
Fixes #679

# Description
expands the dump and from_file methods of Simulation to be able to deal with exchange files.
Tests were added. 
A follow-up issue may be needed, as gwfgwt exchanges are generated in the write-method and so in some cases the write method must be called first, before the dump method. 

# Checklist

- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
