### PR TITLE
Issue #772 set repeat stress

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -417,6 +417,8 @@ Fixed
 - :meth:`imod.prepare.LayerRegridder.regrid` will now correctly skip values
   if ``top_source`` or ``bottom_source`` are NaN.
 - :func:`imod.gen.write` no longer errors on dataframes with empty columns.
+- :func:`imod.mf6.BoundaryCondition.set_repeat_stress` reinstated. This is  
+ a temporary measure, it gives a deprecation warning.
 
 Changed
 ~~~~~~~

--- a/imod/mf6/boundary_condition.py
+++ b/imod/mf6/boundary_condition.py
@@ -14,7 +14,8 @@ from imod.mf6.auxiliary_variables import (
 from imod.mf6.package import Package
 from imod.mf6.write_context import WriteContext
 from imod.typing.grid import GridDataArray
-
+from imod.wq.timeutil import to_datetime
+import warnings
 
 def _dis_recarr(arrdict, layer, notnull):
     # Define the numpy structured array dtype
@@ -86,11 +87,21 @@ class BoundaryCondition(Package, abc.ABC):
         times: Dict of datetime-like to datetime-like.
             The data of the value datetime is used for the key datetime.
         """
+        warnings.warn(
+            f"""{self.__class__.__name__}.set_repeat_stress(...) is deprecated.
+            In the future, add repeat stresses as constructor parameters. 
+            An object containing them can be created using 'get_repeat_stress', as follows:
+            repeat_stress = get_repeat_stress(repeat_periods) # args before provided to River.set_repeat_stress
+            riv = imod.mf6.River(..., repeat_stress=repeat_stress)
+            """,
+            DeprecationWarning,
+        )
+
         keys = [
-            imod.wq.timeutil.to_datetime(key, use_cftime=False) for key in times.keys()
+            to_datetime(key, use_cftime=False) for key in times.keys()
         ]
         values = [
-            imod.wq.timeutil.to_datetime(value, use_cftime=False)
+            to_datetime(value, use_cftime=False)
             for value in times.values()
         ]
         self.dataset["repeat_stress"] = xr.DataArray(

--- a/imod/mf6/boundary_condition.py
+++ b/imod/mf6/boundary_condition.py
@@ -90,10 +90,17 @@ class BoundaryCondition(Package, abc.ABC):
         """
         warnings.warn(
             f"""{self.__class__.__name__}.set_repeat_stress(...) is deprecated.
-            In the future, add repeat stresses as constructor parameters. 
-            An object containing them can be created using 'get_repeat_stress', as follows:
+            In the future, add repeat stresses as constructor parameters. An
+            object containing them can be created using 'get_repeat_stress', as
+            follows:
+
+            from imod.mf6.utilities.package_utils import get_repeat_stress
+
             repeat_stress = get_repeat_stress(repeat_periods) # args before provided to River.set_repeat_stress
             riv = imod.mf6.River(..., repeat_stress=repeat_stress)
+
+            Note that the location of get_repeat_stress (imod.mf6.utilities.package_utils)
+            may change in the future
             """,
             DeprecationWarning,
         )

--- a/imod/mf6/boundary_condition.py
+++ b/imod/mf6/boundary_condition.py
@@ -77,6 +77,27 @@ class BoundaryCondition(Package, abc.ABC):
         else:
             expand_transient_auxiliary_variables(self)
 
+    def set_repeat_stress(self, times) -> None:
+        """
+        Set repeat stresses: re-use data of earlier periods.
+
+        Parameters
+        ----------
+        times: Dict of datetime-like to datetime-like.
+            The data of the value datetime is used for the key datetime.
+        """
+        keys = [
+            imod.wq.timeutil.to_datetime(key, use_cftime=False) for key in times.keys()
+        ]
+        values = [
+            imod.wq.timeutil.to_datetime(value, use_cftime=False)
+            for value in times.values()
+        ]
+        self.dataset["repeat_stress"] = xr.DataArray(
+            data=np.column_stack((keys, values)),
+            dims=("repeat", "repeat_items"),
+        )
+        
     def _max_active_n(self):
         """
         Determine the maximum active number of cells that are active

--- a/imod/mf6/boundary_condition.py
+++ b/imod/mf6/boundary_condition.py
@@ -79,7 +79,7 @@ class BoundaryCondition(Package, abc.ABC):
         else:
             expand_transient_auxiliary_variables(self)
 
-    def set_repeat_stress(self, times) -> None:
+    def set_repeat_stress(self, times: dict[np.datetime64,np.datetime64]) -> None:
         """
         Set repeat stresses: re-use data of earlier periods.
 

--- a/imod/mf6/boundary_condition.py
+++ b/imod/mf6/boundary_condition.py
@@ -1,5 +1,6 @@
 import abc
 import pathlib
+import warnings
 from copy import copy, deepcopy
 from typing import Mapping, Optional, Union
 
@@ -12,10 +13,10 @@ from imod.mf6.auxiliary_variables import (
     get_variable_names,
 )
 from imod.mf6.package import Package
+from imod.mf6.utilities.package_utils import get_repeat_stress
 from imod.mf6.write_context import WriteContext
 from imod.typing.grid import GridDataArray
-from imod.wq.timeutil import to_datetime
-import warnings
+
 
 def _dis_recarr(arrdict, layer, notnull):
     # Define the numpy structured array dtype
@@ -97,17 +98,7 @@ class BoundaryCondition(Package, abc.ABC):
             DeprecationWarning,
         )
 
-        keys = [
-            to_datetime(key, use_cftime=False) for key in times.keys()
-        ]
-        values = [
-            to_datetime(value, use_cftime=False)
-            for value in times.values()
-        ]
-        self.dataset["repeat_stress"] = xr.DataArray(
-            data=np.column_stack((keys, values)),
-            dims=("repeat", "repeat_items"),
-        )
+        self.dataset["repeat_stress"] = get_repeat_stress(times)
         
     def _max_active_n(self):
         """

--- a/imod/tests/test_mf6/test_mf6_drn.py
+++ b/imod/tests/test_mf6/test_mf6_drn.py
@@ -332,14 +332,6 @@ def test_repeat_stress_old_style(
         dtype="datetime64[ns]",
     )
 
-    repeat_stress = xr.DataArray(
-        [
-            [globaltimes[3], globaltimes[0]],
-            [globaltimes[4], globaltimes[1]],
-        ],
-        dims=("repeat", "repeat_items"),
-    )
-
     expected = textwrap.dedent(
         """\
         begin options
@@ -366,14 +358,6 @@ def test_repeat_stress_old_style(
         end period
         """
     )
-
-    drn = imod.mf6.Drainage(
-        elevation=elevation_fc,
-        conductance=conductance_fc,
-        repeat_stress=repeat_stress,
-    )
-    actual = drn.render(directory, "drn", globaltimes, False)
-    assert actual == expected
 
     drn = imod.mf6.Drainage(
         elevation=elevation_fc,

--- a/imod/tests/test_mf6/test_mf6_drn.py
+++ b/imod/tests/test_mf6/test_mf6_drn.py
@@ -315,6 +315,79 @@ def test_repeat_stress(
     assert actual == expected
 
 
+@pytest.mark.usefixtures("elevation_fc", "conductance_fc")
+def test_repeat_stress_old_style(
+    elevation_fc,
+    conductance_fc,
+):
+    directory = pathlib.Path("mymodel")
+    globaltimes = np.array(
+        [
+            "2000-01-01",
+            "2000-01-02",
+            "2000-01-03",
+            "2000-01-04",
+            "2000-01-05",
+        ],
+        dtype="datetime64[ns]",
+    )
+
+    repeat_stress = xr.DataArray(
+        [
+            [globaltimes[3], globaltimes[0]],
+            [globaltimes[4], globaltimes[1]],
+        ],
+        dims=("repeat", "repeat_items"),
+    )
+
+    expected = textwrap.dedent(
+        """\
+        begin options
+        end options
+
+        begin dimensions
+          maxbound 2
+        end dimensions
+
+        begin period 1
+          open/close mymodel/drn/drn-0.dat
+        end period
+        begin period 2
+          open/close mymodel/drn/drn-1.dat
+        end period
+        begin period 3
+          open/close mymodel/drn/drn-2.dat
+        end period
+        begin period 4
+          open/close mymodel/drn/drn-0.dat
+        end period
+        begin period 5
+          open/close mymodel/drn/drn-1.dat
+        end period
+        """
+    )
+
+    drn = imod.mf6.Drainage(
+        elevation=elevation_fc,
+        conductance=conductance_fc,
+        repeat_stress=repeat_stress,
+    )
+    actual = drn.render(directory, "drn", globaltimes, False)
+    assert actual == expected
+
+    drn = imod.mf6.Drainage(
+        elevation=elevation_fc,
+        conductance=conductance_fc,
+    )
+    drn.set_repeat_stress(
+        times={
+            globaltimes[3]: globaltimes[0],
+            globaltimes[4]: globaltimes[1],
+        }
+    )
+    actual = drn.render(directory, "drn", globaltimes, False)
+    assert actual == expected
+
 def test_clip_box(drainage):
     drn = imod.mf6.Drainage(**drainage)
 


### PR DESCRIPTION
Fixes #772

# Description
reinstated a method (set_period_data) that was removed, but which was used in user scripts. It is now back, with a deprecation warning. 

# Checklist

- [X] Links to correct issue
- [X] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
