### PR TITLE
Issue #578 now can write after splitting

### DIFF
--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -5,6 +5,7 @@ import copy
 import pathlib
 import subprocess
 import warnings
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, DefaultDict, Iterable, Optional, Union, cast
 
@@ -15,7 +16,6 @@ import tomli
 import tomli_w
 import xarray as xr
 import xugrid as xu
-from copy import deepcopy
 
 import imod
 import imod.logging

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -15,6 +15,7 @@ import tomli
 import tomli_w
 import xarray as xr
 import xugrid as xu
+from copy import deepcopy
 
 import imod
 import imod.logging
@@ -999,7 +1000,7 @@ class Modflow6Simulation(collections.UserDict):
 
         new_simulation = imod.mf6.Modflow6Simulation(f"{self.name}_partioned")
         for package_name, package in {**original_packages}.items():
-            new_simulation[package_name] = package
+            new_simulation[package_name] = deepcopy(package)
 
         for model_name, model in original_models.items():
             solution_name = self.get_solution_name(model_name)

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -21,7 +21,7 @@ from imod.mf6.statusinfo import NestedStatusInfo, StatusInfo
 from imod.schemata import ValidationError
 from imod.tests.fixtures.mf6_modelrun_fixture import assert_simulation_can_run
 from imod.typing.grid import zeros_like
-
+from  filecmp import dircmp
 
 def roundtrip(simulation, tmpdir_factory, name):
     # TODO: look at the values?
@@ -126,6 +126,19 @@ def test_simulation_open_flow_budget(circle_model, tmp_path):
     ]
     assert isinstance(budget["chd"], xu.UgridDataArray)
 
+def test_write_circle_model_twice(circle_model, tmp_path):  
+    
+    simulation = circle_model
+
+    # write simulation, then write the simulation a second time
+    simulation.write(tmp_path/ "first_time", binary=False)
+    simulation.write(tmp_path/ "second_time", binary=False)
+
+    #check that text output is the same
+    diff = dircmp(tmp_path/"first_time", tmp_path/"second_time")
+    assert len(diff.diff_files) == 0
+    assert len(diff.left_only) == 0
+    assert len(diff.right_only) == 0    
 
 @pytest.mark.usefixtures("circle_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -4,6 +4,7 @@ import sys
 import textwrap
 from copy import deepcopy
 from datetime import datetime
+from filecmp import dircmp
 from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock
@@ -21,7 +22,7 @@ from imod.mf6.statusinfo import NestedStatusInfo, StatusInfo
 from imod.schemata import ValidationError
 from imod.tests.fixtures.mf6_modelrun_fixture import assert_simulation_can_run
 from imod.typing.grid import zeros_like
-from  filecmp import dircmp
+
 
 def roundtrip(simulation, tmpdir_factory, name):
     # TODO: look at the values?

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -12,7 +12,7 @@ import imod
 from imod.mf6 import Modflow6Simulation
 from imod.mf6.wel import Well
 from imod.typing.grid import zeros_like
-
+from  filecmp import dircmp
 
 @pytest.mark.usefixtures("transient_twri_model")
 @pytest.fixture(scope="function")
@@ -238,7 +238,28 @@ def test_split_dump(
     assert len(diff.left_only) == 0
     assert len(diff.right_only) == 0    
 
+@pytest.mark.usefixtures("transient_twri_model")
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases.case_four_squares)
+def test_partitioning_write_after_split(
+    tmp_path: Path,
+    transient_twri_model: Modflow6Simulation,
+    partition_array: xr.DataArray,
+):
+    simulation = transient_twri_model
 
+    # write simulation before splitting, then split simulation, then write the simulation a second time
+    simulation.write(tmp_path/ "first_time", binary=False)
+
+    _ = simulation.split(partition_array)
+
+    simulation.write(tmp_path/ "second_time", binary=False)
+
+    #check that text output was not affected by splitting
+    diff = dircmp(tmp_path/"first_time", tmp_path/"second_time")
+    assert len(diff.diff_files) == 0
+    assert len(diff.left_only) == 0
+    assert len(diff.right_only) == 0    
+    
 @pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_structured_with_inactive_cells(

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -12,7 +12,7 @@ import imod
 from imod.mf6 import Modflow6Simulation
 from imod.mf6.wel import Well
 from imod.typing.grid import zeros_like
-from  filecmp import dircmp
+
 
 @pytest.mark.usefixtures("transient_twri_model")
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Fixes #578 

# Description
The simulation could not be written to file after splitting, because  some  packages of the split simulation were 
the same object as those packages of the source simulation, so that any further modifications to the packages were also applied to the source simulation, making it inconsistent. 
This has been fixed.
Another comment in the Issue stated that calling "write" on a simulation twice also gave an issue.
This could not be reproduced, but a test was added just in case

# Checklist
- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
