### PR TITLE
Issue #601 deepcopy

### DIFF
--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -27,8 +27,6 @@ from imod.schemata import ValidationError
 from imod.typing import GridDataArray
 
 
-
-
 class Modflow6Model(collections.UserDict, abc.ABC):
     _mandatory_packages: Tuple[str, ...] = ()
     _model_id: Optional[str] = None

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -47,7 +47,6 @@ class Modflow6Model(collections.UserDict, abc.ABC):
             self[k] = v
 
         self._options = {}
-        self._template = None
 
     def __setitem__(self, key, value):
         if len(key) > 16:

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -32,7 +32,7 @@ from imod.typing import GridDataArray
 class Modflow6Model(collections.UserDict, abc.ABC):
     _mandatory_packages: Tuple[str, ...] = ()
     _model_id: Optional[str] = None
-
+    _template: Template
 
     @staticmethod
     def _initialize_template(name: str) -> Template:

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -27,15 +27,19 @@ from imod.schemata import ValidationError
 from imod.typing import GridDataArray
 
 
-def initialize_template(name: str) -> Template:
-    loader = jinja2.PackageLoader("imod", "templates/mf6")
-    env = jinja2.Environment(loader=loader, keep_trailing_newline=True)
-    return env.get_template(name)
 
 
 class Modflow6Model(collections.UserDict, abc.ABC):
     _mandatory_packages: Tuple[str, ...] = ()
     _model_id: Optional[str] = None
+
+
+    @staticmethod
+    def _initialize_template(name: str) -> Template:
+        loader = jinja2.PackageLoader("imod", "templates/mf6")
+        env = jinja2.Environment(loader=loader, keep_trailing_newline=True)
+        return env.get_template(name)
+
 
     def __init__(self, **kwargs):
         collections.UserDict.__init__(self)

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from imod.mf6 import ConstantHead
 from imod.mf6.clipped_boundary_condition_creator import create_clipped_boundary
-from imod.mf6.model import Modflow6Model, initialize_template
+from imod.mf6.model import Modflow6Model
 from imod.mf6.regridding_utils import RegridderType
 from imod.typing import GridDataArray
 
@@ -15,6 +15,7 @@ from imod.typing import GridDataArray
 class GroundwaterFlowModel(Modflow6Model):
     _mandatory_packages = ("npf", "ic", "oc", "sto")
     _model_id = "gwf6"
+    _template = Modflow6Model._initialize_template("gwt-nam.j2")
 
     def __init__(
         self,
@@ -34,7 +35,7 @@ class GroundwaterFlowModel(Modflow6Model):
             "newton": newton,
             "under_relaxation": under_relaxation,
         }
-        self._template = initialize_template("gwf-nam.j2")
+
 
     def _get_unique_regridder_types(self) -> dict[RegridderType, str]:
         """

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -15,7 +15,7 @@ from imod.typing import GridDataArray
 class GroundwaterFlowModel(Modflow6Model):
     _mandatory_packages = ("npf", "ic", "oc", "sto")
     _model_id = "gwf6"
-    _template = Modflow6Model._initialize_template("gwt-nam.j2")
+    _template = Modflow6Model._initialize_template("gwf-nam.j2")
 
     def __init__(
         self,

--- a/imod/mf6/model_gwt.py
+++ b/imod/mf6/model_gwt.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from imod.mf6.model import Modflow6Model, initialize_template
+from imod.mf6.model import Modflow6Model
 
 
 class GroundwaterTransportModel(Modflow6Model):
@@ -13,6 +13,7 @@ class GroundwaterTransportModel(Modflow6Model):
 
     _mandatory_packages = ("mst", "dsp", "oc", "ic")
     _model_id = "gwt6"
+    _template = Modflow6Model._initialize_template("gwt-nam.j2")
 
     def __init__(
         self,
@@ -29,4 +30,3 @@ class GroundwaterTransportModel(Modflow6Model):
             "save_flows": save_flows,
         }
 
-        self._template = initialize_template("gwt-nam.j2")

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -441,10 +441,7 @@ def test_purge_empty_package(
 
 
 def test_deepcopy(
-    tmp_path: Path,
     unstructured_flow_model: GroundwaterFlowModel,
 ):
-    # test that purging leaves the non-empty packages in place
-    
-    npfcopy = deepcopy(unstructured_flow_model["npf"])
-    copy = deepcopy(unstructured_flow_model)
+    # test  making a deepcopy will not crash 
+    _ = deepcopy(unstructured_flow_model)

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -437,3 +437,14 @@ def test_purge_empty_package(
     unstructured_flow_model["hfb"] = imod.mf6.HorizontalFlowBarrierResistance(geometry)
     unstructured_flow_model.purge_empty_packages()
     assert original_nr_packages == len(unstructured_flow_model.items())
+
+
+
+def test_deepcopy(
+    tmp_path: Path,
+    unstructured_flow_model: GroundwaterFlowModel,
+):
+    # test that purging leaves the non-empty packages in place
+    
+    npfcopy = deepcopy(unstructured_flow_model["npf"])
+    copy = deepcopy(unstructured_flow_model)

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import textwrap
+from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
@@ -19,7 +20,7 @@ from imod.mf6.simulation import get_models, get_packages
 from imod.mf6.statusinfo import NestedStatusInfo, StatusInfo
 from imod.schemata import ValidationError
 from imod.typing.grid import zeros_like
-from copy import deepcopy
+
 
 def roundtrip(simulation, tmpdir_factory, name):
     # TODO: look at the values?

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -19,7 +19,7 @@ from imod.mf6.simulation import get_models, get_packages
 from imod.mf6.statusinfo import NestedStatusInfo, StatusInfo
 from imod.schemata import ValidationError
 from imod.typing.grid import zeros_like
-
+from copy import deepcopy
 
 def roundtrip(simulation, tmpdir_factory, name):
     # TODO: look at the values?
@@ -474,6 +474,12 @@ class TestModflow6Simulation:
         # Act/Assert
         with pytest.raises(RuntimeError):
             _ = split_simulation.clip_box()
+
+    def test_deepcopy(
+        split_transient_twri_model
+    ):
+        # test  making a deepcopy will not crash 
+        _ = deepcopy( split_transient_twri_model)           
 
     @pytest.mark.usefixtures("split_transient_twri_model")
     def test_prevent_regrid_like_after_split(


### PR DESCRIPTION
Fixes #601

# Description
Fixes deepcopying for model and simulation objects. 
The issue was that the jinja-template was  an instance variable in these classes, and when making a deepcopy python attempted to copy them. But the jinja templates are not copyable, so this caused a crash. Now the templates are class variables for model and simulation, so when making a deepcopy, the same template object is used for   the copy as for the source. 

# Checklist

- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
