### PR TITLE
Issue #830 Boundary condition with coord not in dim alignment in validation

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+[Unreleased]
+------------
+
+Fixed
+~~~~~
+- Incorrect validation error ``data values found at nodata values of
+  idomain`` where boundary condition packages with a scalar coordinate, which is
+  not set as dimension. 
+
 [0.15.3] - 2024-02-22
 ---------------------
 

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -77,6 +77,18 @@ def scalar_None(obj):
         return (len(obj.shape) == 0) & (~obj.notnull()).all()
 
 
+def align_other_obj_with_coords(obj: GridDataArray, other_obj: GridDataArray) -> Tuple[xr.DataArray, xr.DataArray]:
+    """
+    Align other_obj with obj if coordname in obj but not in its dims.
+    Avoid issues like:
+    https://github.com/Deltares/imod-python/issues/830
+
+    """
+    for coordname in obj.coords.keys():
+        if (coordname in other_obj.dims) and not (coordname in obj.dims):
+            obj = obj.expand_dims(coordname)
+    return xr.align(obj, other_obj, join="left")
+
 class ValidationError(Exception):
     pass
 
@@ -542,6 +554,8 @@ class AllInsideNoDataSchema(NoDataComparisonSchema):
         other_obj = kwargs[self.other]
         valid = self.is_notnull(obj)
         other_valid = self.is_other_notnull(other_obj)
+
+        valid, other_valid = align_other_obj_with_coords(valid, other_obj)
 
         if (valid & ~other_valid).any():
             raise ValidationError(f"data values found at nodata values of {self.other}")

--- a/imod/tests/test_mf6/test_mf6_riv.py
+++ b/imod/tests/test_mf6/test_mf6_riv.py
@@ -127,6 +127,18 @@ def test_inconsistent_nan(riv_data, dis_data):
 
     assert len(errors) == 1
 
+@parametrize_with_cases("riv_data,dis_data", cases=RivDisCases)
+def test_layer_coord_allowed(riv_data, dis_data):
+    # Test if no bugs like https://github.com/Deltares/imod-python/issues/830
+    river = imod.mf6.River(**riv_data)
+    river.dataset = river.dataset.sel(layer=2, drop=False)
+
+    dis_data["idomain"][1, ...] = 0
+
+    errors = river._validate(river._write_schemata, **dis_data)
+
+    assert len(errors) == 0
+
 
 @parametrize_with_cases("riv_data", cases=RivCases)
 def test_check_layer(riv_data):


### PR DESCRIPTION
Fixes #830 

# Description
Aligns var of boundary condition in validation with other_obj (sec. idomain) if coordinate assigned, but not set as dimension.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
