### PR TITLE
Issue #878 fix equidistant dxdy in merge_partitions

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -8,6 +8,15 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 
 [Unreleased]
 ------------
+Fixed
+~~~~~
+- Fix issue where :func:`imod.idf.open_subdomains` and
+  :func:`imod.mf6.Modflow6Simulation.open_head` (for split simulations) would
+  return arrays with incorrect ``dx`` and ``dy`` coordinates for equidistant
+  data.
+- Fix issue where :func:`imod.idf.open_subdomains` returned a flipped ``dy``
+  coordinate for nonequidistant data.
+
 Added
 ~~~~~
 - The :func:`imod.mf6.model.mask_all_packages` now also masks the idomain array

--- a/imod/tests/test_formats/test_idf.py
+++ b/imod/tests/test_formats/test_idf.py
@@ -158,6 +158,8 @@ def test_open_subdomains(subdomains, expected, equidistant, tmp_path):
 
     assert np.all(da["y"].values == expected_coords["y"])
     assert np.all(da["x"].values == expected_coords["x"])
+    assert np.all(da["dx"].values == dx)
+    assert np.all(da["dy"].values == dy)
 
     assert da.values.dtype == np.float32
 
@@ -200,6 +202,8 @@ def test_open_subdomains_species(subdomains, expected, equidistant, tmp_path):
 
     assert np.all(da["y"].values == expected_coords["y"])
     assert np.all(da["x"].values == expected_coords["x"])
+    assert np.all(da["dx"].values == dx)
+    assert np.all(da["dy"].values == dy)
 
     assert da.values.dtype == np.float32
 

--- a/imod/typing/structured.py
+++ b/imod/typing/structured.py
@@ -140,6 +140,10 @@ def _unique_coords(das: List[xr.DataArray], dim: str) -> xr.DataArray:
     return np.unique(np.concatenate([da.coords[dim].values for da in das]))
 
 
+def _is_nonequidistant_coord(da: xr.DataArray, dim: str) -> bool:
+    return (dim in da.coords) and (da.coords[dim].size != 1)
+
+
 def _merge_nonequidistant_coords(
     das: List[xr.DataArray], coordname: str, indices: List[np.ndarray], nsize: int
 ):
@@ -174,10 +178,10 @@ def _merge_partitions(das: List[xr.DataArray]) -> xr.DataArray:
     coords = dict(first.coords)
     coords["x"] = x
     coords["y"] = y[::-1]
-    if "dx" in first.coords:
+    if _is_nonequidistant_coord(first, "dx"):
         coords["dx"] = ("x", _merge_nonequidistant_coords(das, "dx", ixs, ncol))
-    if "dy" in first.coords:
-        coords["dy"] = ("y", _merge_nonequidistant_coords(das, "dy", iys, nrow)[::-1])
+    if _is_nonequidistant_coord(first, "dy"):
+        coords["dy"] = ("y", _merge_nonequidistant_coords(das, "dy", iys, nrow))
 
     arrays = [da.data for da in das]
     if first.chunks is None:


### PR DESCRIPTION
Fixes #878 and #110

# Description
This improves the check for which a call was made to ``_merge_nonequidistant_coords``.
Also I encountered that ``dy`` was flipped when it shouldn't have been, so that has been removed as well.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
