### PR TITLE
Issue #724 Validation package settings

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -26,6 +26,8 @@ Added
 - The :func:`imod.mf6.model.mask_all_packages` now also masks the idomain array
   of the model discretization, and can be used with a mask array without a layer
   dimension, to mask all layers the same way
+- Validation for incompatible settings in the :class:`imod.mf6.NodePropertyFlow`
+  and :class:`imod.mf6.Dispersion` packages.
 
 
 [0.15.3] - 2024-02-22

--- a/imod/mf6/dsp.py
+++ b/imod/mf6/dsp.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from imod.mf6.package import Package
 from imod.mf6.validation import PKG_DIMS_SCHEMA
-from imod.schemata import DTypeSchema, IdentityNoDataSchema, IndexesSchema
+from imod.schemata import DTypeSchema, IdentityNoDataSchema, IndexesSchema, CompatibleSettingsSchema, DimsSchema
 
 
 class Dispersion(Package):
@@ -108,8 +108,8 @@ class Dispersion(Package):
             IndexesSchema(),
             PKG_DIMS_SCHEMA,
         ],
-        "xt3d_off": [DTypeSchema(np.bool_)],
-        "xt3d_rhs": [DTypeSchema(np.bool_)],
+        "xt3d_off": [DTypeSchema(np.bool_), DimsSchema()],
+        "xt3d_rhs": [DTypeSchema(np.bool_), DimsSchema(), CompatibleSettingsSchema(other="xt3d_off", other_value=False)],
     }
 
     _write_schemata = {
@@ -157,3 +157,10 @@ class Dispersion(Package):
         }
         super().__init__(dict_dataset)
         self._validate_init_schemata(validate)
+
+    def _validate(self, schemata, **kwargs):
+        # Insert additional kwargs
+        kwargs["xt3d_off"] = self["xt3d_off"]
+        errors = super()._validate(schemata, **kwargs)
+
+        return errors

--- a/imod/mf6/npf.py
+++ b/imod/mf6/npf.py
@@ -10,6 +10,8 @@ from imod.schemata import (
     DTypeSchema,
     IdentityNoDataSchema,
     IndexesSchema,
+    CompatibleSettingsSchema,
+    DimsSchema
 )
 from imod.typing import GridDataArray
 
@@ -273,13 +275,14 @@ class NodePropertyFlow(Package):
             IndexesSchema(),
             PKG_DIMS_SCHEMA,
         ],
-        "alternative_cell_averaging": [DTypeSchema(str)],
-        "save_flows": [DTypeSchema(np.bool_)],
+        "alternative_cell_averaging": [DTypeSchema(str), DimsSchema(), CompatibleSettingsSchema("xt3d_option", False)],
+        "rhs_option": [DTypeSchema(np.bool_), DimsSchema(), CompatibleSettingsSchema("xt3d_option", True)],
+        "save_flows": [DTypeSchema(np.bool_), DimsSchema()],
         "starting_head_as_confined_thickness": [DTypeSchema(np.bool_)],
         "variable_vertical_conductance": [DTypeSchema(np.bool_)],
         "dewatered": [DTypeSchema(np.bool_)],
         "perched": [DTypeSchema(np.bool_)],
-        "save_specific_discharge": [DTypeSchema(np.bool_)],
+        "save_specific_discharge": [DTypeSchema(np.bool_), DimsSchema()],
     }
 
     _write_schemata = {
@@ -440,3 +443,10 @@ class NodePropertyFlow(Package):
         Returns the "dewatered" option value for this object. Used only when variable_vertical_conductance is true
         """
         return _dataarray_to_bool(self.dataset["dewatered"])
+
+    def _validate(self, schemata, **kwargs):
+        # Insert additional kwargs
+        kwargs["xt3d_option"] = self["xt3d_option"]
+        errors = super()._validate(schemata, **kwargs)
+
+        return errors

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -42,7 +42,7 @@ import xarray as xr
 import xugrid as xu
 from numpy.typing import DTypeLike  # noqa: F401
 
-from imod.typing import GridDataArray
+from imod.typing import GridDataArray, ScalarDataArray
 
 DimsT = Union[str, None]
 ShapeT = Tuple[Union[int, None]]
@@ -280,6 +280,24 @@ class ShapeSchema(BaseSchema):
                 raise ValidationError(
                     f"shape mismatch in axis {i}: {actual} != {expected}"
                 )
+
+
+class CompatibleSettingsSchema(BaseSchema):
+    def __init__(self, other: ScalarDataArray, other_value: bool) -> None:
+        """
+        Validate if settings are compatible
+        """
+        self.other = other
+        self.other_value = other_value
+
+    def validate(self, obj: ScalarDataArray, **kwargs) -> None:
+        other_obj = kwargs[self.other]
+        if scalar_None(obj) or scalar_None(other_obj):
+            return
+        expected = np.all(other_obj == self.other_value)
+
+        if obj and not expected:
+            raise ValidationError(f"Incompatible setting: {self.other} should be {self.other_value}")
 
 
 class CoordsSchema(BaseSchema):

--- a/imod/tests/test_mf6/test_mf6_npf.py
+++ b/imod/tests/test_mf6/test_mf6_npf.py
@@ -92,6 +92,53 @@ def test_validate_false():
     )
 
 
+def test_incompatible_setting():
+    layer = np.array([1, 2, 3])
+    icelltype = xr.DataArray([1, 0, 0], {"layer": layer}, ("layer",))
+    k = xr.DataArray([1.0e-3, 1.0e-4, 2.0e-4], {"layer": layer}, ("layer",))
+    k33 = xr.DataArray([2.0e-8, 2.0e-8, 2.0e-8], {"layer": layer}, ("layer",))
+
+    message = textwrap.dedent(
+        """
+        * rhs_option
+        \t- Incompatible setting: xt3d_option should be True"""
+    )
+
+    with pytest.raises(ValidationError, match=re.escape(message)):
+        imod.mf6.NodePropertyFlow(
+            icelltype=icelltype,
+            k=k,
+            k33=k33,
+            variable_vertical_conductance=True,
+            dewatered=True,
+            perched=True,
+            save_flows=True,
+            xt3d_option=False,
+            rhs_option=True,
+            alternative_cell_averaging="AMT-HMK",
+        )
+
+    message = textwrap.dedent(
+        """
+        * alternative_cell_averaging
+        \t- Incompatible setting: xt3d_option should be False"""
+    )
+
+    with pytest.raises(ValidationError, match=re.escape(message)):
+        imod.mf6.NodePropertyFlow(
+            icelltype=icelltype,
+            k=k,
+            k33=k33,
+            variable_vertical_conductance=True,
+            dewatered=True,
+            perched=True,
+            save_flows=True,
+            xt3d_option=True,
+            alternative_cell_averaging="AMT-HMK",
+        )
+
+
+
 def test_wrong_dim():
     layer = np.array([1, 2, 3])
     icelltype = xr.DataArray(

--- a/imod/tests/test_mf6/test_mf6_transport_model.py
+++ b/imod/tests/test_mf6/test_mf6_transport_model.py
@@ -20,7 +20,7 @@ def test_long_package_name():
 
 def test_transport_model_rendering():
     adv = imod.mf6.AdvectionCentral()
-    disp = imod.mf6.Dispersion(1e-4, 1.0, 10.0, 1.0, 2.0, 3.0, True, True)
+    disp = imod.mf6.Dispersion(1e-4, 1.0, 10.0, 1.0, 2.0, 3.0, False, True)
     m = imod.mf6.GroundwaterTransportModel(print_input=True, save_flows=True)
     m["dsp"] = disp
     m["adv"] = adv

--- a/imod/typing/__init__.py
+++ b/imod/typing/__init__.py
@@ -9,5 +9,6 @@ import xugrid as xu
 
 GridDataArray: TypeAlias = Union[xr.DataArray, xu.UgridDataArray]
 GridDataset: TypeAlias = Union[xr.Dataset, xu.UgridDataset]
+ScalarDataArray: TypeAlias = Union[xr.DataArray, xu.UgridDataArray]
 ScalarDataset: TypeAlias = Union[xr.Dataset, xu.UgridDataset]
 UnstructuredData: TypeAlias = Union[xu.UgridDataset, xu.UgridDataArray]


### PR DESCRIPTION
Fixes #724

# Description
- Adds new validation scheme to compare setting incompatibility
- Implements validation of incompatible settings in the NPF and DSP package.
- Validation of IMS and model settings (newton) would require quite some extra code for little gains, so I scrapped that.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
