### PR TITLE
Issue #885 Fix the Pixi pipeline

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -686,7 +686,7 @@ object UpdateDependencies : BuildType({
                     
                     echo "Update dependencies" 
                     del pixi.lock
-                    pixi install --environment default
+                    pixi install
                     
                     echo "Add any changes" 
                     git add pixi.lock


### PR DESCRIPTION
Fixes #885 

The Pixi dependencies pipeline is broken. The command to regenerate the pixi file doesn't work which resulted in a PR where the pixi.lock file is deleted.
This commit fixes that

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
