### PR TITLE
Issue #818 verify one flowmodel

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+[Feature branch specific]
+-------------------------
+- Checks that only one flow model is present in a simulation when calling
+:func:`imod.mf6.Modflow6Simulation.regrid_like`, :func:`imod.mf6.Modflow6Simulation.clip_box` or  :func:`imod.mf6.Modflow6Simulation.split` 
+
 [Unreleased]
 ------------
 

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -975,9 +975,9 @@ class Modflow6Simulation(collections.UserDict):
 
         flow_models = self.get_models_of_type("gwf6")
         transport_models = self.get_models_of_type("gwt6")
-        if any(transport_models) and len(flow_models) != 1:
+        if len(flow_models) != 1:
             raise ValueError(
-                "splitting of simulations with more (or less) than 1 flow model currently not supported, if a transport model is present"
+                "splitting of simulations with more (or less) than 1 flow model currently not supported."
             )
 
         if not any(flow_models) and not any(transport_models):
@@ -1062,7 +1062,11 @@ class Modflow6Simulation(collections.UserDict):
             raise RuntimeError(
                 "Unable to regrid simulation. Regridding can only be done on simulations that haven't been split."
             )
-
+        flow_models = self.get_models_of_type("gwf6")
+        if len(flow_models) != 1:
+            raise ValueError(
+                "Unable to regrid simulation. Regridding can only be done on simulations that have a single flow model."
+            )
         result = self.__class__(regridded_simulation_name)
         for key, item in self.items():
             if isinstance(item, GroundwaterFlowModel):

--- a/imod/tests/conftest.py
+++ b/imod/tests/conftest.py
@@ -51,6 +51,7 @@ from .fixtures.mf6_small_models_fixture import (
     structured_flow_simulation,
     unstructured_flow_model,
     unstructured_flow_simulation,
+    structured_flow_simulation_2_flow_models,
 )
 from .fixtures.mf6_twri_disv_fixture import twri_disv_model
 from .fixtures.mf6_twri_fixture import (

--- a/imod/tests/conftest.py
+++ b/imod/tests/conftest.py
@@ -49,9 +49,9 @@ from .fixtures.mf6_small_models_fixture import (
     solution_settings,
     structured_flow_model,
     structured_flow_simulation,
+    structured_flow_simulation_2_flow_models,
     unstructured_flow_model,
     unstructured_flow_simulation,
-    structured_flow_simulation_2_flow_models,
 )
 from .fixtures.mf6_twri_disv_fixture import twri_disv_model
 from .fixtures.mf6_twri_fixture import (

--- a/imod/tests/fixtures/mf6_small_models_fixture.py
+++ b/imod/tests/fixtures/mf6_small_models_fixture.py
@@ -1,10 +1,10 @@
+from copy import deepcopy
 from typing import Callable, Union
 
 import numpy as np
 import pytest
 import xarray as xr
 import xugrid as xu
-from copy import deepcopy
 
 import imod
 

--- a/imod/tests/fixtures/mf6_small_models_fixture.py
+++ b/imod/tests/fixtures/mf6_small_models_fixture.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import xarray as xr
 import xugrid as xu
+from copy import deepcopy
 
 import imod
 
@@ -190,6 +191,15 @@ def structured_flow_simulation(
         additional_times=["2000-01-01T00:00", "2020-01-02T00:00", "2020-01-03T00:00"]
     )
     return simulation
+
+@pytest.fixture(scope="function")
+def structured_flow_simulation_2_flow_models(structured_flow_simulation: imod.mf6.Modflow6Simulation)-> imod.mf6.Modflow6Simulation:
+    """Returns transient confined model."""
+    other_flow_model = deepcopy(structured_flow_simulation["flow"])
+    structured_flow_simulation["flow_copy"] = other_flow_model
+    structured_flow_simulation["solution"].add_model_to_solution("flow_copy")   
+
+    return structured_flow_simulation
 
 
 @pytest.fixture(scope="function")

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -16,14 +16,13 @@ import xugrid as xu
 
 import imod
 from imod.mf6.model import Modflow6Model
-from imod.mf6.model_gwf import GroundwaterFlowModel
 from imod.mf6.multimodel.modelsplitter import PartitionInfo
 from imod.mf6.statusinfo import NestedStatusInfo, StatusInfo
 from imod.schemata import ValidationError
-from imod.tests.fixtures.mf6_modelrun_fixture import assert_simulation_can_run
 from imod.typing.grid import zeros_like
-
-
+from imod.tests.fixtures.mf6_small_models_fixture import (
+    grid_data_structured,
+)
 def roundtrip(simulation, tmpdir_factory, name):
     # TODO: look at the values?
     tmp_path = tmpdir_factory.mktemp(name)
@@ -292,47 +291,42 @@ class TestModflow6Simulation:
         with pytest.raises(ValueError):
             _ = simulation.split(submodel_labels)
 
-    def test_split_multiple_models(self, tmp_path, circle_model):
+    def test_split_multiple_flow_models(self, structured_flow_simulation_2_flow_models):
         # Arrange.
-        oc2 = deepcopy(circle_model["GWF_1"]["oc"])
-        npf2 = deepcopy(circle_model["GWF_1"]["npf"])
-        disv2 = deepcopy(circle_model["GWF_1"]["disv"])
-        sto2 = deepcopy(circle_model["GWF_1"]["sto"])
-        chd2 = deepcopy(circle_model["GWF_1"]["chd"])
-        rch2 = deepcopy(circle_model["GWF_1"]["rch"])
-        ic2 = deepcopy(circle_model["GWF_1"]["ic"])
-        gwf_2 = GroundwaterFlowModel()
-        gwf_2["oc"] = oc2
-        gwf_2["npf"] = npf2
-        gwf_2["disv"] = disv2
-        gwf_2["sto"] = sto2
-        gwf_2["chd"] = chd2
-        gwf_2["rch"] = rch2
-        gwf_2["ic"] = ic2
-        circle_model["GWF_2"] = gwf_2
-        circle_model["solver"].add_model_to_solution("GWF_2")
-
-        active = circle_model["GWF_1"].domain.sel(layer=1)
-        submodel_labels = xu.zeros_like(active)
-        submodel_labels.values[90:] = 1
+        active = structured_flow_simulation_2_flow_models["flow"].domain.sel(layer=1)
+        submodel_labels = xr.zeros_like(active)
+        submodel_labels.values[:,3:] = 1
 
         # Act
-        new_simulation = circle_model.split(submodel_labels)
+        with pytest.raises(ValueError):
+            _ = structured_flow_simulation_2_flow_models.split(submodel_labels)
 
-        # Assert
-        assert (
-            new_simulation["split_exchanges"][0]["model_name_1"].values[()] == "GWF_1_0"
-        )
-        assert (
-            new_simulation["split_exchanges"][0]["model_name_2"].values[()] == "GWF_1_1"
-        )
-        assert (
-            new_simulation["split_exchanges"][1]["model_name_1"].values[()] == "GWF_2_0"
-        )
-        assert (
-            new_simulation["split_exchanges"][1]["model_name_2"].values[()] == "GWF_2_1"
-        )
-        assert_simulation_can_run(new_simulation, "disv", tmp_path)
+    def test_regrid_multiple_flow_models(self, structured_flow_simulation_2_flow_models):
+        # Arrange
+        finer_idomain = grid_data_structured(np.int32, 1, 0.4)
+
+        # Act
+        with pytest.raises(ValueError):
+            _ = structured_flow_simulation_2_flow_models.regrid_like("regridded_model", finer_idomain, False)
+
+    def test_mask_clipping_multiple_flow_models(self, structured_flow_simulation_2_flow_models):
+        # Arrange
+        active = structured_flow_simulation_2_flow_models["flow"].domain
+        grid_y_min = active.coords["y"][0]
+        grid_y_max = active.coords["y"][-1]
+        # Act/Assert
+        with pytest.raises(RuntimeError):
+            _ = structured_flow_simulation_2_flow_models.clip_box(
+                    y_min= grid_y_min,
+                    y_max = grid_y_max/2                
+                )
+
+
+
+        # Act
+        with pytest.raises(ValueError):
+            _ = transient_twri_simulation_2_flow_models.regrid_like(finer_idomain)            
+
 
     @pytest.mark.usefixtures("transient_twri_model")
     def test_exchanges_in_simulation_file(self, transient_twri_model, tmp_path):
@@ -405,9 +399,14 @@ class TestModflow6Simulation:
         # Arrange.
         split_simulation = split_transient_twri_model
 
+        grid_y_min = split_simulation["GWF_1"].domain.coords["y"][0]
+        grid_y_max = split_simulation["GWF_1"].domain.coords["y"][-1]
         # Act/Assert
         with pytest.raises(RuntimeError):
-            _ = split_simulation.clip_box()
+            _ = split_simulation.clip_box(
+                    y_min= grid_y_min,
+                    y_max = grid_y_max/2                
+                )
 
     def test_deepcopy(
         split_transient_twri_model


### PR DESCRIPTION
Fixes #818

# Description
Throws an error if multiple flow models are present when clipping, regridding or splitting a simulation. 

# Checklist

- [X] Links to correct issue
- [X] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
