### PR TITLE
Issue #609 simplify jinja template

### DIFF
--- a/imod/mf6/exchangebase.py
+++ b/imod/mf6/exchangebase.py
@@ -46,7 +46,12 @@ class ExchangeBase(Package):
         )
     
     def render_with_geometric_constants(self,  directory: Path, pkgname: str, globaltimes: Union[list[np.datetime64], np.ndarray], binary: bool) -> str:
-
+        
+        if hasattr(self, "_template"):
+            template = self._template
+        else:
+            raise RuntimeError("exchange file does not have a template")
+        
         d = Package._get_render_dictionary(self, directory, pkgname, globaltimes, binary)
         is_structured = len(self.dataset["cell_id1"].shape) > 1
         datablock = pd.DataFrame()
@@ -64,4 +69,4 @@ class ExchangeBase(Package):
                   datablock[key] = self.dataset[key].values[:]      
                                       
         d["datablock"] = datablock.to_string(index=False,  header=False )
-        return self._template.render(d)        
+        return template.render(d)        

--- a/imod/mf6/exchangebase.py
+++ b/imod/mf6/exchangebase.py
@@ -50,7 +50,7 @@ class ExchangeBase(Package):
         if hasattr(self, "_template"):
             template = self._template
         else:
-            raise RuntimeError("exchange file does not have a template")
+            raise RuntimeError("exchange package does not have a template")
         
         d = Package._get_render_dictionary(self, directory, pkgname, globaltimes, binary)
         is_structured = len(self.dataset["cell_id1"].shape) > 1

--- a/imod/mf6/exchangebase.py
+++ b/imod/mf6/exchangebase.py
@@ -53,18 +53,24 @@ class ExchangeBase(Package):
             raise RuntimeError("exchange package does not have a template")
         
         d = Package._get_render_dictionary(self, directory, pkgname, globaltimes, binary)
-        is_structured = len(self.dataset["cell_id1"].shape) > 1
+        
         datablock = pd.DataFrame()
-        datablock["layer1"] =  self.dataset["layer"].values[:]                 
-        datablock["cell_id1"] = self.dataset["cell_id1"].values[:,0]
+        datablock["layer1"] =  self.dataset["layer"].values[:] 
+
+        # If the grid is structured, the cell_id arrays will have both a row and a column dimension, 
+        # but if it is unstructured, it will have only a cellid dimension
+        is_structured = len(self.dataset["cell_id1"].shape) > 1
+        is_structured = is_structured and self.dataset["cell_id1"].shape[1] > 1
+
+        datablock["cell_id1_1"] = self.dataset["cell_id1"].values[:,0]  
         if is_structured:
              datablock["cell_id1_2"] = self.dataset["cell_id1"].values[:,1]
         datablock["layer2"] =  self.dataset["layer"].values[:]  
-        datablock["cell_id2"] = self.dataset["cell_id2"].values[:,0]
+        datablock["cell_id2_1"] = self.dataset["cell_id2"].values[:,0]
         if is_structured: 
-             datablock["cell_id1_2_2"] = self.dataset["cell_id2"].values[:,1]
+             datablock["cell_id2_2"] = self.dataset["cell_id2"].values[:,1]
 
-        for key in ["ihc", "cl1", "cl2", "hwva", "angldegx","cdist" ]:
+        for key in ["ihc", "cl1", "cl2", "hwva", "angldegx", "cdist" ]:
             if key in  self.dataset.keys():
                   datablock[key] = self.dataset[key].values[:]      
                                       

--- a/imod/mf6/gwfgwf.py
+++ b/imod/mf6/gwfgwf.py
@@ -8,7 +8,7 @@ from imod.mf6.auxiliary_variables import expand_transient_auxiliary_variables
 from imod.mf6.exchangebase import ExchangeBase
 from imod.mf6.package import Package
 from imod.typing import GridDataArray
-
+import  pandas as pd
 
 class GWFGWF(ExchangeBase):
     """
@@ -89,3 +89,29 @@ class GWFGWF(ExchangeBase):
         state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         raise NotImplementedError("this package cannot be clipped")
+
+    def render(self, directory, pkgname, globaltimes, binary):
+
+        """
+        cell_id1: xr.DataArray,
+        cell_id2: xr.DataArray,
+        layer: xr.DataArray,
+        cl1: xr.DataArray,
+        cl2: xr.DataArray,
+        hwva: xr.DataArray,
+        angldegx: Optional[xr.DataArray] = None,
+        cdist: Optional[xr.DataArray] = None,
+        """
+        d = Package._get_render_dictionary(self, directory, pkgname, globaltimes, binary)
+        datablock = pd.DataFrame()
+        datablock["layer1"] =  self.dataset["layer"].values[:]         
+        datablock["cell_id1"] = self.dataset["cell_id1"].values[:,0]
+        datablock["layer2"] =  self.dataset["layer"].values[:]  
+        datablock["cell_id2"] = self.dataset["cell_id2"].values[:,0]
+        datablock["cl1"] =  self.dataset["cl1"].values[:]   
+        datablock["cl2"] =  self.dataset["cl2"].values[:]        
+        datablock["hwva"] =  self.dataset["hwva"].values[:]   
+        datablock["angldegx"] =  self.dataset["angldegx"].values[:]       
+        datablock["cdist"] =  self.dataset["cdist"].values[:]                                                 
+        d["datablock"] = datablock.to_string(index=False,  header=False )
+        return self._template.render(d)

--- a/imod/mf6/gwfgwf.py
+++ b/imod/mf6/gwfgwf.py
@@ -108,6 +108,7 @@ class GWFGWF(ExchangeBase):
         datablock["cell_id1"] = self.dataset["cell_id1"].values[:,0]
         datablock["layer2"] =  self.dataset["layer"].values[:]  
         datablock["cell_id2"] = self.dataset["cell_id2"].values[:,0]
+        datablock["ihc"] = self.dataset["ihc"].values[:]        
         datablock["cl1"] =  self.dataset["cl1"].values[:]   
         datablock["cl2"] =  self.dataset["cl2"].values[:]        
         datablock["hwva"] =  self.dataset["hwva"].values[:]   

--- a/imod/mf6/gwfgwf.py
+++ b/imod/mf6/gwfgwf.py
@@ -1,8 +1,8 @@
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 
 import cftime
 import numpy as np
-import pandas as pd
 import xarray as xr
 
 from imod.mf6.auxiliary_variables import expand_transient_auxiliary_variables
@@ -92,23 +92,5 @@ class GWFGWF(ExchangeBase):
     ) -> Package:
         raise NotImplementedError("this package cannot be clipped")
 
-    def render(self, directory, pkgname, globaltimes, binary):
-
-        d = Package._get_render_dictionary(self, directory, pkgname, globaltimes, binary)
-        is_structured = len(self.dataset["cell_id1"].shape) > 1
-        datablock = pd.DataFrame()
-        datablock["layer1"] =  self.dataset["layer"].values[:]                 
-        datablock["cell_id1"] = self.dataset["cell_id1"].values[:,0]
-        if is_structured:
-             datablock["cell_id1_2"] = self.dataset["cell_id1"].values[:,1]
-        datablock["layer2"] =  self.dataset["layer"].values[:]  
-        datablock["cell_id2"] = self.dataset["cell_id2"].values[:,0]
-        if is_structured: 
-             datablock["cell_id1_2_2"] = self.dataset["cell_id2"].values[:,1]
-
-        for key in ["ihc", "cl1", "cl2", "hwva", "angldegx","cdist" ]:
-            if key in  self.dataset.keys():
-                  datablock[key] = self.dataset[key].values[:]      
-                                      
-        d["datablock"] = datablock.to_string(index=False,  header=False )
-        return self._template.render(d)
+    def render(self, directory: Path, pkgname: str, globaltimes: Union[list[np.datetime64], np.ndarray], binary: bool) -> str:
+       return self.render_with_geometric_constants(directory, pkgname, globaltimes, binary)

--- a/imod/mf6/gwtgwt.py
+++ b/imod/mf6/gwtgwt.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
 
 import cftime
 import numpy as np
@@ -86,3 +87,7 @@ class GWTGWT(ExchangeBase):
         state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         raise NotImplementedError("this package cannot be clipped")
+
+
+    def render(self, directory: Path, pkgname: str, globaltimes: Union[list[np.datetime64], np.ndarray], binary: bool) -> str:
+        return self.render_with_geometric_constants(directory, pkgname, globaltimes, binary)

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -186,7 +186,7 @@ class Package(PackageBase, IPackage, abc.ABC):
             else:
                 np.savetxt(fname=f, X=da.values, fmt=fmt)
 
-    def _get_render_dictionary(self, directory, pkgname, globaltimes, binary):
+    def _get_render_dictionary(self, directory: pathlib.Path, pkgname: str, globaltimes: Union[list[np.datetime64], np.ndarray], binary: bool) ->dict[str,Any]:
         d = {}
         if directory is None:
             pkg_directory = pkgname

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -194,7 +194,7 @@ class Package(PackageBase, IPackage, abc.ABC):
             pkg_directory = pathlib.Path(directory) / pkgname
 
         for varname in self.dataset.data_vars:
-            key = self._keyword_map.get(varname, varname)
+            key = self._keyword_map.get(str(varname), str(varname))
 
             if hasattr(self, "_grid_data") and varname in self._grid_data:
                 layered, value = self._compose_values(

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -186,7 +186,7 @@ class Package(PackageBase, IPackage, abc.ABC):
             else:
                 np.savetxt(fname=f, X=da.values, fmt=fmt)
 
-    def render(self, directory, pkgname, globaltimes, binary):
+    def _get_render_dictionary(self, directory, pkgname, globaltimes, binary):
         d = {}
         if directory is None:
             pkg_directory = pkgname
@@ -209,7 +209,10 @@ class Package(PackageBase, IPackage, abc.ABC):
 
         if (hasattr(self, "_auxiliary_data")) and (names := get_variable_names(self)):
             d["auxiliary"] = names
-
+        return d
+    
+    def render(self, directory, pkgname, globaltimes, binary):
+        d = self._get_render_dictionary( directory, pkgname, globaltimes, binary)
         return self._template.render(d)
 
     @staticmethod

--- a/imod/templates/mf6/exg-gwfgwf.j2
+++ b/imod/templates/mf6/exg-gwfgwf.j2
@@ -33,7 +33,5 @@ begin exchangedata
 # first 3 (structured) or 2 (unstructured) columns are the exchange boundary cell indices in the numbering local to {{model_name_1}}
 # second 3 (structured) or 2 (unstructured) columns are the exchange boundary cell indices in the numbering local to {{model_name_2}}
 # followed by columns ihc, cl1, cl2, hwva and auxiliary variables, if any
-{%- for i in range(nexg) %}
-  {{layer[i]}} {{cell_id1[i]|join(" ")}} {{layer[i]}} {{cell_id2[i]|join(" ")}} {{ihc[i]}} {{cl1[i]}} {{cl2[i]}} {{hwva[i]}} {%- if auxiliary_data is defined %} {{auxiliary_data.T[i]|join(" ")}}{% endif %}
-{%- endfor %}
+{{datablock}} 
 end exchangedata

--- a/imod/templates/mf6/exg-gwtgwt.j2
+++ b/imod/templates/mf6/exg-gwtgwt.j2
@@ -31,7 +31,5 @@ begin exchangedata
 # first 3 (structured) or 2 (unstructured) columns are the exchange boundary cell indices in the numbering local to {{model_name_1}}
 # second 3 (structured) or 2 (unstructured) columns are the exchange boundary cell indices in the numbering local to {{model_name_2}}
 # followed by columns ihc, cl1, cl2, hwva and auxiliary variables, if any
-{%- for i in range(nexg) %}
-  {{layer[i]}} {{cell_id1[i]|join(" ")}} {{layer[i]}} {{cell_id2[i]|join(" ")}} {{ihc[i]}} {{cl1[i]}} {{cl2[i]}} {{hwva[i]}} {%- if auxiliary_data is defined %} {{auxiliary_data.T[i]|join(" ")}}{% endif %}
-{%- endfor %}
+{{datablock}}
 end exchangedata

--- a/imod/tests/test_mf6/test_mf6_gwfgwf.py
+++ b/imod/tests/test_mf6/test_mf6_gwfgwf.py
@@ -75,24 +75,24 @@ class TestGwfgwf:
 
         expected = textwrap.dedent(
             """
-        begin options
-        end options
-
-        begin dimensions
-          nexg 9
-        end dimensions
-
-        begin exchangedata
-          12 1 1 12 1 2 1 1.0 1.0 2.0
-          12 2 1 12 2 2 1 1.0 1.0 2.0
-          12 3 1 12 3 2 1 1.0 1.0 2.0
-          13 1 1 13 1 2 1 1.0 1.0 2.0
-          13 2 1 13 2 2 1 1.0 1.0 2.0
-          13 3 1 13 3 2 1 1.0 1.0 2.0
-          14 1 1 14 1 2 1 1.0 1.0 2.0
-          14 2 1 14 2 2 1 1.0 1.0 2.0
-          14 3 1 14 3 2 1 1.0 1.0 2.0
-        end exchangedata
+    begin options
+    end options
+    
+    begin dimensions
+      nexg 9
+    end dimensions
+    
+    begin exchangedata
+    12 1 1 12 1 2 1 1.0 1.0 2.0
+    12 2 1 12 2 2 1 1.0 1.0 2.0
+    12 3 1 12 3 2 1 1.0 1.0 2.0
+    13 1 1 13 1 2 1 1.0 1.0 2.0
+    13 2 1 13 2 2 1 1.0 1.0 2.0
+    13 3 1 13 3 2 1 1.0 1.0 2.0
+    14 1 1 14 1 2 1 1.0 1.0 2.0
+    14 2 1 14 2 2 1 1.0 1.0 2.0
+    14 3 1 14 3 2 1 1.0 1.0 2.0 
+    end exchangedata
         """
         )
         actual = remove_comment_lines(actual)
@@ -109,25 +109,25 @@ class TestGwfgwf:
 
         expected = textwrap.dedent(
             """
-        begin options
-          auxiliary angldegx cdist
-        end options
-
-        begin dimensions
-          nexg 9
-        end dimensions
-
-        begin exchangedata
-          12 1 12 2 1 1.0 1.0 2.0 90.0 2.0
-          12 2 12 2 1 1.0 1.0 2.0 90.0 2.0
-          12 3 12 4 1 1.0 1.0 2.0 90.0 2.0
-          13 1 13 2 1 1.0 1.0 2.0 90.0 2.0
-          13 2 13 2 1 1.0 1.0 2.0 90.0 2.0
-          13 3 13 4 1 1.0 1.0 2.0 90.0 2.0
-          14 1 14 2 1 1.0 1.0 2.0 90.0 2.0
-          14 2 14 2 1 1.0 1.0 2.0 90.0 2.0
-          14 3 14 4 1 1.0 1.0 2.0 90.0 2.0
-        end exchangedata
+    begin options
+      auxiliary angldegx cdist
+    end options
+    
+    begin dimensions
+      nexg 9
+    end dimensions
+    
+    begin exchangedata
+    12 1 12 2 1 1.0 1.0 2.0 90.0 2.0
+    12 2 12 2 1 1.0 1.0 2.0 90.0 2.0
+    12 3 12 4 1 1.0 1.0 2.0 90.0 2.0
+    13 1 13 2 1 1.0 1.0 2.0 90.0 2.0
+    13 2 13 2 1 1.0 1.0 2.0 90.0 2.0
+    13 3 13 4 1 1.0 1.0 2.0 90.0 2.0
+    14 1 14 2 1 1.0 1.0 2.0 90.0 2.0
+    14 2 14 2 1 1.0 1.0 2.0 90.0 2.0
+    14 3 14 4 1 1.0 1.0 2.0 90.0 2.0 
+    end exchangedata
         """
         )
         actual = remove_comment_lines(actual)


### PR DESCRIPTION
Fixes #609

# Description
some logic contained in the jinja templates for gwfgwf and gwtgwt was removed. Specifically, the part that builds a table of geometric constants. Now this logic is in python, it uses pandas to create it and to convert he table to a string.

# Checklist
- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
