### PR TITLE
Issue #652 save flows configurable

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -25,7 +25,9 @@ Fixed
   notice. Function now throws a DeprecationWarning to use
   :func:`imod.prepare.spatial.round_extent` instead.
 - :meth'`imod.mf6.Modflow6Simulation.write` failed after splitting the simulation. This has been fixed.
-
+- modflow options like "print flow" , "save flow" and "print input" can now be set on
+:class:`imod.mf6.Well`
+ 
 Added
 ~~~~~
 - The :func:`imod.mf6.model.mask_all_packages` now also masks the idomain array

--- a/imod/mf6/mf6_wel_adapter.py
+++ b/imod/mf6/mf6_wel_adapter.py
@@ -55,6 +55,8 @@ class Mf6Wel(BoundaryCondition):
         concentration=None,
         concentration_boundary_type="aux",
         save_flows: Optional[bool] = None,
+        print_flows: Optional[bool]= None,
+        print_input: Optional[bool]= None,
         validate: bool = True,
     ):
         dict_dataset = {
@@ -63,6 +65,8 @@ class Mf6Wel(BoundaryCondition):
             "concentration": concentration,
             "concentration_boundary_type": concentration_boundary_type,
             "save_flows": save_flows,
+            "print_flows": print_flows,
+            "print_input": print_input,            
         }
         super().__init__(dict_dataset)
         self._validate_init_schemata(validate)

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -590,9 +590,9 @@ class Well(BoundaryCondition, IPointDataPackage):
         ds = ds.assign(**ds_vars.data_vars)
 
         ds = remove_inactive(ds, active)
-
-        # TODO: make options like "save_flows" configurable. Issue github #623
-        ds["save_flows"] = True
+        ds["save_flows"] = self["save_flows"].values[()]
+        ds["print_flows"] = self["print_flows"].values[()]
+        ds["print_input"] = self["print_input"].values[()]
 
         return Mf6Wel(**ds.data_vars)
 

--- a/imod/tests/fixtures/mf6_twri_fixture.py
+++ b/imod/tests/fixtures/mf6_twri_fixture.py
@@ -145,6 +145,7 @@ def make_twri_model():
         screen_bottom=screen_bottom,
         rate=rate_wel,
         minimum_k=1e-19,
+        save_flows=True
     )
     gwf_model["dis"] = imod.mf6.StructuredDiscretization(
         top=200.0, bottom=bottom, idomain=idomain

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -411,3 +411,29 @@ def test_is_empty():
 
     hfb = HorizontalFlowBarrierResistance(geometry)
     assert not hfb.is_empty()
+
+@pytest.mark.parametrize(
+    "parameterizable_basic_dis",
+    [BasicDisSettings(nlay=2, nrow=3, ncol=3, xstart=0, xstop=3)],
+    indirect=True,
+)
+@pytest.mark.parametrize("print_input", [True, False])
+def test_set_options(print_input, parameterizable_basic_dis):
+    idomain, top, bottom = parameterizable_basic_dis
+    hfb = HorizontalFlowBarrierResistance(
+        geometry=gpd.GeoDataFrame(
+            geometry=[
+                shapely.linestrings([-1000.0, 1000.0], [0.3, 0.3]),
+            ],
+            data={
+                "resistance": [1e3],
+                "ztop": [10.0],
+                "zbottom": [0.0],
+            },
+           
+        ),
+        print_input = print_input
+    )
+    k = ones_like(top)
+    mf6_package = hfb.to_mf6_pkg(idomain, top, bottom, k)
+    assert mf6_package.dataset["print_input"].values[()] == print_input

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -156,6 +156,26 @@ def test_to_mf6_pkg__high_lvl_transient(basic_dis, well_high_lvl_test_data_trans
     np.testing.assert_equal(mf6_ds["rate"].values, rate_expected)
 
 
+@pytest.mark.parametrize("save_flows", [True, False])
+@pytest.mark.parametrize("print_input", [True, False])
+@pytest.mark.parametrize("print_flows", [True, False])
+def test_to_mf6_pkg__save_flows(basic_dis, well_high_lvl_test_data_transient, save_flows, print_input, print_flows):
+    # Arrange
+    idomain, top, bottom = basic_dis
+
+    wel = imod.mf6.Well(*well_high_lvl_test_data_transient, save_flows=save_flows, print_input= print_input, print_flows= print_flows)
+    active = idomain == 1
+    k = xr.ones_like(idomain)
+
+    # Act
+    mf6_wel = wel.to_mf6_pkg(active, top, bottom, k)
+    mf6_ds = mf6_wel.dataset
+
+    # Assert
+    mf6_ds["save_flows"].values[()] == save_flows
+    mf6_ds["print_input"].values[()] == print_input 
+    mf6_ds["print_flows"].values[()] == print_flows
+
 def test_is_empty(well_high_lvl_test_data_transient):
     # Arrange
     wel = imod.mf6.Well(*well_high_lvl_test_data_transient)


### PR DESCRIPTION
Fixes #652 

# Description
made several options configurable for the well package: "save flows", "print input" and "print flows". these can now be set on the high level well package, and they will then appear in the (low level) mf6 input.
 Added tests.
For the HFB package, there is only one such options: print input. A test has been added to ensure it appear on the low-level object. 

# Checklist

- [X] Links to correct issue
- [X] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
