### PR TITLE
Issue #888 move masking

### DIFF
--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -21,6 +21,7 @@ import imod
 from imod.mf6.interfaces.imodel import IModel
 from imod.mf6.package import Package
 from imod.mf6.statusinfo import NestedStatusInfo, StatusInfo, StatusInfoBase
+from imod.mf6.utilities.mask import _mask_all_packages
 from imod.mf6.utilities.regrid import (
     _regrid_like,
 )
@@ -28,7 +29,6 @@ from imod.mf6.validation import pkg_errors_to_status_info
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.typing import GridDataArray
-from imod.mf6.utilities.mask import _mask_all_packages
 
 
 class Modflow6Model( collections.UserDict, IModel, abc.ABC):

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -28,6 +28,7 @@ from imod.mf6.validation import pkg_errors_to_status_info
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.typing import GridDataArray
+from imod.mf6.utilities.mask import _mask_all_packages
 
 
 class Modflow6Model( collections.UserDict, IModel, abc.ABC):
@@ -500,12 +501,8 @@ class Modflow6Model( collections.UserDict, IModel, abc.ABC):
             idomain-like integer array. 1 sets cells to active, 0 sets cells to inactive, 
             -1 sets cells to vertical passthrough
         """
-        if any([coord not in ["x", "y", "layer", "mesh2d_nFaces", "dx", "dy"] for coord in mask.coords]):
-            raise ValueError("unexpected coordinate dimension in masking domain")
 
-        for pkgname, pkg in self.items():
-            self[pkgname] = pkg.mask(mask)
-        self.purge_empty_packages()
+        _mask_all_packages(self, mask)
 
     def purge_empty_packages(self, model_name: Optional[str] = "") -> None:
         """

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import numbers
 import pathlib
 from collections import defaultdict
 from typing import Any, Mapping, Optional, Tuple, Union
@@ -12,19 +11,15 @@ import numpy as np
 import xarray as xr
 import xugrid as xu
 
-
 import imod
-from imod.mf6.auxiliary_variables import (
-    expand_transient_auxiliary_variables,
-    get_variable_names,
-    remove_expanded_auxiliary_variables_from_dataset,
-)
+from imod.mf6.auxiliary_variables import get_variable_names
 from imod.mf6.interfaces.ipackage import IPackage
 from imod.mf6.pkgbase import (
     EXCHANGE_PACKAGES,
     TRANSPORT_PACKAGES,
     PackageBase,
 )
+from imod.mf6.utilities.mask import _mask
 from imod.mf6.utilities.regrid import (
     RegridderType,
     _regrid_like,
@@ -39,7 +34,7 @@ from imod.schemata import (
     ValidationError,
 )
 from imod.typing import GridDataArray
-from imod.mf6.utilities.mask import _mask
+
 
 class Package(PackageBase, IPackage, abc.ABC):
     """

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -39,7 +39,7 @@ from imod.schemata import (
     ValidationError,
 )
 from imod.typing import GridDataArray
-
+from imod.mf6.utilities.mask import _mask
 
 class Package(PackageBase, IPackage, abc.ABC):
     """
@@ -540,7 +540,7 @@ class Package(PackageBase, IPackage, abc.ABC):
             The package with part masked.
         """
 
-     
+        return _mask(self, mask)
 
 
     def regrid_like(

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -37,6 +37,7 @@ from imod.mf6.out import open_cbc, open_conc, open_hds
 from imod.mf6.package import Package
 from imod.mf6.ssm import SourceSinkMixing
 from imod.mf6.statusinfo import NestedStatusInfo
+from imod.mf6.utilities.mask import _mask_all_models
 from imod.mf6.utilities.regrid import _regrid_like
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
@@ -47,7 +48,6 @@ from imod.typing.grid import (
     is_unstructured,
     merge_partitions,
 )
-from imod.mf6.utilities.mask import _mask_all_models
 
 OUTPUT_FUNC_MAPPING: dict[str, Callable] = {
     "head": open_hds,

--- a/imod/mf6/utilities/mask.py
+++ b/imod/mf6/utilities/mask.py
@@ -42,7 +42,8 @@ def _mask_all_packages(
     model: IModel,
     mask: GridDataArray,
 ):
-    if any([coord not in ["x", "y", "layer", "mesh2d_nFaces", "dx", "dy"] for coord in mask.coords]):
+    spatial_dimension_names = get_spatial_dimension_names(mask)
+    if any([coord not in spatial_dimension_names for coord in mask.coords]):
         raise ValueError("unexpected coordinate dimension in masking domain")
 
     for pkgname, pkg in model.items():

--- a/imod/mf6/utilities/mask.py
+++ b/imod/mf6/utilities/mask.py
@@ -1,0 +1,109 @@
+
+from imod.mf6.interfaces.isimulation import ISimulation
+from imod.mf6.interfaces.imodel import IModel
+from imod.mf6.interfaces.ipackage import IPackage
+from imod.typing.grid import GridDataArray, get_spatial_dimension_names, is_same_domain
+
+from xarray.core.utils import is_scalar
+import numpy as np
+from imod.mf6.auxiliary_variables import (
+    expand_transient_auxiliary_variables,
+    get_variable_names,
+    remove_expanded_auxiliary_variables_from_dataset,
+)
+
+
+def _mask_all_models(
+        simulation: ISimulation,
+        mask: GridDataArray,
+    ):
+        spatial_dims = get_spatial_dimension_names(mask)
+        if any([coord not in spatial_dims for coord in mask.coords]):
+            raise ValueError("unexpected coordinate dimension in masking domain")
+        
+
+        if simulation.is_split():
+            raise ValueError("masking can only be applied to simulations that have not been split. Apply masking before splitting.")                    
+
+        flowmodels =list(simulation.get_models_of_type("gwf6").keys())
+        transportmodels = list(simulation.get_models_of_type("gwt6").keys())      
+        modelnames = flowmodels + transportmodels
+
+
+        for name in modelnames:
+            if is_same_domain(simulation[name].domain, mask):
+                simulation[name].mask_all_packages(mask)
+            else:
+                raise ValueError("masking can only be applied to simulations when all the models in the simulation use the same grid.")
+            
+
+def _mask_all_packages(
+    model: IModel,
+    mask: GridDataArray,
+):
+    if any([coord not in ["x", "y", "layer", "mesh2d_nFaces", "dx", "dy"] for coord in mask.coords]):
+        raise ValueError("unexpected coordinate dimension in masking domain")
+
+    for pkgname, pkg in model.items():
+        model[pkgname] = pkg.mask(mask)
+    model.purge_empty_packages()
+
+
+def _mask(package: IPackage,  mask: GridDataArray):
+    masked = {}
+    if hasattr(package,"auxiliary_data_fields"):
+        remove_expanded_auxiliary_variables_from_dataset(package)
+    for var in package.dataset.data_vars.keys():
+        if package._skip_masking_variable(var, package.dataset[var]):
+            masked[var] = package.dataset[var]
+        else:
+            masked[var] = package._mask_spatial_var(var, mask)
+    if hasattr(package,"auxiliary_data_fields"):
+        expand_transient_auxiliary_variables(package)
+    return type(package)(**masked)
+
+
+def _skip_masking_variable(package: IPackage, var: str, da: GridDataArray)->bool: 
+    if package._skip_masking_dataarray(var) or len(da.dims) == 0 or set(da.coords).issubset(["layer"]):
+        return True
+    if is_scalar(da.values[()]):
+        return True
+    spatial_dims = ["x", "y", "mesh2d_nFaces", "layer"]
+    if not np.any( [coord in spatial_dims for coord in da.coords]):
+        return True
+    return False
+
+
+
+
+def _mask_spatial_var(self, var: str, mask: GridDataArray)->GridDataArray:
+    da = self.dataset[var]
+    array_mask = self._adjust_mask_for_unlayered_data(da, mask)
+
+    if issubclass(da.dtype.type, numbers.Integral):
+        if var == "idomain":
+            return da.where(array_mask > 0, other=array_mask)
+        else:
+            return da.where(array_mask > 0, other=0)
+    elif issubclass(da.dtype.type, numbers.Real):
+        return da.where(array_mask > 0)
+    else:
+        raise TypeError(
+            f"Expected dtype float or integer. Received instead: {da.dtype}"
+        )
+
+def _adjust_mask_for_unlayered_data(self, da: GridDataArray, mask: GridDataArray)->GridDataArray:
+    '''
+    Some arrays are not layered while the mask is layered (for example the
+    top array in dis or disv packaged). In that case we use the top layer of
+    the mask to perform the masking. If layer is not a dataset dimension,
+    but still a dataset coordinate, we limit the mask to the relevant layer
+    coordinate(s). 
+    '''
+    array_mask  = mask
+    if "layer" in da.coords and "layer" not in da.dims:
+        array_mask = mask.sel(layer=da.coords["layer"])        
+    if "layer" not in da.coords and "layer" in array_mask.coords:
+        array_mask = mask.isel(layer=0)
+
+    return array_mask         

--- a/imod/mf6/utilities/mask.py
+++ b/imod/mf6/utilities/mask.py
@@ -1,18 +1,18 @@
 
-from imod.mf6.interfaces.isimulation import ISimulation
+import numbers
+
+import numpy as np
+from xarray.core.utils import is_scalar
+
+from imod.mf6.auxiliary_variables import (
+        expand_transient_auxiliary_variables,
+        remove_expanded_auxiliary_variables_from_dataset,
+)
 from imod.mf6.interfaces.imodel import IModel
 from imod.mf6.interfaces.ipackage import IPackage
+from imod.mf6.interfaces.isimulation import ISimulation
 from imod.typing.grid import GridDataArray, get_spatial_dimension_names, is_same_domain
 
-from xarray.core.utils import is_scalar
-import numpy as np
-from imod.mf6.auxiliary_variables import (
-    expand_transient_auxiliary_variables,
-    get_variable_names,
-    remove_expanded_auxiliary_variables_from_dataset,
-)
-
-import numbers
 
 def _mask_all_models(
         simulation: ISimulation,


### PR DESCRIPTION
Fixes #888 

# Description
Moving the masking code for package, model and simulation into utilities.mask.py. To preserve the interface, 
the original methods in package, model and simulation are preserved, but now they call the utilities method under the hood. 

# Checklist
- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
