### PR TITLE
Issue #923: Pin xarray version to higher version

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -107,7 +107,7 @@ toolz = "*"
 tqdm = "*"
 twine = "*"
 vtk = { version = ">=9.0", build = "*qt*", channel = "conda-forge" }
-xarray = ">=2023.04.0"
+xarray = ">=2023.08.0"
 xugrid = ">=0.9.0"
 zarr = "*"
 build = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "tomli_w",
     "toolz",
     "tqdm",
-    "xarray >=2023.04.0",
+    "xarray >=2023.08.0",
     "xugrid >=0.9.0",
 ]
 


### PR DESCRIPTION
Part of #923

# Description
In the new version of imod.idf.open_subdomains we use xr.Coordinates, [added in the v2023.08.0 xarray version](https://docs.xarray.dev/en/stable/whats-new.html#v2023-08-0-aug-18-2023), however we didn't update the minimum xarray version. This pins the minimum xarray version to the correct version.

# Checklist

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
