### PR TITLE
Issue #930 Fix the line numbers and filenames being printed in the logging decorator

### DIFF
--- a/imod/logging/__init__.py
+++ b/imod/logging/__init__.py
@@ -61,6 +61,7 @@ If you want to integrate imod-python logging into your own logging framework
 from imod.logging._loggerholder import _LoggerHolder
 from imod.logging.config import LoggerType, configure
 from imod.logging.ilogger import ILogger  # noqa: I001
+from imod.logging.logging_decorators import init_log_decorator, standard_log_decorator
 from imod.logging.loglevel import LogLevel
 
 logger = _LoggerHolder()

--- a/imod/logging/_loggerholder.py
+++ b/imod/logging/_loggerholder.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from imod.logging.ilogger import ILogger
 from imod.logging.nulllogger import NullLogger
 
@@ -47,17 +49,17 @@ class _LoggerHolder(ILogger):
     def instance(self, value: ILogger) -> None:
         self._instance = value
 
-    def debug(self, message: str) -> None:
-        self.instance.debug(message)
+    def debug(self, message: str, additional_depth: Optional[int]) -> None:
+        self.instance.debug(message, additional_depth)
 
-    def info(self, message: str) -> None:
-        self.instance.info(message)
+    def info(self, message: str, additional_depth: Optional[int]) -> None:
+        self.instance.info(message, additional_depth)
 
-    def warning(self, message: str) -> None:
-        self.instance.warning(message)
+    def warning(self, message: str, additional_depth: Optional[int]) -> None:
+        self.instance.warning(message, additional_depth)
 
-    def error(self, message: str) -> None:
-        self.instance.error(message)
+    def error(self, message: str, additional_depth: Optional[int]) -> None:
+        self.instance.error(message, additional_depth)
 
-    def critical(self, message: str) -> None:
-        self.instance.critical(message)
+    def critical(self, message: str, additional_depth: Optional[int]) -> None:
+        self.instance.critical(message, additional_depth)

--- a/imod/logging/ilogger.py
+++ b/imod/logging/ilogger.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from typing import Optional
 
 from imod.logging.loglevel import LogLevel
 
@@ -9,7 +10,7 @@ class ILogger:
     """
 
     @abstractmethod
-    def debug(self, message: str) -> None:
+    def debug(self, message: str, additional_depth: Optional[int]) -> None:
         """
         Log message with severity ':attr:`~imod.logging.loglevel.LogLevel.DEBUG`'.
 
@@ -17,11 +18,14 @@ class ILogger:
         ----------
         message : str
             message to be logged
+        additional_depth: Optional[int]
+            additional depth level. Use this to correct the filename and line number
+            when you add logging to a decorator
         """
         raise NotImplementedError
 
     @abstractmethod
-    def info(self, message: str) -> None:
+    def info(self, message: str, additional_depth: Optional[int]) -> None:
         """
         Log message with severity ':attr:`~imod.logging.loglevel.LogLevel.INFO`'.
 
@@ -29,11 +33,14 @@ class ILogger:
         ----------
         message : str
             message to be logged
+        additional_depth: Optional[int]
+            additional depth level. Use this to correct the filename and line number
+            when you add logging to a decorator
         """
         raise NotImplementedError
 
     @abstractmethod
-    def warning(self, message: str) -> None:
+    def warning(self, message: str, additional_depth: Optional[int]) -> None:
         """
         Log message with severity ':attr:`~imod.logging.loglevel.LogLevel.WARNING`'.
 
@@ -41,11 +48,14 @@ class ILogger:
         ----------
         message : str
             message to be logged
+        additional_depth: Optional[int]
+            additional depth level. Use this to correct the filename and line number
+            when you add logging to a decorator
         """
         raise NotImplementedError
 
     @abstractmethod
-    def error(self, message: str) -> None:
+    def error(self, message: str, additional_depth: Optional[int]) -> None:
         """
         Log message with severity ':attr:`~imod.logging.loglevel.LogLevel.ERROR`'.
 
@@ -53,11 +63,14 @@ class ILogger:
         ----------
         message : str
             message to be logged
+        additional_depth: Optional[int]
+            additional depth level. Use this to correct the filename and line number
+            when you add logging to a decorator
         """
         raise NotImplementedError
 
     @abstractmethod
-    def critical(self, message: str) -> None:
+    def critical(self, message: str, additional_depth: Optional[int]) -> None:
         """
         Log message with severity ':attr:`~imod.logging.loglevel.LogLevel.CRITICAL`'.
 
@@ -65,23 +78,26 @@ class ILogger:
         ----------
         message : str
             message to be logged
+        additional_depth: Optional[int]
+            additional depth level. Use this to correct the filename and line number
+            when you add logging to a decorator
         """
         raise NotImplementedError
 
-    def log(self, loglevel: LogLevel, message: str) -> None:
-        '''
+    def log(self, loglevel: LogLevel, message: str, additional_depth: Optional[int]) -> None:
+        """
         logs a message with the specified urgency level.
-        '''
+        """
         match loglevel:
             case LogLevel.DEBUG:
-                self.debug(message)
+                self.debug(message, additional_depth)
             case LogLevel.INFO:
-                self.info(message)
+                self.info(message, additional_depth)
             case LogLevel.WARNING:
-                self.warning(message)   
+                self.warning(message, additional_depth)
             case LogLevel.ERROR:
-                self.error(message)   
+                self.error(message, additional_depth)
             case LogLevel.CRITICAL:      
-                self.critical(message)   
+                self.critical(message, additional_depth)
             case _:
                 raise ValueError(f"Unknown logging urgency at level {loglevel}")

--- a/imod/logging/logging_decorators.py
+++ b/imod/logging/logging_decorators.py
@@ -1,34 +1,42 @@
-from imod.logging import logger
 from imod.logging.loglevel import LogLevel
 
 
-# decorator to print log messages announcing the begin and end of the decorated method
 def standard_log_decorator(start_level: LogLevel = LogLevel.INFO, end_level: LogLevel = LogLevel.DEBUG):
+    """
+    Decorator to print log messages announcing the beginning and end of the decorated method
+    """
     def decorator(fun):
         def wrapper(*args, **kwargs):
-            object_name = str(type(args[0]).__name__)
-            start_message = f"beginning execution of {fun.__module__}.{fun.__name__} for object {object_name}..."
-            end_message = f"finished execution of {fun.__module__}.{fun.__name__}  for object {object_name}..."
+            from imod.logging import logger
 
-            logger.log(loglevel=start_level, message=start_message)
+            object_name = str(type(args[0]).__name__)
+            start_message = f"Beginning execution of {fun.__module__}.{fun.__name__} for object {object_name}..."
+            end_message = f"Finished execution of {fun.__module__}.{fun.__name__}  for object {object_name}..."
+
+            logger.log(loglevel=start_level, message=start_message, additional_depth=2)
             return_value = fun(*args, **kwargs)
-            logger.log(loglevel=end_level, message=end_message)
+            logger.log(loglevel=end_level, message=end_message, additional_depth=2)
             return return_value
         return wrapper
-    return  decorator
+    return decorator
        
-# decorator to print log messages announcing the begin and end of initialization methods
+
 def init_log_decorator(start_level: LogLevel = LogLevel.INFO, end_level: LogLevel = LogLevel.DEBUG):
+    """
+    Decorator to print log messages announcing the beginning and end of initialization methods
+    """
     def decorator(fun):
         def wrapper(*args, **kwargs):
+            from imod.logging import logger
+
             object_name = str(type(args[0]).__name__)
             start_message = f"Initializing the {object_name} package..."
-            end_message = f"Succesfully initialized the {object_name}..."
+            end_message = f"Successfully initialized the {object_name}..."
 
-            logger.log( loglevel=start_level,message=start_message)
+            logger.log(loglevel=start_level, message=start_message, additional_depth=2)
             return_value = fun(*args, **kwargs)
-            logger.log(loglevel=end_level,message=end_message)
+            logger.log(loglevel=end_level, message=end_message, additional_depth=2)
             return return_value
         return wrapper
-    return  decorator
+    return decorator
          

--- a/imod/logging/logurulogger.py
+++ b/imod/logging/logurulogger.py
@@ -1,9 +1,28 @@
 import sys
+from typing import Optional
 
 from loguru import logger
 
 from imod.logging.ilogger import ILogger
 from imod.logging.loglevel import LogLevel
+
+
+def _depth_level(additional_depth: Optional[int]) -> int:
+    """
+    The depth level is used to print the file and line number of the line being logged.
+    Because there are a few layers between the place where the imod logger is used and
+    the place where the pyton logger is used we need to set a custom stack level.
+
+    An additional_depth can be provided to add to this default depth level.
+    This is useful when a decorator is added which introduces an additional level between
+    the imod logger and the loguru logger.
+    """
+
+    default_stack_level = 2
+    if additional_depth is not None:
+        return default_stack_level + additional_depth
+    else:
+        return default_stack_level
 
 
 class LoguruLogger(ILogger):
@@ -25,17 +44,17 @@ class LoguruLogger(ILogger):
         if add_default_file_handler:
             logger.add("imod-python.log", level=log_level.value)
 
-    def debug(self, message: str) -> None:
-        logger.opt(depth=2).debug(message)
+    def debug(self, message: str, additional_depth: Optional[int] = None) -> None:
+        logger.opt(depth=_depth_level(additional_depth)).debug(message)
 
-    def info(self, message: str) -> None:
-        logger.opt(depth=2).info(message)
+    def info(self, message: str, additional_depth: Optional[int] = None) -> None:
+        logger.opt(depth=_depth_level(additional_depth)).info(message)
 
-    def warning(self, message: str) -> None:
-        logger.opt(depth=2).warning(message)
+    def warning(self, message: str, additional_depth: Optional[int] = None) -> None:
+        logger.opt(depth=_depth_level(additional_depth)).warning(message)
 
-    def error(self, message: str) -> None:
-        logger.opt(depth=2).error(message)
+    def error(self, message: str, additional_depth: Optional[int] = None) -> None:
+        logger.opt(depth=_depth_level(additional_depth)).error(message)
 
-    def critical(self, message: str) -> None:
-        logger.opt(depth=2).critical(message)
+    def critical(self, message: str, additional_depth: Optional[int] = None) -> None:
+        logger.opt(depth=_depth_level(additional_depth)).critical(message)

--- a/imod/logging/nulllogger.py
+++ b/imod/logging/nulllogger.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from imod.logging.ilogger import ILogger
 
 
@@ -9,17 +11,17 @@ class NullLogger(ILogger):
     def __init__(self) -> None:
         pass
 
-    def debug(self, message: str) -> None:
+    def debug(self, message: str, additional_depth: Optional[int] = None) -> None:
         pass
 
-    def info(self, message: str) -> None:
+    def info(self, message: str, additional_depth: Optional[int] = None) -> None:
         pass
 
-    def warning(self, message: str) -> None:
+    def warning(self, message: str, additional_depth: Optional[int] = None) -> None:
         pass
 
-    def error(self, message: str) -> None:
+    def error(self, message: str, additional_depth: Optional[int] = None) -> None:
         pass
 
-    def critical(self, message: str) -> None:
+    def critical(self, message: str, additional_depth: Optional[int] = None) -> None:
         pass

--- a/imod/logging/pythonlogger.py
+++ b/imod/logging/pythonlogger.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from typing import Optional
 
 from imod.logging.ilogger import ILogger
 from imod.logging.loglevel import LogLevel
@@ -9,6 +10,24 @@ def _formatter():
     return logging.Formatter(
         "%(name)s: %(asctime)s | %(levelname)s | %(filename)s:%(lineno)s | %(process)d >>> %(message)s"
     )
+
+
+def _stack_level(additional_depth: Optional[int]) -> int:
+    """
+    The stack level is used to print the file and line number of the line being logged.
+    Because there are a few layers between the place where the imod logger is used and
+    the place where the pyton logger is used we need to set a custom stack level.
+
+    An additional_depth can be provided to add to this default stack level.
+    This is useful when a decorator is added which introduces an additional level between
+    the imod logger and the python logger.
+    """
+
+    default_stack_level = 3
+    if additional_depth is not None:
+        return default_stack_level + additional_depth
+    else:
+        return default_stack_level
 
 
 class PythonLogger(ILogger):
@@ -30,20 +49,20 @@ class PythonLogger(ILogger):
         if add_default_file_handler:
             self._add_file_handler()
 
-    def debug(self, message: str) -> None:
-        self.logger.debug(message, stacklevel=3)
+    def debug(self, message: str, additional_depth: Optional[int] = None) -> None:
+        self.logger.debug(message, stacklevel=_stack_level(additional_depth))
 
-    def info(self, message: str) -> None:
-        self.logger.info(message, stacklevel=3)
+    def info(self, message: str, additional_depth: Optional[int] = None) -> None:
+        self.logger.info(message, stacklevel=_stack_level(additional_depth))
 
-    def warning(self, message: str) -> None:
-        self.logger.warning(message, stacklevel=3)
+    def warning(self, message: str, additional_depth: Optional[int] = None) -> None:
+        self.logger.warning(message, stacklevel=_stack_level(additional_depth))
 
-    def error(self, message: str) -> None:
-        self.logger.error(message, stacklevel=3)
+    def error(self, message: str, additional_depth: Optional[int] = None) -> None:
+        self.logger.error(message, stacklevel=_stack_level(additional_depth))
 
-    def critical(self, message: str) -> None:
-        self.logger.critical(message, stacklevel=3)
+    def critical(self, message: str, additional_depth: Optional[int] = None) -> None:
+        self.logger.critical(message, stacklevel=_stack_level(additional_depth))
 
     def _set_level(self, log_level: LogLevel) -> None:
         self.logger.setLevel(log_level.value)

--- a/imod/mf6/buy.py
+++ b/imod/mf6/buy.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence
 import numpy as np
 import xarray as xr
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.package import Package
 from imod.schemata import DTypeSchema
 

--- a/imod/mf6/chd.py
+++ b/imod/mf6/chd.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/cnc.py
+++ b/imod/mf6/cnc.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA

--- a/imod/mf6/dis.py
+++ b/imod/mf6/dis.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 import numpy as np
 
 import imod
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.package import Package
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/disv.py
+++ b/imod/mf6/disv.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import numpy as np
 import pandas as pd
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.package import Package
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/dsp.py
+++ b/imod/mf6/dsp.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.package import Package
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/evt.py
+++ b/imod/mf6/evt.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.utilities.regrid import RegridderType
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA, CONC_DIMS_SCHEMA

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/gwfgwf.py
+++ b/imod/mf6/gwfgwf.py
@@ -5,7 +5,7 @@ import cftime
 import numpy as np
 import xarray as xr
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.auxiliary_variables import expand_transient_auxiliary_variables
 from imod.mf6.exchangebase import ExchangeBase
 from imod.mf6.package import Package

--- a/imod/mf6/gwfgwt.py
+++ b/imod/mf6/gwfgwt.py
@@ -4,7 +4,7 @@ from typing import Optional
 import cftime
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.exchangebase import ExchangeBase
 from imod.mf6.package import Package
 from imod.typing import GridDataArray

--- a/imod/mf6/gwtgwt.py
+++ b/imod/mf6/gwtgwt.py
@@ -5,7 +5,7 @@ import cftime
 import numpy as np
 import xarray as xr
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.auxiliary_variables import expand_transient_auxiliary_variables
 from imod.mf6.exchangebase import ExchangeBase
 from imod.mf6.package import Package

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -12,7 +12,7 @@ import xarray as xr
 import xugrid as xu
 from fastcore.dispatch import typedispatch
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.interfaces.ilinedatapackage import ILineDataPackage
 from imod.mf6.mf6_hfb_adapter import Mf6HorizontalFlowBarrier

--- a/imod/mf6/ic.py
+++ b/imod/mf6/ic.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.package import Package
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/ims.py
+++ b/imod/mf6/ims.py
@@ -1,7 +1,7 @@
 import numpy as np
 import xarray as xr
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.package import Package
 from imod.schemata import DTypeSchema
 

--- a/imod/mf6/ist.py
+++ b/imod/mf6/ist.py
@@ -3,7 +3,7 @@ from typing import Optional
 import numpy as np
 import xarray as xr
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.package import Package
 from imod.mf6.validation import PKG_DIMS_SCHEMA
 from imod.schemata import (

--- a/imod/mf6/lak.py
+++ b/imod/mf6/lak.py
@@ -15,7 +15,7 @@ import pandas as pd
 import xarray as xr
 
 from imod import mf6
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.package import Package
 from imod.mf6.pkgbase import PackageBase

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -18,7 +18,7 @@ import xugrid as xu
 from jinja2 import Template
 
 import imod
-from imod.logging.logging_decorators import standard_log_decorator
+from imod.logging import standard_log_decorator
 from imod.mf6.interfaces.imodel import IModel
 from imod.mf6.package import Package
 from imod.mf6.statusinfo import NestedStatusInfo, StatusInfo, StatusInfoBase

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -5,7 +5,7 @@ from typing import Optional
 import cftime
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6 import ConstantHead
 from imod.mf6.clipped_boundary_condition_creator import create_clipped_boundary
 from imod.mf6.model import Modflow6Model

--- a/imod/mf6/model_gwt.py
+++ b/imod/mf6/model_gwt.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.model import Modflow6Model
 
 

--- a/imod/mf6/mst.py
+++ b/imod/mf6/mst.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.package import Package
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/npf.py
+++ b/imod/mf6/npf.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.package import Package
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/oc.py
+++ b/imod/mf6/oc.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.package import Package
 from imod.mf6.utilities.dataset import is_dataarray_none

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -12,7 +12,7 @@ import xarray as xr
 import xugrid as xu
 
 import imod
-from imod.logging.logging_decorators import standard_log_decorator
+from imod.logging import standard_log_decorator
 from imod.mf6.auxiliary_variables import (
     get_variable_names,
 )

--- a/imod/mf6/rch.py
+++ b/imod/mf6/rch.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -20,7 +20,7 @@ import xugrid as xu
 import imod
 import imod.logging
 import imod.mf6.exchangebase
-from imod.logging.logging_decorators import standard_log_decorator
+from imod.logging import standard_log_decorator
 from imod.mf6.gwfgwf import GWFGWF
 from imod.mf6.gwfgwt import GWFGWT
 from imod.mf6.gwtgwt import GWTGWT

--- a/imod/mf6/src.py
+++ b/imod/mf6/src.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.package import Package
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA

--- a/imod/mf6/ssm.py
+++ b/imod/mf6/ssm.py
@@ -2,8 +2,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging import logger
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator, logger
 from imod.mf6 import GroundwaterFlowModel
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.interfaces.iregridpackage import IRegridPackage

--- a/imod/mf6/sto.py
+++ b/imod/mf6/sto.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.package import Package
 from imod.mf6.utilities.regrid import RegridderType

--- a/imod/mf6/timedis.py
+++ b/imod/mf6/timedis.py
@@ -1,7 +1,7 @@
 import cftime
 import numpy as np
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.package import Package
 from imod.schemata import DimsSchema, DTypeSchema
 

--- a/imod/mf6/uzf.py
+++ b/imod/mf6/uzf.py
@@ -1,7 +1,7 @@
 import numpy as np
 import xarray as xr
 
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import AdvancedBoundaryCondition, BoundaryCondition
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA
 from imod.schemata import (

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -11,7 +11,7 @@ import xarray as xr
 import xugrid as xu
 
 import imod
-from imod.logging.logging_decorators import init_log_decorator
+from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import (
     BoundaryCondition,
     DisStructuredBoundaryCondition,


### PR DESCRIPTION
Fixes #930 

# Description
In #917 loggind decorators have been added. The idea is that they log the start and end of the method they decorate.
However the filenames and linenumber they log are incorrect. This has to do with the depth level being provided to the loggers. They used to be hardcoded but to work correctly with decorators they have to be configurable. This commit adds  that functionality

Log output before:
```
imod: 2024-03-25 12:43:42,230 | INFO | ilogger.py:79 | 5220 >>> Initializing the VerticesDiscretization package...
imod: 2024-03-25 12:43:42,236 | INFO | ilogger.py:79 | 5220 >>> beginning execution of imod.mf6.package._validate for object VerticesDiscretization...
imod: 2024-03-25 12:43:42,245 | DEBUG | ilogger.py:77 | 5220 >>> finished execution of imod.mf6.package._validate  for object VerticesDiscretization...
imod: 2024-03-25 12:43:42,245 | DEBUG | ilogger.py:77 | 5220 >>> Succesfully initialized the VerticesDiscretization...
imod: 2024-03-25 12:43:42,250 | INFO | ilogger.py:79 | 5220 >>> Initializing the ConstantHead package...
imod: 2024-03-25 12:43:42,268 | INFO | ilogger.py:79 | 5220 >>> beginning execution of imod.mf6.package._validate for object ConstantHead...
imod: 2024-03-25 12:43:42,272 | DEBUG | ilogger.py:77 | 5220 >>> finished execution of imod.mf6.package._validate  for object ConstantHead...
imod: 2024-03-25 12:43:42,273 | DEBUG | ilogger.py:77 | 5220 >>> Succesfully initialized the ConstantHead...
imod: 2024-03-25 12:43:42,273 | INFO | ilogger.py:79 | 5220 >>> Initializing the InitialConditions package...
imod: 2024-03-25 12:43:42,273 | INFO | ilogger.py:79 | 5220 >>> beginning execution of imod.mf6.package._validate for object InitialConditions...
```


Log output after:
```
imod: 2024-03-25 12:35:31,080 | INFO | mask.py:65 | 2180 >>> Initializing the VerticesDiscretization package...
imod: 2024-03-25 12:35:31,086 | INFO | disv.py:156 | 2180 >>> beginning execution of imod.mf6.package._validate for object VerticesDiscretization...
imod: 2024-03-25 12:35:31,095 | DEBUG | disv.py:156 | 2180 >>> finished execution of imod.mf6.package._validate  for object VerticesDiscretization...
imod: 2024-03-25 12:35:31,095 | DEBUG | mask.py:65 | 2180 >>> Succesfully initialized the VerticesDiscretization...
imod: 2024-03-25 12:35:31,102 | INFO | mask.py:65 | 2180 >>> Initializing the ConstantHead package...
imod: 2024-03-25 12:35:31,111 | INFO | chd.py:149 | 2180 >>> beginning execution of imod.mf6.package._validate for object ConstantHead...
imod: 2024-03-25 12:35:31,118 | DEBUG | chd.py:149 | 2180 >>> finished execution of imod.mf6.package._validate  for object ConstantHead...
imod: 2024-03-25 12:35:31,118 | DEBUG | mask.py:65 | 2180 >>> Succesfully initialized the ConstantHead...
imod: 2024-03-25 12:35:31,119 | INFO | mask.py:65 | 2180 >>> Initializing the InitialConditions package...
imod: 2024-03-25 12:35:31,119 | INFO | package.py:329 | 2180 >>> beginning execution of imod.mf6.package._validate for object InitialConditions...
```
# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
