### PR TITLE
Issue #942 time functions in logging decorator

### DIFF
--- a/imod/logging/logging_decorators.py
+++ b/imod/logging/logging_decorators.py
@@ -1,4 +1,5 @@
 from imod.logging.loglevel import LogLevel
+from time import time
 
 
 def standard_log_decorator(
@@ -12,12 +13,20 @@ def standard_log_decorator(
         def wrapper(*args, **kwargs):
             from imod.logging import logger
 
+            # anounce start of function
             object_name = str(type(args[0]).__name__)
             start_message = f"Beginning execution of {fun.__module__}.{fun.__name__} for object {object_name}..."
-            end_message = f"Finished execution of {fun.__module__}.{fun.__name__}  for object {object_name}..."
 
+            # anounce start of function
+            start_time = time()
             logger.log(loglevel=start_level, message=start_message, additional_depth=2)
+
+            # run function
             return_value = fun(*args, **kwargs)
+            end_time = time()
+
+            # anounce end of function
+            end_message = f"Finished execution of {fun.__module__}.{fun.__name__}  for object {object_name} in {end_time - start_time} seconds..."
             logger.log(loglevel=end_level, message=end_message, additional_depth=2)
             return return_value
 
@@ -37,12 +46,18 @@ def init_log_decorator(
         def wrapper(*args, **kwargs):
             from imod.logging import logger
 
+            # anounce start of function
             object_name = str(type(args[0]).__name__)
             start_message = f"Initializing the {object_name} package..."
-            end_message = f"Successfully initialized the {object_name}..."
-
+            start_time = time()
             logger.log(loglevel=start_level, message=start_message, additional_depth=2)
+
+            # run function
             return_value = fun(*args, **kwargs)
+            end_time = time()
+
+            # anounce end of function
+            end_message = f"Successfully initialized the {object_name} in {end_time - start_time} seconds..."
             logger.log(loglevel=end_level, message=end_message, additional_depth=2)
             return return_value
 

--- a/imod/logging/logging_decorators.py
+++ b/imod/logging/logging_decorators.py
@@ -1,5 +1,6 @@
-from imod.logging.loglevel import LogLevel
 from time import time
+
+from imod.logging.loglevel import LogLevel
 
 
 def standard_log_decorator(

--- a/imod/tests/test_mf6/test_mf6_logging.py
+++ b/imod/tests/test_mf6/test_mf6_logging.py
@@ -166,6 +166,4 @@ def test_runtime_is_logged(drainage, tmp_path):
     with open(logfile_path, "r") as log_file:
         log = log_file.read()
 
-        assert (
-            re.search("in 0.5[0-9]* seconds", log) is not None
-        )
+        assert re.search("in 0.5[0-9]* seconds", log) is not None

--- a/imod/tests/test_mf6/test_mf6_logging.py
+++ b/imod/tests/test_mf6/test_mf6_logging.py
@@ -1,16 +1,16 @@
+import re
 import sys
 from io import StringIO
 from pathlib import Path
-import re
+from time import sleep
+
 import numpy as np
 import pytest
 import xarray as xr
-from time import sleep
+
 import imod
-from imod.logging import LoggerType, LogLevel
+from imod.logging import LoggerType, LogLevel, standard_log_decorator
 from imod.mf6.write_context import WriteContext
-from imod.logging import standard_log_decorator
-from typing import Any
 
 out = StringIO()
 simple_real_number_regexp = (

--- a/imod/tests/test_mf6/test_mf6_logging.py
+++ b/imod/tests/test_mf6/test_mf6_logging.py
@@ -144,7 +144,7 @@ def test_write_simulation_is_logged(
 def test_runtime_is_logged(drainage, tmp_path):
     # arrange
     @standard_log_decorator()
-    def procrastinate(_):
+    def sleep_half_a_second(_):
         sleep(0.5)
 
     logfile_path = tmp_path / "logfile.txt"
@@ -158,7 +158,7 @@ def test_runtime_is_logged(drainage, tmp_path):
             add_default_stream_handler=True,
         )
 
-        procrastinate(
+        sleep_half_a_second(
             drainage
         )  # the logger needs an imod-python object as the first function argument
 

--- a/imod/tests/test_mf6/test_mf6_logging.py
+++ b/imod/tests/test_mf6/test_mf6_logging.py
@@ -167,5 +167,5 @@ def test_runtime_is_logged(drainage, tmp_path):
         log = log_file.read()
 
         assert (
-            re.search(f"in 0.5{simple_real_number_regexp} seconds...", log) is not None
+            re.search(f"in 0.5[0-9]* seconds", log) is not None
         )

--- a/imod/tests/test_mf6/test_mf6_logging.py
+++ b/imod/tests/test_mf6/test_mf6_logging.py
@@ -167,5 +167,5 @@ def test_runtime_is_logged(drainage, tmp_path):
         log = log_file.read()
 
         assert (
-            re.search(f"in 0.5[0-9]* seconds", log) is not None
+            re.search("in 0.5[0-9]* seconds", log) is not None
         )


### PR DESCRIPTION
Fixes #942

# Description
The logger now also prints how long a logged function takes to complete.

# Checklist


- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
