### PR TITLE
Issue #897 balance check

### DIFF
--- a/imod/tests/fixtures/mf6_circle_fixture.py
+++ b/imod/tests/fixtures/mf6_circle_fixture.py
@@ -161,7 +161,8 @@ def make_circle_model_flow_with_transport_data(species: list[str]):
         reordering_method=None,
         relaxation_factor=0.97,
     )
-    simulation.create_time_discretization(additional_times=["2000-01-01", "2001-01-01"])
+    simtimes = pd.date_range(start="2000-01-01", end="2001-01-01", freq="W")    
+    simulation.create_time_discretization(simtimes)
     return simulation
 
 

--- a/imod/tests/fixtures/mf6_circle_fixture.py
+++ b/imod/tests/fixtures/mf6_circle_fixture.py
@@ -161,7 +161,7 @@ def make_circle_model_flow_with_transport_data(species: list[str]):
         reordering_method=None,
         relaxation_factor=0.97,
     )
-    simtimes = pd.date_range(start="2000-01-01", end="2001-01-01", freq="W")    
+    simtimes = pd.date_range(start="2000-01-01", end="2001-01-01", freq="W")
     simulation.create_time_discretization(simtimes)
     return simulation
 

--- a/imod/tests/fixtures/mf6_circle_fixture.py
+++ b/imod/tests/fixtures/mf6_circle_fixture.py
@@ -76,7 +76,8 @@ def make_circle_model():
         reordering_method=None,
         relaxation_factor=0.97,
     )
-    simulation.create_time_discretization(additional_times=["2000-01-01", "2000-01-02"])
+    simtimes = pd.date_range(start="2000-01-01", end="2001-01-01", freq="W")    
+    simulation.create_time_discretization(additional_times=simtimes)
     return simulation
 
 
@@ -160,7 +161,7 @@ def make_circle_model_flow_with_transport_data(species: list[str]):
         reordering_method=None,
         relaxation_factor=0.97,
     )
-    simulation.create_time_discretization(additional_times=["2000-01-01", "2000-01-02"])
+    simulation.create_time_discretization(additional_times=["2000-01-01", "2001-01-01"])
     return simulation
 
 

--- a/imod/tests/fixtures/mf6_circle_fixture.py
+++ b/imod/tests/fixtures/mf6_circle_fixture.py
@@ -76,7 +76,7 @@ def make_circle_model():
         reordering_method=None,
         relaxation_factor=0.97,
     )
-    simtimes = pd.date_range(start="2000-01-01", end="2001-01-01", freq="W")    
+    simtimes = pd.date_range(start="2000-01-01", end="2001-01-01", freq="W")
     simulation.create_time_discretization(additional_times=simtimes)
     return simulation
 

--- a/imod/tests/test_mf6/test_circle.py
+++ b/imod/tests/test_mf6/test_circle.py
@@ -45,11 +45,11 @@ def test_simulation_write_and_run(circle_model, tmp_path):
     )
     assert isinstance(head, xu.UgridDataArray)
     assert np.all(
-        head["time"].values
-        == np.array(datetime(1999, 1, 1, 0, 0, 1), dtype="datetime64[ns]")
+        head["time"].values[0]
+        == np.array(datetime(1999, 1, 1, 0, 0, 7), dtype="datetime64[ns]")
     )
     assert head.dims == ("time", "layer", "mesh2d_nFaces")
-    assert head.shape == (1, 2, 216)
+    assert head.shape == (52, 2, 216)
 
 
 @pytest.mark.usefixtures("circle_model")
@@ -102,7 +102,7 @@ def test_simulation_write_and_run_evt(circle_model_evt, tmp_path):
     )
     assert isinstance(head, xu.UgridDataArray)
     assert head.dims == ("time", "layer", "mesh2d_nFaces")
-    assert head.shape == (1, 2, 216)
+    assert head.shape == (52, 2, 216)
 
 
 @pytest.mark.usefixtures("circle_model_evt")

--- a/imod/tests/test_mf6/test_mf6_out.py
+++ b/imod/tests/test_mf6/test_mf6_out.py
@@ -289,10 +289,10 @@ def test_open_cbc__disv(circle_result):
         ]
         for key, array in cbc.items():
             if key in ("chd", "flow-lower-face"):
-                assert array.shape == (1, 2, 216)
+                assert array.shape == (52, 2, 216)
                 assert array.dims[-1] == array.ugrid.grid.face_dimension
             else:
-                assert array.shape == (1, 2, 342)
+                assert array.shape == (52, 2, 342)
                 assert array.dims[-1] == array.ugrid.grid.edge_dimension
             assert isinstance(array, xu.UgridDataArray)
             assert isinstance(array.data, dask.array.Array)
@@ -333,10 +333,10 @@ def test_open_cbc__disv_sto(circle_result_sto):
         ]
         for key, array in cbc.items():
             if key in ("chd", "flow-lower-face", "sto-ss"):
-                assert array.shape == (1, 2, 216)
+                assert array.shape == (52, 2, 216)
                 assert array.dims[-1] == array.ugrid.grid.face_dimension
             else:
-                assert array.shape == (1, 2, 342)
+                assert array.shape == (52, 2, 342)
                 assert array.dims[-1] == array.ugrid.grid.edge_dimension
             assert isinstance(array, xu.UgridDataArray)
             assert isinstance(array.data, dask.array.Array)

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -71,15 +71,15 @@ def test_simulation_open_head(circle_model, tmp_path):
 
     assert isinstance(head_notime, xu.UgridDataArray)
     assert head_notime.dims == ("time", "layer", "mesh2d_nFaces")
-    assert head_notime.shape == (1, 2, 216)
+    assert head_notime.shape == (52, 2, 216)
 
     # open heads with time conversion.
     head = simulation.open_head(
         simulation_start_time=datetime(2013, 3, 11, 22, 0, 0), time_unit="w"
     )
     assert head.dims == ("time", "layer", "mesh2d_nFaces")
-    assert head.shape == (1, 2, 216)
-    assert str(head.coords["time"].values[()][0]) == "2013-03-18T22:00:00.000000000"
+    assert head.shape == (52, 2, 216)
+    assert str(head.coords["time"].values[()][0]) == "2013-04-29T22:00:00.000000000"
 
 
 @pytest.mark.usefixtures("circle_model")
@@ -100,7 +100,7 @@ def test_simulation_open_head_relative_path(circle_model, tmp_path):
 
     assert isinstance(head, xu.UgridDataArray)
     assert head.dims == ("time", "layer", "mesh2d_nFaces")
-    assert head.shape == (1, 2, 216)
+    assert head.shape == (52, 2, 216)
 
 
 @pytest.mark.usefixtures("circle_model")

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioned_simulation_postprocessing.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioned_simulation_postprocessing.py
@@ -109,9 +109,10 @@ def test_import_heads_unstructured(tmp_path, circle_partitioned):
 
     # Assert
     assert np.allclose(merged_heads.coords["layer"].values, [1, 2])
-    assert np.allclose(merged_heads.coords["time"].values, list (np.arange(7.0,365.0,7.0)))
+    assert np.allclose(
+        merged_heads.coords["time"].values, list(np.arange(7.0, 365.0, 7.0))
+    )
     assert np.allclose(merged_heads.coords["mesh2d_nFaces"].values, list(range(216)))
-
 
 
 @pytest.mark.usefixtures("split_transient_twri_model")

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioned_simulation_postprocessing.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioned_simulation_postprocessing.py
@@ -109,11 +109,9 @@ def test_import_heads_unstructured(tmp_path, circle_partitioned):
 
     # Assert
     assert np.allclose(merged_heads.coords["layer"].values, [1, 2])
-    assert np.allclose(merged_heads.coords["time"].values, [1.0])
+    assert np.allclose(merged_heads.coords["time"].values, list (np.arange(7.0,365.0,7.0)))
     assert np.allclose(merged_heads.coords["mesh2d_nFaces"].values, list(range(216)))
-    assert np.allclose(merged_heads.coords["layer"].values, [1, 2])
-    assert np.allclose(merged_heads.coords["time"].values, [1.0])
-    assert np.allclose(merged_heads.coords["mesh2d_nFaces"].values, list(range(216)))
+
 
 
 @pytest.mark.usefixtures("split_transient_twri_model")

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
@@ -152,47 +152,36 @@ def test_partitioning_unstructured(
     # Run the original example, so without partitioning, and save the simulation
     # results.
     original_dir = tmp_path / "original"
-    simulation.write(original_dir, binary=False)
-    simulation.run()
+    expected_head, _, expected_flow_budget, _ = (
+        run_simulation( original_dir, simulation)
+    )
 
-    expected_head = simulation.open_head(
-        simulation_start_time=np.datetime64("1999-01-01"),
-        time_unit="d",
-    )
-    expected_flow_cbc = simulation.open_flow_budget(
-        simulation_start_time=np.datetime64("1999-01-01"),
-        time_unit="d",
-    )
 
     # Partition the simulation, run it, and save the (merged) results.
     split_simulation = simulation.split(partition_array)
-
-    split_simulation.write(tmp_path, binary=False)
-    split_simulation.run()  # %%
-    actual_head = split_simulation.open_head(
-        simulation_start_time="01-01-1999", time_unit="d"
+    split_dir = tmp_path / "split"
+    actual_head, _, actual_flow_budget, _ = (
+        run_simulation( split_dir, split_simulation)
     )
-    actual_head = actual_head.ugrid.reindex_like(expected_head)
-
-    actual_flow_cbc = split_simulation.open_flow_budget(
-        simulation_start_time=np.datetime64("1999-01-01"), time_unit="d"
-    )
-    actual_flow_cbc = actual_flow_cbc.ugrid.reindex_like(expected_flow_cbc)
+    actual_head = actual_head.ugrid.reindex_like(expected_flow_budget)
+    actual_flow_budget = actual_flow_budget.ugrid.reindex_like(expected_flow_budget)
 
     # Compare the head result of the original simulation with the result of the partitioned simulation.
     np.testing.assert_allclose(
         actual_head["head"].values, expected_head.values, rtol=1e-5, atol=1e-3
     )
-    for key in ["flow-lower-face", "flow-horizontal-face"]:
-        if partition_array["name"].values[()] == "concentric" and key in [
-            "flow-horizontal-face"
-        ]:
-            continue
+    is_exchange_cell, is_exchange_edge = get_exchange_masks(
+        actual_flow_budget, expected_flow_budget
+    )    
+    for key in ["flow-lower-face", "flow-horizontal-face", "chd"]:
+        marker = is_exchange_cell
+        if key == "flow-horizontal-face":
+            marker = is_exchange_edge        
         np.testing.assert_allclose(
-            actual_flow_cbc[key].values,
-            expected_flow_cbc[key].values,
-            rtol=1e-5,
-            atol=1e-3,
+            expected_flow_budget[key].where(~marker, 0).values,
+            actual_flow_budget[key].where(~marker, 0).values,
+            rtol=0.3,
+            atol=3e-3,
         )
 
 
@@ -267,42 +256,40 @@ def test_partitioning_unstructured_hfb(
     # Run the original example, so without partitioning, and save the simulation
     # results
     original_dir = tmp_path / "original"
-    simulation.write(original_dir, binary=False)
-    simulation.run()
-
-    expected_head = simulation.open_head()
-    expected_flow_cbc = simulation.open_flow_budget()
+    expected_head, _, expected_flow_budget, _ = (
+        run_simulation( original_dir, simulation)
+    )
 
     # Partition the simulation, run it, and save the (merged) results
     split_simulation = simulation.split(partition_array)
-
-    split_simulation.write(tmp_path, binary=False)
-    split_simulation.run()
-
-    actual_head = split_simulation.open_head()
-
-    actual_flow_cbc = split_simulation.open_flow_budget()
+    split_dir = tmp_path / "split"
+    actual_head, _, actual_flow_budget, _ = (
+        run_simulation( split_dir, split_simulation)
+    )
 
     actual_head = actual_head.ugrid.reindex_like(expected_head)
-    actual_flow_cbc = actual_flow_cbc.ugrid.reindex_like(expected_flow_cbc)
+    actual_flow_budget = actual_flow_budget.ugrid.reindex_like(expected_flow_budget)
 
     # Compare the head result of the original simulation with the result of the
     # partitioned simulation. Criteria are a bit looser than in other tests
     # because we are dealing with a problem with heads ranging roughly from 20
     # m to 0 m, and the HFB adds extra complexity to this.
+    is_exchange_cell, is_exchange_edge = get_exchange_masks(
+        actual_flow_budget, expected_flow_budget
+    )
     np.testing.assert_allclose(
         actual_head["head"].values, expected_head.values, rtol=0.005
     )
+    
     for key in ["flow-lower-face", "flow-horizontal-face"]:
-        if partition_array["name"].values[()] == "concentric" and key in [
-            "flow-horizontal-face"
-        ]:
-            continue
+        marker = is_exchange_cell
+        if key == "flow-horizontal-face":
+            marker = is_exchange_edge        
         np.testing.assert_allclose(
-            actual_flow_cbc[key].values,
-            expected_flow_cbc[key].values,
-            rtol=1.0,
-            atol=31.66250038,
+            expected_flow_budget[key].where(~marker, 0).values,
+            actual_flow_budget[key].where(~marker, 0).values,
+            rtol=0.3,
+            atol=3e-3,
         )
 
 
@@ -325,46 +312,55 @@ def test_partitioning_unstructured_with_well(
     # Run the original example, so without partitioning, and save the simulation
     # results.
     original_dir = tmp_path / "original"
-    simulation.write(original_dir, binary=False)
-    simulation.run()
-
-    expected_head = simulation.open_head()
-    expected_flow_cbc = simulation.open_flow_budget()
+    expected_head, _, expected_flow_budget, _ = (
+        run_simulation( original_dir, simulation)
+    )
 
     # Partition the simulation, run it, and save the (merged) results
     split_simulation = simulation.split(partition_array)
 
-    split_simulation.write(tmp_path, binary=False)
-    split_simulation.run()
+    split_dir = tmp_path / "split"
+    actual_head, _, actual_flow_budget, _ = (
+        run_simulation( split_dir, split_simulation)
+    )
 
-    actual_head = split_simulation.open_head()
     actual_head = actual_head.ugrid.reindex_like(expected_head)
-
-    actual_cbc = split_simulation.open_flow_budget()
-    actual_cbc = actual_cbc.ugrid.reindex_like(expected_flow_cbc)
+    actual_flow_budget = actual_flow_budget.ugrid.reindex_like(expected_flow_budget)
     # Compare the head result of the original simulation with the result of the
     # partitioned simulation.
+    is_exchange_cell, is_exchange_edge = get_exchange_masks(
+        actual_flow_budget, expected_flow_budget
+    )
+
     np.testing.assert_allclose(
         actual_head["head"].values, expected_head.values, rtol=1e-5, atol=1e-3
     )
     for key in ["flow-lower-face", "flow-horizontal-face"]:
+        marker = is_exchange_cell
+        if key == "flow-horizontal-face":
+            marker = is_exchange_edge        
         np.testing.assert_allclose(
-            actual_cbc[key].values,
-            expected_flow_cbc[key].values,
-            rtol=1,
-            atol=0.01615156,
+            expected_flow_budget[key].where(~marker, 0).values,
+            actual_flow_budget[key].where(~marker, 0).values,
+            rtol=0.3,
+            atol=3e-3,
         )
 
 
-def run_simulation(tmp_path, simulation, species):
+def run_simulation(tmp_path, simulation, species=None):
+    has_transport = species is not None
     simulation.write(tmp_path)
     simulation.run()
     head = simulation.open_head()
-    concentration = simulation.open_concentration()
     flow_budget = simulation.open_flow_budget()
     flow_budget = flow_budget.sel(time=364)
-    transport_budget = simulation.open_transport_budget(species)
-    transport_budget = transport_budget.sel(time=364)
+    concentration = None
+    transport_budget = None
+    transport_budget = None  
+    if has_transport:
+        concentration = simulation.open_concentration()    
+        transport_budget = simulation.open_transport_budget(species)
+        transport_budget = transport_budget.sel(time=364)
     return head, concentration, flow_budget, transport_budget
 
 

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
@@ -173,7 +173,7 @@ def test_partitioning_unstructured(
     is_exchange_cell, is_exchange_edge = get_exchange_masks(
         actual_flow_budget, expected_flow_budget
     )    
-    for key in ["flow-lower-face", "flow-horizontal-face", "chd"]:
+    for key in ["flow-lower-face", "flow-horizontal-face"]:
         marker = is_exchange_cell
         if key == "flow-horizontal-face":
             marker = is_exchange_edge        

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
@@ -355,6 +355,8 @@ def test_partitioning_unstructured_with_well(
 
 
 def run_simulation(tmp_path, simulation, species=None):
+    # writes the simulation, runs it, and returns results including head,
+    # concentration, flow_budget and transport_budget
     has_transport = species is not None
     simulation.write(tmp_path)
     simulation.run()


### PR DESCRIPTION
Fixes #897 

# Description
- simplifies the tests for partitioning unstructured models, especially related to comparing the balance results before ánd after partitioning. 
- Made the timestepping settings equal for all the circle models in  the circle fixture.
- Now the cellfaces bordering the partition boundary, and the edges forming the partition boundary are not included in the results comparison. This allows us to make the comparison tolerances much stricter.

# Checklist
- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
