### PR TITLE
Issue #536 misleading well message

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -13,6 +13,8 @@ Fixed
 ~~~~~
 - No ``ValidationError`` thrown anymore in :class:`imod.mf6.River` when
   ``bottom_elevation`` equals ``bottom`` in the model discretization.
+- When wells outside of the domain are added, an exception is raised with an 
+  error message stating a well is outside of the domain.
 
 [0.16.0] - 2024-03-29
 ---------------------

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -578,7 +578,7 @@ class Well(BoundaryCondition, IPointDataPackage):
 
         if nwells_df == 0:
             raise ValueError("No wells were assigned in package. None were present.")
-        # @TODO: reinstate this check. issue github #621.
+
         if not is_partitioned and nwells_df != nwells_assigned:
             raise ValueError(
                 "One or more well(s) are completely invalid due to minimum conductivity and thickness constraints."

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -394,7 +394,7 @@ class Well(BoundaryCondition, IPointDataPackage):
         wells_df = wells_df.reset_index()
 
         wells_assigned = assign_wells(
-            wells_df, top_3d, bottom, k, minimum_thickness, minimum_k
+            wells_df, top_3d, bottom, k, minimum_thickness, minimum_k, True
         )
         # Set multi-index again
         wells_assigned = wells_assigned.set_index(index_names).sort_index()

--- a/imod/prepare/wells.py
+++ b/imod/prepare/wells.py
@@ -47,7 +47,7 @@ def locate_wells(
     top: Union[xr.DataArray, xu.UgridDataArray],
     bottom: Union[xr.DataArray, xu.UgridDataArray],
     k: Union[xr.DataArray, xu.UgridDataArray, None],
-    throw_if_well_not_placed: bool = False
+    throw_if_well_not_placed: bool = False,
 ):
     if not isinstance(top, (xu.UgridDataArray, xr.DataArray)):
         raise TypeError(
@@ -65,12 +65,12 @@ def locate_wells(
     xy_bottom = imod.select.points_values(bottom, x=x, y=y, out_of_bounds="ignore")
 
     # Raise exception if not all wells could be mapped onto the domain
-    if  throw_if_well_not_placed and len(x) > len(xy_top["index"]):
-        inside = imod.select.points_in_bounds(top, x=x,y=y)
-        out = np.where(inside ==False)
+    if throw_if_well_not_placed and len(x) > len(xy_top["index"]):
+        inside = imod.select.points_in_bounds(top, x=x, y=y)
+        out = np.where(~inside)
         raise ValueError(
-            f'well at x = {x[out[0]]} and y = {y[out[0]]} could not be mapped on the grid'
-        )       
+            f"well at x = {x[out[0]]} and y = {y[out[0]]} could not be mapped on the grid"
+        )
 
     if k is not None:
         xy_k = imod.select.points_values(k, x=x, y=y, out_of_bounds="ignore")
@@ -93,7 +93,7 @@ def assign_wells(
     k: Optional[Union[xr.DataArray, xu.UgridDataArray]] = None,
     minimum_thickness: Optional[float] = 0.05,
     minimum_k: Optional[float] = 1.0,
-    throw_if_well_not_placed: bool = False    
+    throw_if_well_not_placed: bool = False,
 ) -> pd.DataFrame:
     """
     Distribute well pumping rate according to filter length when ``k=None``, or
@@ -137,7 +137,9 @@ def assign_wells(
             f"received: {members}"
         )
 
-    id_in_bounds, xy_top, xy_bottom, xy_k = locate_wells(wells, top, bottom, k, throw_if_well_not_placed)
+    id_in_bounds, xy_top, xy_bottom, xy_k = locate_wells(
+        wells, top, bottom, k, throw_if_well_not_placed
+    )
     wells_in_bounds = wells.set_index("id").loc[id_in_bounds].reset_index()
     first = wells_in_bounds.groupby("id").first()
     overlap = compute_overlap(first, xy_top, xy_bottom)

--- a/imod/prepare/wells.py
+++ b/imod/prepare/wells.py
@@ -68,7 +68,7 @@ def locate_wells(
         for ind in first["index"].values:
             if not ind in xy_bottom["index"]:
                 raise ValueError(
-                    f'well with index {ind} and x = {first["x"][ind]} and y = {first["y"][ind]} could not be mapped on the grid'
+                    f'well at x = {first["x"][ind]} and y = {first["y"][ind]} could not be mapped on the grid'
                 )
 
     if k is not None:

--- a/imod/prepare/wells.py
+++ b/imod/prepare/wells.py
@@ -62,6 +62,15 @@ def locate_wells(
 
     xy_top = imod.select.points_values(top, x=x, y=y, out_of_bounds="ignore")
     xy_bottom = imod.select.points_values(bottom, x=x, y=y, out_of_bounds="ignore")
+
+    # Raise exception if not all wells could be mapped onto the domain
+    if xy_bottom["index"].shape[0] < len(x):
+        for ind in first["index"].values:
+            if not ind in xy_bottom["index"]:
+                raise ValueError(
+                    f'well with index {ind} and x = {first["x"][ind]} and y = {first["y"][ind]} could not be mapped on the grid'
+                )
+
     if k is not None:
         xy_k = imod.select.points_values(k, x=x, y=y, out_of_bounds="ignore")
 

--- a/imod/prepare/wells.py
+++ b/imod/prepare/wells.py
@@ -47,6 +47,7 @@ def locate_wells(
     top: Union[xr.DataArray, xu.UgridDataArray],
     bottom: Union[xr.DataArray, xu.UgridDataArray],
     k: Union[xr.DataArray, xu.UgridDataArray, None],
+    throw_if_well_not_placed: bool = False
 ):
     if not isinstance(top, (xu.UgridDataArray, xr.DataArray)):
         raise TypeError(
@@ -64,12 +65,12 @@ def locate_wells(
     xy_bottom = imod.select.points_values(bottom, x=x, y=y, out_of_bounds="ignore")
 
     # Raise exception if not all wells could be mapped onto the domain
-    if xy_bottom["index"].shape[0] < len(x):
-        for ind in first["index"].values:
-            if not ind in xy_bottom["index"]:
-                raise ValueError(
-                    f'well at x = {first["x"][ind]} and y = {first["y"][ind]} could not be mapped on the grid'
-                )
+    if  throw_if_well_not_placed and len(x) > len(xy_top["index"]):
+        inside = imod.select.points_in_bounds(top, x=x,y=y)
+        out = np.where(inside ==False)
+        raise ValueError(
+            f'well at x = {x[out[0]]} and y = {y[out[0]]} could not be mapped on the grid'
+        )       
 
     if k is not None:
         xy_k = imod.select.points_values(k, x=x, y=y, out_of_bounds="ignore")
@@ -92,6 +93,7 @@ def assign_wells(
     k: Optional[Union[xr.DataArray, xu.UgridDataArray]] = None,
     minimum_thickness: Optional[float] = 0.05,
     minimum_k: Optional[float] = 1.0,
+    throw_if_well_not_placed: bool = False    
 ) -> pd.DataFrame:
     """
     Distribute well pumping rate according to filter length when ``k=None``, or
@@ -135,7 +137,7 @@ def assign_wells(
             f"received: {members}"
         )
 
-    id_in_bounds, xy_top, xy_bottom, xy_k = locate_wells(wells, top, bottom, k)
+    id_in_bounds, xy_top, xy_bottom, xy_k = locate_wells(wells, top, bottom, k, throw_if_well_not_placed)
     wells_in_bounds = wells.set_index("id").loc[id_in_bounds].reset_index()
     first = wells_in_bounds.groupby("id").first()
     overlap = compute_overlap(first, xy_top, xy_bottom)

--- a/imod/tests/test_mf6/test_well_highlvl.py
+++ b/imod/tests/test_mf6/test_well_highlvl.py
@@ -262,3 +262,28 @@ def test_non_unique_ids(twri_simulation: imod.mf6.Modflow6Simulation):
             print_flows=True,
             validate=True,
         )
+
+
+def test_error_message_wells_outside_grid(
+    tmp_path: Path, twri_simulation: imod.mf6.Modflow6Simulation
+):
+
+    # define 2 wells oustide of the model domain
+    twri_simulation["GWF_1"]["well"] = imod.mf6.Well(
+        x=[1e5, 5e3],
+        y=[1e5, 5e3],
+        screen_top=[0.0, 0.0],
+        screen_bottom=[-400.0, -400],
+        rate=[1.0, 3.0],
+        print_flows=True,
+        validate=True,
+    )
+
+    asserted = False
+    try :
+        twri_simulation.write(tmp_path, binary=False)
+    except Exception as e:
+        asserted = True
+        assert "Not all wells could be assigned" in str(e)
+
+    assert asserted

--- a/imod/tests/test_mf6/test_well_highlvl.py
+++ b/imod/tests/test_mf6/test_well_highlvl.py
@@ -272,7 +272,7 @@ def test_non_unique_ids(twri_simulation: imod.mf6.Modflow6Simulation):
 def test_error_message_wells_outside_grid(tmp_path: Path, fixture_name: str, request):
     simulation = request.getfixturevalue(fixture_name)
 
-    # define a well oustide of the model domain
+    # define wells inside the domain, and also  one outside
     in_domain_wells = {0: {"x": 1.0, "y": 2.0}, 1: {"x": 4.0, "y": 5.0}}
     out_of_domain_well = {"x": 500000, "y": 600000}
     simulation["GWF_1"]["well"] = imod.mf6.Well(
@@ -291,7 +291,7 @@ def test_error_message_wells_outside_grid(tmp_path: Path, fixture_name: str, req
     except Exception as e:
         asserted = True
 
-        # ensure the coordinates of the offending well are present in the error message
+        # ensure the coordinates of the first offending well are present in the error message
         assert str(out_of_domain_well["x"]) in str(e)
         assert str(out_of_domain_well["y"]) in str(e)
 


### PR DESCRIPTION
Fixes #536 

# Description
This PR solves a bug. When a well was added outside of the domain, this resulted in an error message stating that the 
well was not added to the model because it violated constraints of minimum thickness / minimum k. The real reason, that the well was outside of the domain, was not mentioned. 
Now a separate check has been added that checks if the wells are inside the domain, and if not it give an error message
stating this, as well as the coordinates of the first well outside of the domain. 

#d Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [X] Links to correct issue
- [X] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
