### PR TITLE
Issue #938 clipping state boundary

### DIFF
--- a/imod/mf6/gwfgwf.py
+++ b/imod/mf6/gwfgwf.py
@@ -90,7 +90,6 @@ class GWFGWF(ExchangeBase):
         y_max: Optional[float] = None,
         top: Optional[GridDataArray] = None,
         bottom: Optional[GridDataArray] = None,
-        state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         raise NotImplementedError("this package cannot be clipped")
 

--- a/imod/mf6/gwfgwt.py
+++ b/imod/mf6/gwfgwt.py
@@ -36,7 +36,6 @@ class GWFGWT(ExchangeBase):
         y_max: Optional[float] = None,
         top: Optional[GridDataArray] = None,
         bottom: Optional[GridDataArray] = None,
-        state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         """
         The GWF-GWT exchange does not have any spatial coordinates that can be clipped.

--- a/imod/mf6/gwtgwt.py
+++ b/imod/mf6/gwtgwt.py
@@ -87,7 +87,6 @@ class GWTGWT(ExchangeBase):
         y_max: Optional[float] = None,
         top: Optional[GridDataArray] = None,
         bottom: Optional[GridDataArray] = None,
-        state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         raise NotImplementedError("this package cannot be clipped")
 

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -584,7 +584,6 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
         y_max: optional, float
         top: optional, GridDataArray
         bottom: optional, GridDataArray
-        state_for_boundary: optional, GridDataArray
 
         Returns
         -------

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -559,7 +559,6 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
         y_max: Optional[float] = None,
         top: Optional[GridDataArray] = None,
         bottom: Optional[GridDataArray] = None,
-        state_for_boundary: Optional[GridDataArray] = None,
     ) -> "HorizontalFlowBarrierBase":
         """
         Clip a package by a bounding box (time, layer, y, x).

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -359,6 +359,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         x_max: Optional[float] = None,
         y_min: Optional[float] = None,
         y_max: Optional[float] = None,
+        state_for_boundary: Optional[GridDataArray] = None,
     ):
         """
         Clip a model by a bounding box (time, layer, y, x).
@@ -382,7 +383,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         x_max: optional, float
         y_min: optional, float
         y_max: optional, float
-        state_for_boundary :
+        state_for_boundary: optional, float
         """
         supported, error_with_object = self.is_clipping_supported()
         if not supported:
@@ -413,7 +414,6 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         x_max: Optional[float] = None,
         y_min: Optional[float] = None,
         y_max: Optional[float] = None,
-        state_for_boundary: Optional[GridDataArray] = None,
     ):
         """
         Clip a model by a bounding box (time, layer, y, x).
@@ -458,7 +458,6 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
                 y_max=y_max,
                 top=top,
                 bottom=bottom,
-                state_for_boundary=state_for_boundary,
             )
 
         return clipped

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -359,7 +359,6 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         x_max: Optional[float] = None,
         y_min: Optional[float] = None,
         y_max: Optional[float] = None,
-        state_for_boundary: Optional[GridDataArray] = None,
     ):
         """
         Clip a model by a bounding box (time, layer, y, x).
@@ -400,7 +399,6 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
             x_max,
             y_min,
             y_max,
-            state_for_boundary,
         )
 
         return clipped

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -440,7 +440,6 @@ class Package(PackageBase, IPackage, abc.ABC):
         y_max: Optional[float] = None,
         top: Optional[GridDataArray] = None,
         bottom: Optional[GridDataArray] = None,
-        state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         """
         Clip a package by a bounding box (time, layer, y, x).

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -977,18 +977,31 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             state_for_boundary = (
                 None if states_for_boundary is None else states_for_boundary.get(key)
             )
-
-            clipped[key] = value.clip_box(
-                time_min=time_min,
-                time_max=time_max,
-                layer_min=layer_min,
-                layer_max=layer_max,
-                x_min=x_min,
-                x_max=x_max,
-                y_min=y_min,
-                y_max=y_max,
-                state_for_boundary=state_for_boundary,
-            )
+            if isinstance(value, Modflow6Model):
+                clipped[key] = value.clip_box(
+                    time_min=time_min,
+                    time_max=time_max,
+                    layer_min=layer_min,
+                    layer_max=layer_max,
+                    x_min=x_min,
+                    x_max=x_max,
+                    y_min=y_min,
+                    y_max=y_max,
+                    state_for_boundary=state_for_boundary,
+                )
+            elif isinstance(value, Package):
+                clipped[key] = value.clip_box(
+                    time_min=time_min,
+                    time_max=time_max,
+                    layer_min=layer_min,
+                    layer_max=layer_max,
+                    x_min=x_min,
+                    x_max=x_max,
+                    y_min=y_min,
+                    y_max=y_max,
+                )
+            else:
+                raise ValueError(f"object of type {type(value)} cannot be clipped.")
         return clipped
 
     def split(self, submodel_labels: GridDataArray) -> Modflow6Simulation:

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -253,7 +253,6 @@ class Well(BoundaryCondition, IPointDataPackage):
         y_max: Optional[float] = None,
         top: Optional[GridDataArray] = None,
         bottom: Optional[GridDataArray] = None,
-        state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         """
         Clip a package by a bounding box (time, layer, y, x).
@@ -741,7 +740,6 @@ class WellDisStructured(DisStructuredBoundaryCondition):
         y_max: Optional[float] = None,
         top: Optional[GridDataArray] = None,
         bottom: Optional[GridDataArray] = None,
-        state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         """
         Clip a package by a bounding box (time, layer, y, x).
@@ -897,7 +895,6 @@ class WellDisVertices(DisVerticesBoundaryCondition):
         y_max: Optional[float] = None,
         top: Optional[GridDataArray] = None,
         bottom: Optional[GridDataArray] = None,
-        state_for_boundary: Optional[GridDataArray] = None,
     ) -> Package:
         """
         Clip a package by a bounding box (time, layer, y, x).

--- a/imod/tests/test_mf6/test_ex01_twri.py
+++ b/imod/tests/test_mf6/test_ex01_twri.py
@@ -541,7 +541,7 @@ def test_slice_and_run_with_state(transient_twri_model, tmp_path):
     transient_twri_model.run()
     head = transient_twri_model.open_head()
 
-    #set the boundary to  recognizable value, in this case 1.23
+    # set the boundary to  recognizable value, in this case 1.23
     state_for_boundary = {"GWF_1": 1.23 * ones_like(head)}
     clipped_simulation = transient_twri_model.clip_box(
         time_min="2000-01-10",
@@ -555,7 +555,7 @@ def test_slice_and_run_with_state(transient_twri_model, tmp_path):
         states_for_boundary=state_for_boundary,
     )
 
-    #check that the value 1.23 occurrs in the chd_clipped package of the clipped simulation
+    # check that the value 1.23 occurrs in the chd_clipped package of the clipped simulation
     clipped_boundary = clipped_simulation["GWF_1"]["chd_clipped"].dataset.sel(
         time=2, layer=1
     )

--- a/imod/tests/test_mf6/test_ex01_twri.py
+++ b/imod/tests/test_mf6/test_ex01_twri.py
@@ -10,6 +10,7 @@ import xarray as xr
 import imod
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
+from imod.typing.grid import ones_like
 
 
 @pytest.mark.usefixtures("twri_model")
@@ -529,6 +530,37 @@ def test_slice_and_run(transient_twri_model, tmp_path):
     modeldir = tmp_path / "ex01-twri-transient-slice"
     simulation.write(modeldir, binary=True)
     simulation.run()
+
+
+@pytest.mark.usefixtures("transient_twri_model")
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
+def test_slice_and_run_with_state(transient_twri_model, tmp_path):
+    # TODO: bring back well once slicing is implemented...
+    transient_twri_model["GWF_1"].pop("wel")
+    transient_twri_model.write(tmp_path, False, True, False)
+    transient_twri_model.run()
+    head = transient_twri_model.open_head()
+
+    #set the boundary to  recognizable value, in this case 1.23
+    state_for_boundary = {"GWF_1": 1.23 * ones_like(head)}
+    clipped_simulation = transient_twri_model.clip_box(
+        time_min="2000-01-10",
+        time_max="2000-01-20",
+        layer_min=1,
+        layer_max=2,
+        x_min=None,
+        x_max=65_000.0,
+        y_min=10_000.0,
+        y_max=65_000.0,
+        states_for_boundary=state_for_boundary,
+    )
+
+    #check that the value 1.23 occurrs in the chd_clipped package of the clipped simulation
+    clipped_boundary = clipped_simulation["GWF_1"]["chd_clipped"].dataset.sel(
+        time=2, layer=1
+    )
+    np_array = clipped_boundary["head"].values
+    assert (np_array == 1.23).sum() == 33
 
 
 @pytest.mark.usefixtures("transient_twri_model")


### PR DESCRIPTION
Fixes #938

# Description
Removed unused parameter "state_for_boundary" from package clip_box method. It is still in Model.clip_box because there it is used ( in the GroundwaterFlowModel subclass). Added test that does not use mocking. 

# Checklist
- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
