### PR TITLE
added docstrings to the GWF and GWT models

### DIFF
--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -24,7 +24,7 @@ class GroundwaterFlowModel(Modflow6Model):
     listing_file: Optional[str] = None
         name of the listing file to create for this GWF model. If not specified,
         then the name of the list file will be the basename of the GWF model
-        name file and the ‘.lst’ extension.
+        name file and the 'lst' extension.
     print_input: bool = False
         keyword to indicate that the list of all model stress package
         information will be written to the listing file immediately after it is
@@ -32,10 +32,10 @@ class GroundwaterFlowModel(Modflow6Model):
     print_flows: bool = False
         keyword to indicate that the list of all model package flow rates will
         be printed to the listing file for every stress period time step in
-        which “BUDGET PRINT” is specified in Output Control.
+        which "BUDGET PRINT" is specified in Output Control.
     save_flows: bool = False
         indicate that all model package flow terms will be written to the file
-        specified with “BUDGET FILEOUT” in Output Control.
+        specified with "BUDGET FILEOUT" in Output Control.
     newton: bool = False
         activates the Newton-Raphson formulation for groundwater flow between
         connected, convertible groundwater cells and stress packages that
@@ -43,7 +43,7 @@ class GroundwaterFlowModel(Modflow6Model):
     under_relaxation: bool = False,
         indicates whether the groundwater head in a cell will be under-relaxed when
         water levels fall below the bottom of the model below any given cell. By
-        default, Newton-Raphson UNDER_RELAXATION is not applied.
+        default, Newton-Raphson UNDER_RELAXATION is not applied.        
     """
 
     _mandatory_packages = ("npf", "ic", "oc", "sto")

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -13,6 +13,39 @@ from imod.typing import GridDataArray
 
 
 class GroundwaterFlowModel(Modflow6Model):
+    """
+    The GroundwaterFlowModel (GWF) simulates flow of (liquid) groundwater.
+    More information can be found here:
+    https://water.usgs.gov/water-resources/software/MODFLOW-6/mf6io_6.4.2.pdf#page=27
+
+    Parameters
+    ----------
+
+    listing_file: Optional[str] = None
+        name of the listing file to create for this GWF model. If not specified,
+        then the name of the list file will be the basename of the GWF model
+        name file and the ‘.lst’ extension.
+    print_input: bool = False
+        keyword to indicate that the list of all model stress package
+        information will be written to the listing file immediately after it is
+        read.
+    print_flows: bool = False
+        keyword to indicate that the list of all model package flow rates will
+        be printed to the listing file for every stress period time step in
+        which “BUDGET PRINT” is specified in Output Control.
+    save_flows: bool = False
+        indicate that all model package flow terms will be written to the file
+        specified with “BUDGET FILEOUT” in Output Control.
+    newton: bool = False
+        activates the Newton-Raphson formulation for groundwater flow between
+        connected, convertible groundwater cells and stress packages that
+        support calculation of Newton-Raphson terms for groundwater exchanges.
+    under_relaxation: bool = False,
+        indicates whether the groundwater head in a cell will be under-relaxed when
+        water levels fall below the bottom of the model below any given cell. By
+        default, Newton-Raphson UNDER_RELAXATION is not applied.
+    """
+
     _mandatory_packages = ("npf", "ic", "oc", "sto")
     _model_id = "gwf6"
     _template = Modflow6Model._initialize_template("gwf-nam.j2")

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -43,7 +43,7 @@ class GroundwaterFlowModel(Modflow6Model):
     under_relaxation: bool = False,
         indicates whether the groundwater head in a cell will be under-relaxed when
         water levels fall below the bottom of the model below any given cell. By
-        default, Newton-Raphson UNDER_RELAXATION is not applied.        
+        default, Newton-Raphson UNDER_RELAXATION is not applied.
     """
 
     _mandatory_packages = ("npf", "ic", "oc", "sto")

--- a/imod/mf6/model_gwt.py
+++ b/imod/mf6/model_gwt.py
@@ -10,6 +10,26 @@ class GroundwaterTransportModel(Modflow6Model):
     """
     The GroundwaterTransportModel (GWT) simulates transport of a single solute
     species flowing in groundwater.
+    More information can be found here:
+    https://water.usgs.gov/water-resources/software/MODFLOW-6/mf6io_6.4.2.pdf#page=172
+
+    Parameters
+    ----------
+
+    listing_file: Optional[str] = None
+        name of the listing file to create for this GWT model. If not specified,
+        then the name of the list file will be the basename of the GWT model
+        name file and the ‘.lst’ extension.
+    print_input: bool = False
+        if True, indicates that the list of exchange entries will be echoed to
+        the listing file immediately after it is read.
+    print_flows: bool = False
+        if True, indicates that the list of exchange flow rates will be printed
+        to the listing file for every stress period in which “SAVE BUDGET” is
+        specified in Output Control
+    save_flows: bool = False,
+        if True, indicates that all model package flow terms will be written to
+        the file specified with “BUDGET FILEOUT” in Output Control.
     """
 
     _mandatory_packages = ("mst", "dsp", "oc", "ic")

--- a/imod/mf6/model_gwt.py
+++ b/imod/mf6/model_gwt.py
@@ -19,17 +19,17 @@ class GroundwaterTransportModel(Modflow6Model):
     listing_file: Optional[str] = None
         name of the listing file to create for this GWT model. If not specified,
         then the name of the list file will be the basename of the GWT model
-        name file and the ‘.lst’ extension.
+        name file and the 'lst' extension.
     print_input: bool = False
         if True, indicates that the list of exchange entries will be echoed to
         the listing file immediately after it is read.
     print_flows: bool = False
         if True, indicates that the list of exchange flow rates will be printed
-        to the listing file for every stress period in which “SAVE BUDGET” is
+        to the listing file for every stress period in which "SAVE BUDGET" is
         specified in Output Control
     save_flows: bool = False,
         if True, indicates that all model package flow terms will be written to
-        the file specified with “BUDGET FILEOUT” in Output Control.
+        the file specified with "BUDGET FILEOUT" in Output Control.
     """
 
     _mandatory_packages = ("mst", "dsp", "oc", "ic")


### PR DESCRIPTION
Fixes #983 

# Description
Added a docstring to the GWF and GWT classes, including a pointer to the manual where these models are explained, 
and including a list of input parameters

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
