### PR TITLE
Issue #1008 Change the personal access tokens to Deltares Access Tokens

### DIFF
--- a/.teamcity/Templates/GitHubIntegrationTemplate.kt
+++ b/.teamcity/Templates/GitHubIntegrationTemplate.kt
@@ -14,17 +14,13 @@ object GitHubIntegrationTemplate : Template({
             vcsRootExtId = "${DslContext.settingsRoot.id}"
             publisher = github {
                 githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "%github_deltares-service-account_access_token%"
-                }
+                authType = vcsRoot()
             }
         }
         pullRequests {
             vcsRootExtId = "${DslContext.settingsRoot.id}"
             provider = github {
-                authType = token {
-                    token = "%github_deltares-service-account_access_token%"
-                }
+                authType = vcsRoot()
                 filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
             }
         }

--- a/.teamcity/Templates/GitHubIntegrationTemplate.kt
+++ b/.teamcity/Templates/GitHubIntegrationTemplate.kt
@@ -15,7 +15,7 @@ object GitHubIntegrationTemplate : Template({
             publisher = github {
                 githubUrl = "https://api.github.com"
                 authType = personalToken {
-                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
+                    token = "%github_deltares-service-account_access_token%"
                 }
             }
         }
@@ -23,7 +23,7 @@ object GitHubIntegrationTemplate : Template({
             vcsRootExtId = "${DslContext.settingsRoot.id}"
             provider = github {
                 authType = token {
-                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
+                    token = "%github_deltares-service-account_access_token%"
                 }
                 filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
             }

--- a/.teamcity/_Self/MainProject.kt
+++ b/.teamcity/_Self/MainProject.kt
@@ -172,9 +172,7 @@ object Tests : BuildType({
         pullRequests {
             vcsRootExtId = "${DslContext.settingsRoot.id}"
             provider = github {
-                authType = token {
-                    token = "%github_deltares-service-account_access_token%"
-                }
+                authType = vcsRoot()
                 filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
             }
         }

--- a/.teamcity/_Self/MainProject.kt
+++ b/.teamcity/_Self/MainProject.kt
@@ -173,7 +173,7 @@ object Tests : BuildType({
             vcsRootExtId = "${DslContext.settingsRoot.id}"
             provider = github {
                 authType = token {
-                    token = "credentialsJSON:558df52e-822f-4d9d-825a-854846a9a2ff"
+                    token = "%github_deltares-service-account_access_token%"
                 }
                 filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
             }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -30,5 +30,5 @@ node (Plugins -> teamcity-configs -> teamcity-configs:generate),
 the 'Debug' option is available in the context menu for the task.
 */
 
-version = "2023.11"
+version = "2024.03"
 project(_Self.MainProject)


### PR DESCRIPTION
Fixes #1008 

# Description
For some of the build steps my personal access token is used.
This commit replaces those access tokens with the Deltares access tokens.

This has the benefit that:
-  the build don't rely on me renewing the tokens on time 
- templates using these tokens can be shared between teams

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
