### PR TITLE
Add support for discharge scaling in drainage package

### DIFF
--- a/imod/mf6/boundary_condition.py
+++ b/imod/mf6/boundary_condition.py
@@ -303,7 +303,7 @@ class BoundaryCondition(Package, abc.ABC):
         if hasattr(self, "_auxiliary_data"):
             result.extend(get_variable_names(self))
 
-        return result
+        return [var for var in result if var in self.dataset.data_vars]
 
 
 class AdvancedBoundaryCondition(BoundaryCondition, abc.ABC):

--- a/imod/templates/mf6/gwf-drn.j2
+++ b/imod/templates/mf6/gwf-drn.j2
@@ -3,6 +3,8 @@ begin options
 {% endif %}
 {%- if auxmultname is defined %}  auxmultname {{auxmultname}}
 {% endif %}
+{%- if auxdepthname is defined %}  auxdepthname {{auxdepthname}}
+{% endif %}
 {%- if boundnames is defined %}  boundnames
 {% endif %}
 {%- if print_input is defined %}  print_input


### PR DESCRIPTION
Fixes #1011

Still a draft, this adds the drainage discharge scaling depth.

This is a rather pragmatic approach. We're currently only using the auxiliary variables for concentration, which are treated separately. The `_auxiliary_data = {"concentration": "species"}` cannot be meaningfully used, since this specific `scaling_depth` does not contain any additional dimensions.

Adding it to `period_data` ensures that it is written to the data files, but since it's optional, the presences must then be checked in `get_period_names`.
