### PR TITLE
Issue #1020 add allocation first active to elevation

### DIFF
--- a/imod/prepare/topsystem/allocation.py
+++ b/imod/prepare/topsystem/allocation.py
@@ -27,7 +27,7 @@ class ALLOCATION_OPTION(Enum):
     * ``first_active_to_elevation``: RIV, DRN, GHB. Allocate cells spanning from
       first upper active cell up to the river bottom elevation. This matches the
       iMOD 5.6 IDEFLAYER = -1 option.
-    * ``first_active_to_riv_bot__drn``: RIV. Allocate cells spanning from first
+    * ``stage_to_riv_bot_drn_above``: RIV. Allocate cells spanning from first
       upper active cell up to the river bottom elevation. Method returns both
       allocated cells for a river package as well as a drain package. Cells
       above river stage are allocated as drain cells, cells below are as river
@@ -49,7 +49,7 @@ class ALLOCATION_OPTION(Enum):
 
     stage_to_riv_bot = 0
     first_active_to_elevation = -1
-    first_active_to_riv_bot__drn = 1
+    stage_to_riv_bot_drn_above = 1
     at_elevation = 2
     at_first_active = 9  # Not an iMOD 5.6 option
 
@@ -116,8 +116,8 @@ def allocate_riv_cells(
             return _allocate_cells__first_active_to_elevation(
                 active, top, bottom, bottom_elevation
             )
-        case ALLOCATION_OPTION.first_active_to_riv_bot__drn:
-            return _allocate_cells__first_active_to_riv_bot__drn(
+        case ALLOCATION_OPTION.stage_to_riv_bot_drn_above:
+            return _allocate_cells__stage_to_riv_bot_drn_above(
                 active, top, bottom, stage, bottom_elevation
             )
         case ALLOCATION_OPTION.at_elevation:
@@ -129,7 +129,7 @@ def allocate_riv_cells(
                 "Received incompatible setting for rivers, only"
                 f"'{ALLOCATION_OPTION.stage_to_riv_bot.name}' and"
                 f"'{ALLOCATION_OPTION.first_active_to_elevation.name}' and"
-                f"'{ALLOCATION_OPTION.first_active_to_riv_bot__drn.name}' and"
+                f"'{ALLOCATION_OPTION.stage_to_riv_bot_drn_above.name}' and"
                 f"'{ALLOCATION_OPTION.at_elevation.name}' and"
                 f"'{ALLOCATION_OPTION.at_first_active.name}' supported."
                 f"got: '{allocation_option.name}'"
@@ -394,7 +394,7 @@ def _allocate_cells__first_active_to_elevation(
 
 
 @enforced_dim_order
-def _allocate_cells__first_active_to_riv_bot__drn(
+def _allocate_cells__stage_to_riv_bot_drn_above(
     active: GridDataArray,
     top: GridDataArray,
     bottom: GridDataArray,

--- a/imod/tests/test_prepare/test_topsystem.py
+++ b/imod/tests/test_prepare/test_topsystem.py
@@ -31,6 +31,9 @@ def take_nth_layer_column(grid: GridDataArray, n: int) -> GridDataArray:
     DataArray | UgridDataArray
         Column along the layer dimension at the nth cell in the xy plane.
     """
+    if "time" in grid.dims:
+        grid = grid.isel(time=-1)
+
     if is_unstructured(grid):
         return grid.values[:, n]
     else:

--- a/imod/tests/test_prepare/test_topsystem_cases.py
+++ b/imod/tests/test_prepare/test_topsystem_cases.py
@@ -163,7 +163,7 @@ def distribution_by_corrected_transmissivity__drn():
     allocated_layer = xr.DataArray(
         [False, True, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [np.nan, (16/17), (1/17), np.nan]
+    expected = [np.nan, (16 / 17), (1 / 17), np.nan]
     return option, allocated_layer, expected
 
 
@@ -174,7 +174,7 @@ def distribution_by_corrected_transmissivity__first_active__drn():
     allocated_layer = xr.DataArray(
         [True, True, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [(8 / 25), (16 / 25), (1/25), np.nan]
+    expected = [(8 / 25), (16 / 25), (1 / 25), np.nan]
     return option, allocated_layer, expected
 
 
@@ -184,7 +184,7 @@ def distribution_by_corrected_transmissivity__TFTF__drn():
     allocated_layer = xr.DataArray(
         [True, False, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [(8/9), np.nan, (1/9), np.nan]
+    expected = [(8 / 9), np.nan, (1 / 9), np.nan]
     return option, allocated_layer, expected
 
 
@@ -237,7 +237,7 @@ def distribution_by_crosscut_transmissivity__drn():
     allocated_layer = xr.DataArray(
         [False, True, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [np.nan, (4/5), (1/5), np.nan]
+    expected = [np.nan, (4 / 5), (1 / 5), np.nan]
     return option, allocated_layer, expected
 
 
@@ -248,7 +248,7 @@ def distribution_by_crosscut_transmissivity__first_active__drn():
     allocated_layer = xr.DataArray(
         [True, True, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [(2/7), (4/7), (1/7), np.nan]
+    expected = [(2 / 7), (4 / 7), (1 / 7), np.nan]
     return option, allocated_layer, expected
 
 
@@ -259,7 +259,7 @@ def distribution_by_crosscut_transmissivity__TFTF__drn():
     allocated_layer = xr.DataArray(
         [True, False, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [(2/3), np.nan, (1/3), np.nan]
+    expected = [(2 / 3), np.nan, (1 / 3), np.nan]
     return option, allocated_layer, expected
 
 
@@ -312,7 +312,7 @@ def distribution_by_crosscut_thickness__drn():
     allocated_layer = xr.DataArray(
         [False, True, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [np.nan, (2/3), (1/3), np.nan]
+    expected = [np.nan, (2 / 3), (1 / 3), np.nan]
     return option, allocated_layer, expected
 
 

--- a/imod/tests/test_prepare/test_topsystem_cases.py
+++ b/imod/tests/test_prepare/test_topsystem_cases.py
@@ -91,8 +91,8 @@ def allocation_first_active_to_elevation():
 
 
 @case(tags=["riv"])
-def allocation_first_active_to_riv_bot__drn():
-    option = ALLOCATION_OPTION.first_active_to_riv_bot__drn
+def allocation_stage_to_riv_bot_drn_above():
+    option = ALLOCATION_OPTION.stage_to_riv_bot_drn_above
     expected = [False, True, True, False]
     expected__drn = [True, False, False, False]
 

--- a/imod/tests/test_prepare/test_topsystem_cases.py
+++ b/imod/tests/test_prepare/test_topsystem_cases.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 import xarray as xr
 from pytest_cases import case
 
@@ -11,7 +10,14 @@ from imod.typing.grid import zeros_like
 
 
 def time_da():
-    time_ls = [np.datetime64(t) for t in ["2000-01-01", "2000-01-02", "2000-01-03",]]
+    time_ls = [
+        np.datetime64(t)
+        for t in [
+            "2000-01-01",
+            "2000-01-02",
+            "2000-01-03",
+        ]
+    ]
     return xr.DataArray([1.0, 1.0, 1.0], coords={"time": time_ls}, dims=("time",))
 
 

--- a/imod/tests/test_prepare/test_topsystem_cases.py
+++ b/imod/tests/test_prepare/test_topsystem_cases.py
@@ -32,7 +32,7 @@ def drn_structured(basic_dis__topsystem):
     ibound, top, bottom = basic_dis__topsystem
     top = top.sel(layer=1)
     elevation = zeros_like(ibound.sel(layer=1))
-    drain_elevation = elevation - 2.0
+    drain_elevation = elevation - 4.0
     active = ibound == 1
     return active, top, bottom, drain_elevation
 
@@ -40,7 +40,7 @@ def drn_structured(basic_dis__topsystem):
 def drn_unstructured(basic_disv__topsystem):
     ibound, top, bottom = basic_disv__topsystem
     elevation = zeros_like(ibound.sel(layer=1))
-    drain_elevation = elevation - 2.0
+    drain_elevation = elevation - 4.0
     active = ibound == 1
     return active, top, bottom, drain_elevation
 
@@ -49,7 +49,7 @@ def ghb_structured(basic_dis__topsystem):
     ibound, top, bottom = basic_dis__topsystem
     top = top.sel(layer=1)
     elevation = zeros_like(ibound.sel(layer=1))
-    head = elevation - 2.0
+    head = elevation - 4.0
     active = ibound == 1
     return active, top, bottom, head
 
@@ -57,7 +57,7 @@ def ghb_structured(basic_dis__topsystem):
 def ghb_unstructured(basic_disv__topsystem):
     ibound, top, bottom = basic_disv__topsystem
     elevation = zeros_like(ibound.sel(layer=1))
-    head = elevation - 2.0
+    head = elevation - 4.0
     active = ibound == 1
     return active, top, bottom, head
 
@@ -82,9 +82,9 @@ def allocation_stage_to_riv_bot():
     return option, expected, None
 
 
-@case(tags=["riv"])
-def allocation_first_active_to_riv_bot():
-    option = ALLOCATION_OPTION.first_active_to_riv_bot
+@case(tags=["riv", "drn", "ghb"])
+def allocation_first_active_to_elevation():
+    option = ALLOCATION_OPTION.first_active_to_elevation
     expected = [True, True, True, False]
 
     return option, expected, None
@@ -99,16 +99,8 @@ def allocation_first_active_to_riv_bot__drn():
     return option, expected, expected__drn
 
 
-@case(tags=["drn", "ghb"])
+@case(tags=["drn", "ghb", "riv"])
 def allocation_at_elevation():
-    option = ALLOCATION_OPTION.at_elevation
-    expected = [False, True, False, False]
-
-    return option, expected, None
-
-
-@case(tags=["riv"])
-def allocation_at_riv_bottom_elevation():
     option = ALLOCATION_OPTION.at_elevation
     expected = [False, False, True, False]
 
@@ -144,7 +136,7 @@ def distribution_by_corrected_transmissivity__first_active():
     return option, allocated_layer, expected
 
 
-@case(tags=["riv"])
+@case(tags=["riv", "drn"])
 def distribution_by_corrected_transmissivity__third_only():
     """Third layer active only, while stage in second layer"""
     option = DISTRIBUTING_OPTION.by_corrected_transmissivity
@@ -171,30 +163,18 @@ def distribution_by_corrected_transmissivity__drn():
     allocated_layer = xr.DataArray(
         [False, True, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [np.nan, 1.0, 0.0, np.nan]
+    expected = [np.nan, (16/17), (1/17), np.nan]
     return option, allocated_layer, expected
 
 
 @case(tags=["drn"])
 def distribution_by_corrected_transmissivity__first_active__drn():
-    """First active cell allocated, while stage in second layer"""
+    """First active cell allocated, while drain in third layer"""
     option = DISTRIBUTING_OPTION.by_corrected_transmissivity
     allocated_layer = xr.DataArray(
         [True, True, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [(2 / 3), (1 / 3), 0.0, np.nan]
-    return option, allocated_layer, expected
-
-
-@case(tags=["drn"])
-def distribution_by_corrected_transmissivity__third_only__drn():
-    """Third layer active only, while stage in second layer"""
-    option = DISTRIBUTING_OPTION.by_corrected_transmissivity
-    allocated_layer = xr.DataArray(
-        [False, False, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
-    )
-    # xarray turns 0.0 / 0.0 into np.nan, so third element should also be np.nan
-    expected = [np.nan, np.nan, np.nan, np.nan]
+    expected = [(8 / 25), (16 / 25), (1/25), np.nan]
     return option, allocated_layer, expected
 
 
@@ -204,7 +184,7 @@ def distribution_by_corrected_transmissivity__TFTF__drn():
     allocated_layer = xr.DataArray(
         [True, False, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [1.0, np.nan, 0.0, np.nan]
+    expected = [(8/9), np.nan, (1/9), np.nan]
     return option, allocated_layer, expected
 
 
@@ -229,7 +209,7 @@ def distribution_by_crosscut_transmissivity__first_active():
     return option, allocated_layer, expected
 
 
-@case(tags=["riv"])
+@case(tags=["riv", "drn"])
 def distribution_by_crosscut_transmissivity__third_only():
     """Third layer active only, while stage in second layer"""
     option = DISTRIBUTING_OPTION.by_crosscut_transmissivity
@@ -257,41 +237,29 @@ def distribution_by_crosscut_transmissivity__drn():
     allocated_layer = xr.DataArray(
         [False, True, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [np.nan, 1.0, 0.0, np.nan]
+    expected = [np.nan, (4/5), (1/5), np.nan]
     return option, allocated_layer, expected
 
 
 @case(tags=["drn"])
 def distribution_by_crosscut_transmissivity__first_active__drn():
-    """First active cell allocated, while drain elevation in second layer"""
+    """First active cell allocated, while drain elevation in third layer"""
     option = DISTRIBUTING_OPTION.by_crosscut_transmissivity
     allocated_layer = xr.DataArray(
         [True, True, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [0.5, 0.5, 0.0, np.nan]
-    return option, allocated_layer, expected
-
-
-@case(tags=["drn"])
-def distribution_by_crosscut_transmissivity__third_only__drn():
-    """Third layer active only, while drain elevation in second layer"""
-    option = DISTRIBUTING_OPTION.by_crosscut_transmissivity
-    allocated_layer = xr.DataArray(
-        [False, False, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
-    )
-    # xarray turns 0.0 / 0.0 into np.nan, so third element should also be np.nan
-    expected = [np.nan, np.nan, np.nan, np.nan]
+    expected = [(2/7), (4/7), (1/7), np.nan]
     return option, allocated_layer, expected
 
 
 @case(tags=["drn"])
 def distribution_by_crosscut_transmissivity__TFTF__drn():
-    """First and third layer active, while drain elevation in second layer"""
+    """First and third layer active, while drain elevation in third layer"""
     option = DISTRIBUTING_OPTION.by_crosscut_transmissivity
     allocated_layer = xr.DataArray(
         [True, False, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [1.0, np.nan, 0.0, np.nan]
+    expected = [(2/3), np.nan, (1/3), np.nan]
     return option, allocated_layer, expected
 
 
@@ -316,7 +284,7 @@ def distribution_by_crosscut_thickness__first_active():
     return option, allocated_layer, expected
 
 
-@case(tags=["riv"])
+@case(tags=["riv", "drn"])
 def distribution_by_crosscut_thickness__third_only():
     """Third layer active only, while stage in second layer"""
     option = DISTRIBUTING_OPTION.by_crosscut_thickness
@@ -344,7 +312,7 @@ def distribution_by_crosscut_thickness__drn():
     allocated_layer = xr.DataArray(
         [False, True, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [np.nan, 1.0, 0.0, np.nan]
+    expected = [np.nan, (2/3), (1/3), np.nan]
     return option, allocated_layer, expected
 
 
@@ -355,19 +323,7 @@ def distribution_by_crosscut_thickness__first_active__drn():
     allocated_layer = xr.DataArray(
         [True, True, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [0.5, 0.5, 0.0, np.nan]
-    return option, allocated_layer, expected
-
-
-@case(tags=["drn"])
-def distribution_by_crosscut_thickness__third_only__drn():
-    """Third layer active only, while drain elevation in second layer"""
-    option = DISTRIBUTING_OPTION.by_crosscut_thickness
-    allocated_layer = xr.DataArray(
-        [False, False, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
-    )
-    # xarray turns 0.0 / 0.0 into np.nan, so third element should also be np.nan
-    expected = [np.nan, np.nan, np.nan, np.nan]
+    expected = [0.25, 0.5, 0.25, np.nan]
     return option, allocated_layer, expected
 
 
@@ -378,7 +334,7 @@ def distribution_by_crosscut_thickness__TFTF__drn():
     allocated_layer = xr.DataArray(
         [True, False, True, False], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
     )
-    expected = [1.0, np.nan, 0.0, np.nan]
+    expected = [0.5, np.nan, 0.5, np.nan]
     return option, allocated_layer, expected
 
 


### PR DESCRIPTION
Fixes #1020 

# Description
- Renames ``first_active_to_riv_bot__drn`` to ``stage_to_riv_bot_drn_above``
- Renames ``first_active_to_riv_bot`` to ``first_active_to_elevation``
- Update test cases to let drain elevation and ghb head match riv bottom elevation, in this way more some test cases can be removed
- Update drn expected results for conductance distribution where the change in drain elevation resulted in differences (crosscut and corrected variants mainly).

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
