### PR TITLE
Issue #828 attributes gdal

### DIFF
--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -308,13 +308,14 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
             dataset = pkg.dataset
             if isinstance(dataset, xu.UgridDataset):
                 if mdal_compliant:
-                    dataset = pkg.dataset.ugrid.to_dataset()
+                    dataset = dataset.ugrid.to_dataset()
                     mdal_dataset = imod.util.spatial.mdal_compliant_ugrid2d(dataset)
                     mdal_dataset.to_netcdf(modeldirectory / pkg_path)
                 else:
-                    pkg.dataset.ugrid.to_netcdf(modeldirectory / pkg_path)
+                    dataset.ugrid.to_netcdf(modeldirectory / pkg_path)
             else:
-                pkg.to_netcdf(modeldirectory / pkg_path)
+                dataset = imod.util.spatial.gdal_compliant_grid(dataset)
+                dataset.to_netcdf(modeldirectory / pkg_path)
 
         toml_path = modeldirectory / f"{modelname}.toml"
         with open(toml_path, "wb") as f:

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -28,6 +28,7 @@ from imod.mf6.validation import pkg_errors_to_status_info
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.typing import GridDataArray
+from imod.typing.grid import is_spatial_2D
 
 
 class Modflow6Model(collections.UserDict, IModel, abc.ABC):
@@ -344,7 +345,8 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
                 else:
                     dataset.ugrid.to_netcdf(modeldirectory / pkg_path)
             else:
-                dataset = imod.util.spatial.gdal_compliant_grid(dataset, crs=crs)
+                if is_spatial_2D(dataset):
+                    dataset = imod.util.spatial.gdal_compliant_grid(dataset, crs=crs)
                 dataset.to_netcdf(modeldirectory / pkg_path)
 
         toml_path = modeldirectory / f"{modelname}.toml"

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+import rasterio
 import xarray as xr
 import xugrid as xu
 
@@ -51,6 +52,40 @@ def test_twri_disv_roundtrip(twri_disv_model, tmpdir_factory):
 @pytest.mark.usefixtures("circle_model")
 def test_circle_roundtrip(circle_model, tmpdir_factory):
     roundtrip(circle_model, tmpdir_factory, "circle")
+
+
+@pytest.mark.usefixtures("twri_model")
+def test_twri_gdal(twri_model, tmpdir_factory):
+    """
+    Test of dumping a structured model with a CRS results in the necessary
+    attributes for GDAL and a parsable CRS.
+    """
+    tmp_path = tmpdir_factory.mktemp("twri")
+    twri_model.dump(tmp_path, crs="EPSG:28992")
+    ds = xr.open_dataset(tmp_path / "GWF_1" / "dis.nc")
+    assert ds.coords["x"].attrs["axis"] == "X"
+    assert ds.coords["y"].attrs["axis"] == "Y"
+    # Convert long string with full description to EPSG code
+    crs = rasterio.CRS.from_string(ds["spatial_ref"].attrs["spatial_ref"])
+    assert crs == "EPSG:28992"
+
+
+@pytest.mark.usefixtures("twri_disv_model")
+def test_twri_disv_mdal_compliant_semi_roundtrip(twri_disv_model, tmpdir_factory):
+    """
+    Test if dumping an unstructured model with mdal_compliant=True also results
+    in a package written with a crs and unstacked layers, which can be stacked.
+    """
+    tmp_path = tmpdir_factory.mktemp("twri")
+    twri_disv_model.dump(tmp_path, crs="EPSG:28992", mdal_compliant=True)
+    ds = xu.open_dataset(tmp_path / "GWF_1" / "dis.nc")
+    assert len(ds.data_vars) == 7
+    # Convert long string with full description to EPSG code
+    crs = rasterio.CRS.from_string(ds.coords["spatial_ref"].attrs["spatial_ref"])
+    assert crs == "EPSG:28992"
+    # Test if running from_mdal_compliant stacks variables properly again.
+    ds = imod.util.spatial.from_mdal_compliant_ugrid2d(ds)
+    assert len(ds.data_vars) == 3
 
 
 @pytest.mark.usefixtures("circle_model")

--- a/imod/tests/test_util/test_util_spatial.py
+++ b/imod/tests/test_util/test_util_spatial.py
@@ -313,9 +313,10 @@ def test_gdal_compliant_grid():
     assert da_compliant.coords["y"].attrs["long_name"] == "y coordinate of projection"
     assert da_compliant.coords["y"].attrs["standard_name"] == "projection_y_coordinate"
 
+
 def test_gdal_compliant_grid_crs(tmpdir):
     import rioxarray
-    
+
     # Arrange
     data = np.ones((2, 3))
     # explicit dx dy, equidistant
@@ -330,7 +331,7 @@ def test_gdal_compliant_grid_crs(tmpdir):
 
     # Act
     da_compliant = imod.util.spatial.gdal_compliant_grid(da, crs="EPSG:28992")
-    
+
     # Assert
     assert "spatial_ref" in da_compliant.coords
 

--- a/imod/tests/test_util/test_util_spatial.py
+++ b/imod/tests/test_util/test_util_spatial.py
@@ -283,3 +283,18 @@ def test_to_ugrid2d(write=False):
 
     if write:
         uds.to_netcdf("ugrid-a3dt.nc")
+
+
+def test_gdal_compliant_grid():
+    data = np.ones((2, 3))
+    # explicit dx dy, equidistant
+    coords = {
+        "x": [0.5, 1.5, 2.5],
+        "y": [1.5, 0.5],
+        "dx": ("x", [1.0, 1.0, 1.0]),
+        "dy": ("y", [-1.0, -1.0]),
+    }
+    dims = ("y", "x")
+    da = xr.DataArray(data, coords, dims)
+
+    da_compliant = imod.util.spatial.gdal_compliant_grid(da)

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -243,7 +243,7 @@ def bounding_polygon(active: xu.UgridDataArray):  # noqa: F811
 
 
 @typedispatch  # type: ignore [no-redef]
-def is_spatial_2D(array: xr.DataArray) -> bool:
+def is_spatial_2D(array: xr.DataArray | xr.Dataset) -> bool:
     """Return True if the array contains data in at least 2 spatial dimensions"""
     coords = array.coords
     dims = array.dims
@@ -253,7 +253,7 @@ def is_spatial_2D(array: xr.DataArray) -> bool:
 
 
 @typedispatch  # type: ignore [no-redef]
-def is_spatial_2D(array: xu.UgridDataArray) -> bool:  # noqa: F811
+def is_spatial_2D(array: xu.UgridDataArray | xu.UgridDataset) -> bool:  # noqa: F811
     """Return True if the array contains data associated to cell faces"""
     face_dim = array.ugrid.grid.face_dimension
     dims = array.dims

--- a/imod/util/spatial.py
+++ b/imod/util/spatial.py
@@ -312,9 +312,7 @@ def mdal_compliant_ugrid2d(
                 attrs.pop("edge_node_connectivity")
 
     if crs is not None:
-        if isinstance(rioxarray, MissingOptionalModule):
-            raise ModuleNotFoundError("rioxarray is required for this functionality")
-        ds.rio.write_crs(crs, inplace=True)
+        ds.ugrid.grid.set_crs(crs=crs, allow_override=True)
 
     # Make sure time is encoded as a float for MDAL
     # TODO: MDAL requires all data variables to be float (this excludes the UGRID topology data)

--- a/imod/util/spatial.py
+++ b/imod/util/spatial.py
@@ -309,7 +309,7 @@ def mdal_compliant_ugrid2d(dataset: xr.Dataset) -> xr.Dataset:
     return ds
 
 
-def from_mdal_compliant_ugrid2d(dataset: xu.UgridDataset):
+def from_mdal_compliant_ugrid2d(dataset: xu.UgridDataset) -> xu.UgridDataset:
     """
     Undo some of the changes of ``mdal_compliant_ugrid2d``: re-stack the
     layers.
@@ -400,6 +400,28 @@ def to_ugrid2d(data: Union[xr.DataArray, xr.Dataset]) -> xr.Dataset:
         ds[data.name] = ugrid2d_data(data, grid.face_dimension)
     return mdal_compliant_ugrid2d(ds)
 
+
+def gdal_compliant_grid(
+    data: Union[xr.DataArray, xr.Dataset],
+) -> Union[xr.DataArray, xr.Dataset]:
+    """
+    
+    """
+    x_attrs = {
+        "axis": "X",
+        "long_name": "x coordinate of projection",
+        "standard_name": "projection_x_coordinate",
+    }
+    y_attrs = {
+        "axis": "Y",
+        "long_name": "y coordinate of projection",
+        "standard_name": "projection_y_coordinate",
+    }
+
+    x_coord_attrs = data.coords["x"].assign_attrs(x_attrs)
+    y_coord_attrs = data.coords["y"].assign_attrs(y_attrs)
+
+    return data.assign_coords(x=x_coord_attrs, y=y_coord_attrs)
 
 def empty_2d(
     dx: Union[float, FloatArray],

--- a/imod/util/spatial.py
+++ b/imod/util/spatial.py
@@ -312,7 +312,9 @@ def mdal_compliant_ugrid2d(
                 attrs.pop("edge_node_connectivity")
 
     if crs is not None:
-        ds.ugrid.grid.set_crs(crs=crs, allow_override=True)
+        if isinstance(rioxarray, MissingOptionalModule):
+            raise ModuleNotFoundError("rioxarray is required for this functionality")
+        ds.rio.write_crs(crs, inplace=True)
 
     # Make sure time is encoded as a float for MDAL
     # TODO: MDAL requires all data variables to be float (this excludes the UGRID topology data)

--- a/imod/util/spatial.py
+++ b/imod/util/spatial.py
@@ -454,6 +454,7 @@ def gdal_compliant_grid(
 
     return data_gdal
 
+
 def empty_2d(
     dx: Union[float, FloatArray],
     xmin: float,

--- a/imod/util/spatial.py
+++ b/imod/util/spatial.py
@@ -405,7 +405,13 @@ def gdal_compliant_grid(
     data: Union[xr.DataArray, xr.Dataset],
 ) -> Union[xr.DataArray, xr.Dataset]:
     """
-    
+    Assign attributes to x,y coordinates to make data accepted by GDAL.
+
+    Parameters
+    ----------
+    data: xr.DataArray | xr.Dataset
+        Structured data with a x and y coordinate.
+
     """
     x_attrs = {
         "axis": "X",
@@ -417,6 +423,12 @@ def gdal_compliant_grid(
         "long_name": "y coordinate of projection",
         "standard_name": "projection_y_coordinate",
     }
+
+    dims = set(data.dims)
+    missing_dims = {"x", "y"} - dims
+
+    if len(missing_dims) > 0:
+        raise ValueError(f"Missing dimensions: {missing_dims}")
 
     x_coord_attrs = data.coords["x"].assign_attrs(x_attrs)
     y_coord_attrs = data.coords["y"].assign_attrs(y_attrs)

--- a/imod/util/spatial.py
+++ b/imod/util/spatial.py
@@ -245,7 +245,9 @@ def unstack_dim_into_variable(dataset: GridDataset, dim: str) -> GridDataset:
     return unstacked
 
 
-def mdal_compliant_ugrid2d(dataset: xr.Dataset) -> xr.Dataset:
+def mdal_compliant_ugrid2d(
+    dataset: xr.Dataset, crs: Optional[Any] = None
+) -> xr.Dataset:
     """
     Ensures the xarray Dataset will be written to a UGRID netCDF that will be
     accepted by MDAL.
@@ -257,6 +259,10 @@ def mdal_compliant_ugrid2d(dataset: xr.Dataset) -> xr.Dataset:
     Parameters
     ----------
     dataset: xarray.Dataset
+        Dataset to make compliant with MDAL
+    crs: Any, Optional
+        Anything accepted by rasterio.crs.CRS.from_user_input
+        Requires ``rioxarray`` installed.
 
     Returns
     -------
@@ -304,6 +310,11 @@ def mdal_compliant_ugrid2d(dataset: xr.Dataset) -> xr.Dataset:
             edge_nodes = attrs.get("edge_node_connectivity")
             if edge_nodes and edge_nodes not in ds:
                 attrs.pop("edge_node_connectivity")
+
+    if crs is not None:
+        if isinstance(rioxarray, MissingOptionalModule):
+            raise ModuleNotFoundError("rioxarray is required for this functionality")
+        ds.rio.write_crs(crs, inplace=True)
 
     # Make sure time is encoded as a float for MDAL
     # TODO: MDAL requires all data variables to be float (this excludes the UGRID topology data)


### PR DESCRIPTION
Fixes #828 and #217

# Description
This PR adds the following things:
- Add ``gdal_compliant_grid`` utility function for structured grids, which sets the right attributes to spatial coordinates to make them interpretable by GDAL (and thus QGIS).
- Structured grids are automatically assigned these attributes when dumping to file.
- Add ``CRS`` argument to ``dump`` methods to ease loading data in QGIS
- Expose ``dump`` method in API docs (not really readable still due to [this issue](https://github.com/Deltares/imod-python/issues/1032))
- Add small example to FAQ "How-do-I"

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [x] **If feature added**: Added/extended example
