### PR TITLE
Issue #1034 Add Stricter MyPy settings

### DIFF
--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -408,11 +408,16 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
                 )
             )
 
-        barrier_dataset = to_connected_cells_dataset(idomain, unstructured_grid.ugrid.grid, edge_index,
-                {
-                    "hydraulic_characteristic": self.__to_hydraulic_characteristic(barrier_values)
-                },
-            )
+        barrier_dataset = to_connected_cells_dataset(
+            idomain,
+            unstructured_grid.ugrid.grid,
+            edge_index,
+            {
+                "hydraulic_characteristic": self.__to_hydraulic_characteristic(
+                    barrier_values
+                )
+            },
+        )
 
         barrier_dataset["print_input"] = self.dataset["print_input"]
 

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -37,7 +37,7 @@ except ImportError:
     shapely = MissingOptionalModule("shapely")
 
 
-@typedispatch  # type: ignore[no-redef]
+@typedispatch
 def _derive_connected_cell_ids(
     idomain: xr.DataArray, grid: xu.Ugrid2d, edge_index: np.ndarray
 ):
@@ -408,19 +408,11 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
                 )
             )
 
-        barrier_dataset = typing.cast(
-            xr.Dataset,
-            to_connected_cells_dataset(
-                idomain,
-                unstructured_grid.ugrid.grid,
-                edge_index,
+        barrier_dataset = to_connected_cells_dataset(idomain, unstructured_grid.ugrid.grid, edge_index,
                 {
-                    "hydraulic_characteristic": self.__to_hydraulic_characteristic(
-                        barrier_values
-                    )
+                    "hydraulic_characteristic": self.__to_hydraulic_characteristic(barrier_values)
                 },
-            ),
-        )
+            )
 
         barrier_dataset["print_input"] = self.dataset["print_input"]
 
@@ -505,9 +497,9 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
     def __to_resistance(self, value: xu.UgridDataArray) -> xu.UgridDataArray:
         match self._get_barrier_type():
             case BarrierType.HydraulicCharacteristic:
-                return 1.0 / value  # type: ignore
+                return 1.0 / value
             case BarrierType.Multiplier:
-                return -1.0 / value  # type: ignore
+                return -1.0 / value
             case BarrierType.Resistance:
                 return value
 

--- a/imod/mf6/multimodel/partition_generator.py
+++ b/imod/mf6/multimodel/partition_generator.py
@@ -31,7 +31,7 @@ def get_label_array(simulation: Modflow6Simulation, npartitions: int) -> GridDat
     return _partition_idomain(idomain_top, npartitions)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def _partition_idomain(
     idomain_grid: xu.UgridDataArray, npartitions: int
 ) -> GridDataArray:
@@ -43,7 +43,7 @@ def _partition_idomain(
     return labels
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def _partition_idomain(idomain_grid: xr.DataArray, npartitions: int) -> GridDataArray:
     """
     Create a label array for structured grids by creating rectangular

--- a/imod/mf6/utilities/clip.py
+++ b/imod/mf6/utilities/clip.py
@@ -21,14 +21,14 @@ except ImportError:
     shapely = MissingOptionalModule("shapely")
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def clip_by_grid(_: object, grid: object) -> None:
     raise TypeError(
         f"'grid' should be of type xr.DataArray, xu.Ugrid2d or xu.UgridDataArray, got {type(grid)}"
     )
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def clip_by_grid(package: IPackageBase, active: xr.DataArray) -> IPackageBase:  # noqa: F811
     domain_slice = get_active_domain_slice(active)
     x_min, x_max = domain_slice["x"].start, domain_slice["x"].stop
@@ -43,7 +43,7 @@ def clip_by_grid(package: IPackageBase, active: xr.DataArray) -> IPackageBase:  
     return clipped_package
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def clip_by_grid(package: IPackageBase, active: xu.UgridDataArray) -> IPackageBase:  # noqa: F811
     domain_slice = get_active_domain_slice(active)
 
@@ -55,7 +55,7 @@ def clip_by_grid(package: IPackageBase, active: xu.UgridDataArray) -> IPackageBa
     return new
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def clip_by_grid(  # noqa: F811
     package: IPointDataPackage, active: xu.UgridDataArray
 ) -> IPointDataPackage:
@@ -92,7 +92,7 @@ def _filter_inactive_cells(package, active):
                 )
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def clip_by_grid(package: ILineDataPackage, active: GridDataArray) -> ILineDataPackage:  # noqa: F811
     """Clip LineDataPackage outside unstructured/structured grid."""
 

--- a/imod/mf6/utilities/mask.py
+++ b/imod/mf6/utilities/mask.py
@@ -85,7 +85,7 @@ def _skip_dataarray(da: GridDataArray) -> bool:
     return False
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def _skip_variable(package: IPackage, var: str) -> bool:
     return False
 

--- a/imod/mf6/utilities/regrid.py
+++ b/imod/mf6/utilities/regrid.py
@@ -209,7 +209,7 @@ def _get_unique_regridder_types(model: IModel) -> defaultdict[RegridderType, lis
     return methods
 
 
-@typedispatch  # type: ignore[no-redef]
+@typedispatch
 def _regrid_like(
     package: IRegridPackage,
     target_grid: GridDataArray,

--- a/imod/select/grid.py
+++ b/imod/select/grid.py
@@ -15,7 +15,7 @@ def _reduce_grid_except_dims(
     grid: GridDataArray, preserve_dims: List[str]
 ) -> GridDataArray:
     to_reduce = {dim: 0 for dim in grid.dims if dim not in preserve_dims}
-    return grid.isel(**to_reduce)  # type: ignore [no-untyped-call, misc, arg-type]
+    return grid.isel(**to_reduce)  # type: ignore [misc, arg-type]
 
 
 def _validate_grid(grid):

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -11,42 +11,42 @@ from imod.typing import GridDataArray, GridDataset, structured
 from imod.util.spatial import _polygonize
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def zeros_like(grid: xr.DataArray, *args, **kwargs):
     return xr.zeros_like(grid, *args, **kwargs)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def zeros_like(grid: xu.UgridDataArray, *args, **kwargs):  # noqa: F811
     return xu.zeros_like(grid, *args, **kwargs)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def ones_like(grid: xr.DataArray, *args, **kwargs):
     return xr.ones_like(grid, *args, **kwargs)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def ones_like(grid: xu.UgridDataArray, *args, **kwargs):  # noqa: F811
     return xu.ones_like(grid, *args, **kwargs)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def nan_like(grid: xr.DataArray, dtype=np.float32, *args, **kwargs):
     return xr.full_like(grid, fill_value=np.nan, dtype=dtype, *args, **kwargs)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def nan_like(grid: xu.UgridDataArray, dtype=np.float32, *args, **kwargs):  # noqa: F811
     return xu.full_like(grid, fill_value=np.nan, dtype=dtype, *args, **kwargs)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def is_unstructured(grid: xu.UgridDataArray | xu.UgridDataset) -> bool:
     return True
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def is_unstructured(grid: xr.DataArray | xr.Dataset) -> bool:  # noqa: F811
     return False
 
@@ -69,11 +69,11 @@ def _get_first_item(objects: Sequence):
 # Typedispatching doesn't work based on types of list elements, therefore resort to
 # isinstance testing
 def _type_dispatch_functions_on_grid_sequence(
-    objects: Sequence[GridDataArray | GridDataset],
-    unstructured_func: Callable,
-    structured_func: Callable,
-    *args,
-    **kwargs,
+        objects: Sequence[GridDataArray | GridDataset],
+        unstructured_func: Callable,
+        structured_func: Callable,
+        *args,
+        **kwargs,
 ) -> GridDataArray | GridDataset:
     """
     Type dispatch functions on sequence of grids. Functions like merging or concatenating.
@@ -98,11 +98,11 @@ def _type_dispatch_functions_on_grid_sequence(
 # Typedispatching doesn't work based on types of dict elements, therefore resort
 # to manual type testing
 def _type_dispatch_functions_on_dict(
-    dict_of_objects: Mapping[str, GridDataArray | float | bool | int],
-    unstructured_func: Callable,
-    structured_func: Callable,
-    *args,
-    **kwargs,
+        dict_of_objects: Mapping[str, GridDataArray | float | bool | int],
+        unstructured_func: Callable,
+        structured_func: Callable,
+        *args,
+        **kwargs,
 ):
     """
     Typedispatch function on grid and scalar variables provided in dictionary.
@@ -138,7 +138,7 @@ def _type_dispatch_functions_on_dict(
 
 
 def merge(
-    objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
+        objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
 ) -> GridDataset:
     return _type_dispatch_functions_on_grid_sequence(
         objects, xu.merge, xr.merge, *args, **kwargs
@@ -146,7 +146,7 @@ def merge(
 
 
 def merge_partitions(
-    objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
+        objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
 ) -> GridDataArray | GridDataset:
     return _type_dispatch_functions_on_grid_sequence(
         objects, xu.merge_partitions, structured.merge_partitions, *args, **kwargs
@@ -154,7 +154,7 @@ def merge_partitions(
 
 
 def concat(
-    objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
+        objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
 ) -> GridDataArray | GridDataset:
     return _type_dispatch_functions_on_grid_sequence(
         objects, xu.concat, xr.concat, *args, **kwargs
@@ -213,16 +213,16 @@ def merge_unstructured_dataset(variables_to_merge: list[dict], *args, **kwargs):
 
 
 def merge_with_dictionary(
-    variables_to_merge: Mapping[str, GridDataArray | float | bool | int],
-    *args,
-    **kwargs,
+        variables_to_merge: Mapping[str, GridDataArray | float | bool | int],
+        *args,
+        **kwargs,
 ):
     return _type_dispatch_functions_on_dict(
         variables_to_merge, merge_unstructured_dataset, xr.merge, *args, **kwargs
     )
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def bounding_polygon(active: xr.DataArray):
     """Return bounding polygon of active cells"""
     to_polygonize = active.where(active, other=np.nan)
@@ -232,7 +232,7 @@ def bounding_polygon(active: xr.DataArray):
     return polygons_gdf.loc[is_active_polygon]
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def bounding_polygon(active: xu.UgridDataArray):  # noqa: F811
     """Return bounding polygon of active cells"""
     active_indices = np.where(active > 0)[0]
@@ -242,7 +242,7 @@ def bounding_polygon(active: xu.UgridDataArray):  # noqa: F811
     return active_clipped.ugrid.grid.bounding_polygon()
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def is_spatial_2D(array: xr.DataArray) -> bool:
     """Return True if the array contains data in at least 2 spatial dimensions"""
     coords = array.coords
@@ -252,7 +252,7 @@ def is_spatial_2D(array: xr.DataArray) -> bool:
     return has_spatial_coords & has_spatial_dims
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def is_spatial_2D(array: xu.UgridDataArray) -> bool:  # noqa: F811
     """Return True if the array contains data associated to cell faces"""
     face_dim = array.ugrid.grid.face_dimension
@@ -263,67 +263,67 @@ def is_spatial_2D(array: xu.UgridDataArray) -> bool:  # noqa: F811
     return has_spatial_dims & has_spatial_coords
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def is_spatial_2D(_: object) -> bool:  # noqa: F811
     return False
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def is_equal(array1: xu.UgridDataArray, array2: xu.UgridDataArray) -> bool:
     return array1.equals(array2) and array1.ugrid.grid.equals(array2.ugrid.grid)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def is_equal(array1: xr.DataArray, array2: xr.DataArray) -> bool:  # noqa: F811
     return array1.equals(array2)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def is_equal(array1: object, array2: object) -> bool:  # noqa: F811
     return False
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def is_same_domain(grid1: xu.UgridDataArray, grid2: xu.UgridDataArray) -> bool:
     return grid1.coords.equals(grid2.coords) and grid1.ugrid.grid.equals(
         grid2.ugrid.grid
     )
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def is_same_domain(grid1: xr.DataArray, grid2: xr.DataArray) -> bool:  # noqa: F811
     return grid1.coords.equals(grid2.coords)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def is_same_domain(grid1: object, grid2: object) -> bool:  # noqa: F811
     return False
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def get_spatial_dimension_names(grid: xr.DataArray) -> list[str]:
     return ["x", "y", "layer", "dx", "dy"]
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def get_spatial_dimension_names(grid: xu.UgridDataArray) -> list[str]:  # noqa: F811
     facedim = grid.ugrid.grid.face_dimension
     return [facedim, "layer"]
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def get_spatial_dimension_names(grid: object) -> list[str]:  # noqa: F811
     return []
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def get_grid_geometry_hash(grid: xr.DataArray) -> int:
     hash_x = hash(pickle.dumps(grid["x"].values))
     hash_y = hash(pickle.dumps(grid["y"].values))
     return (hash_x, hash_y)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def get_grid_geometry_hash(grid: xu.UgridDataArray) -> int:  # noqa: F811
     hash_x = hash(pickle.dumps(grid.ugrid.grid.node_x))
     hash_y = hash(pickle.dumps(grid.ugrid.grid.node_y))
@@ -331,18 +331,18 @@ def get_grid_geometry_hash(grid: xu.UgridDataArray) -> int:  # noqa: F811
     return (hash_x, hash_y, hash_connectivity)
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def get_grid_geometry_hash(grid: object) -> int:  # noqa: F811
     raise ValueError("get_grid_geometry_hash not supported for this object.")
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch
 def enforce_dim_order(grid: xr.DataArray) -> xr.DataArray:
     """Enforce dimension order to iMOD Python standard"""
     return grid.transpose("species", "time", "layer", "y", "x", missing_dims="ignore")
 
 
-@typedispatch  # type: ignore [no-redef]
+@typedispatch  # type: ignore[no-redef]
 def enforce_dim_order(grid: xu.UgridDataArray) -> xu.UgridDataArray:  # noqa: F811
     """Enforce dimension order to iMOD Python standard"""
     face_dimension = grid.ugrid.grid.face_dimension

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -69,11 +69,11 @@ def _get_first_item(objects: Sequence):
 # Typedispatching doesn't work based on types of list elements, therefore resort to
 # isinstance testing
 def _type_dispatch_functions_on_grid_sequence(
-        objects: Sequence[GridDataArray | GridDataset],
-        unstructured_func: Callable,
-        structured_func: Callable,
-        *args,
-        **kwargs,
+    objects: Sequence[GridDataArray | GridDataset],
+    unstructured_func: Callable,
+    structured_func: Callable,
+    *args,
+    **kwargs,
 ) -> GridDataArray | GridDataset:
     """
     Type dispatch functions on sequence of grids. Functions like merging or concatenating.
@@ -98,11 +98,11 @@ def _type_dispatch_functions_on_grid_sequence(
 # Typedispatching doesn't work based on types of dict elements, therefore resort
 # to manual type testing
 def _type_dispatch_functions_on_dict(
-        dict_of_objects: Mapping[str, GridDataArray | float | bool | int],
-        unstructured_func: Callable,
-        structured_func: Callable,
-        *args,
-        **kwargs,
+    dict_of_objects: Mapping[str, GridDataArray | float | bool | int],
+    unstructured_func: Callable,
+    structured_func: Callable,
+    *args,
+    **kwargs,
 ):
     """
     Typedispatch function on grid and scalar variables provided in dictionary.
@@ -138,7 +138,7 @@ def _type_dispatch_functions_on_dict(
 
 
 def merge(
-        objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
+    objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
 ) -> GridDataset:
     return _type_dispatch_functions_on_grid_sequence(
         objects, xu.merge, xr.merge, *args, **kwargs
@@ -146,7 +146,7 @@ def merge(
 
 
 def merge_partitions(
-        objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
+    objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
 ) -> GridDataArray | GridDataset:
     return _type_dispatch_functions_on_grid_sequence(
         objects, xu.merge_partitions, structured.merge_partitions, *args, **kwargs
@@ -154,7 +154,7 @@ def merge_partitions(
 
 
 def concat(
-        objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
+    objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
 ) -> GridDataArray | GridDataset:
     return _type_dispatch_functions_on_grid_sequence(
         objects, xu.concat, xr.concat, *args, **kwargs
@@ -213,9 +213,9 @@ def merge_unstructured_dataset(variables_to_merge: list[dict], *args, **kwargs):
 
 
 def merge_with_dictionary(
-        variables_to_merge: Mapping[str, GridDataArray | float | bool | int],
-        *args,
-        **kwargs,
+    variables_to_merge: Mapping[str, GridDataArray | float | bool | int],
+    *args,
+    **kwargs,
 ):
     return _type_dispatch_functions_on_dict(
         variables_to_merge, merge_unstructured_dataset, xr.merge, *args, **kwargs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,12 +104,27 @@ files = [
     "imod/typing/**/**.py",
     "imod/util/**/**.py",
 ]
-follow_imports = "silent"
-warn_unused_configs = true
-
-[[tool.mypy.overrides]]
-module = ['mf6', 'logging']
 follow_imports = "normal"
+strict = true
+
+# Strongly recommend enabling this one as soon as you can
+check_untyped_defs = false
+
+# These shouldn't be too much additional work, but may be tricky to
+# get passing if you use a lot of untyped libraries
+disallow_untyped_decorators = false
+disallow_any_generics = false
+
+# These next few are various gradations of forcing use of type annotations
+disallow_untyped_calls = false
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+
+# This one isn't too hard to get passing, but return on investment is lower
+no_implicit_reexport = false
+
+# This one can be tricky to get passing if you use a lot of untyped libraries
+warn_return_any = false
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
Fixes #1034

# Description
This commit adds the MyPy stricter setting to the PyProject.toml file and also fixes some more MyPy errors.

The result of this settings is that instead of rules being disabled by default we know have to disable them explicitly.
This make it visible which rules we are not applying and we still need to fix. 

The ideal situation would be to have no mypy rules at all in tjhe project files which means we are using complying to all MyPy rules.
The road to MyPy strict settings is described by  https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
