### PR TITLE
Issue #1032 preserve docstring autodoc

### DIFF
--- a/imod/logging/logging_decorators.py
+++ b/imod/logging/logging_decorators.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from time import time
 
 from imod.logging.loglevel import LogLevel
@@ -11,6 +12,7 @@ def standard_log_decorator(
     """
 
     def decorator(fun):
+        @wraps(fun)
         def wrapper(*args, **kwargs):
             from imod.logging import logger
 
@@ -44,6 +46,7 @@ def init_log_decorator(
     """
 
     def decorator(fun):
+        @wraps(fun)
         def wrapper(*args, **kwargs):
             from imod.logging import logger
 

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -1,5 +1,6 @@
 import pickle
 import textwrap
+from functools import wraps
 from typing import Callable, Mapping, Sequence
 
 import numpy as np
@@ -369,7 +370,7 @@ def preserve_gridtype(func):
     >>> UgridDataArray() * DataArray() -> UgridDataArray
     >>> DataArray() * UgridDataArray() -> UgridDataArray
     """
-
+    @wraps(func)
     def decorator(*args, **kwargs):
         unstructured = False
         grid = None

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -370,6 +370,7 @@ def preserve_gridtype(func):
     >>> UgridDataArray() * DataArray() -> UgridDataArray
     >>> DataArray() * UgridDataArray() -> UgridDataArray
     """
+
     @wraps(func)
     def decorator(*args, **kwargs):
         unstructured = False

--- a/imod/util/dims.py
+++ b/imod/util/dims.py
@@ -5,6 +5,7 @@ from imod.typing.grid import enforce_dim_order
 
 def enforced_dim_order(func):
     """Decorator to enforce dimension order after function call"""
+
     @wraps(func)
     def decorator(*args, **kwargs):
         x = func(*args, **kwargs)

--- a/imod/util/dims.py
+++ b/imod/util/dims.py
@@ -1,9 +1,11 @@
+from functools import wraps
+
 from imod.typing.grid import enforce_dim_order
 
 
 def enforced_dim_order(func):
     """Decorator to enforce dimension order after function call"""
-
+    @wraps(func)
     def decorator(*args, **kwargs):
         x = func(*args, **kwargs)
         # Multiple grids returned


### PR DESCRIPTION
Fixes #1032 

# Description
This adds functools.wraps to preserve docstrings of decorated functions. These are forwarded to sphinx autodocs. This resolves an issue where decorated functions/methods, such as ``Modflow6Simulation.write``, have empty API docs.

# Checklist
- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
