### PR TITLE
Issue #1049 Restrict PATH to pixi and Modflow6

### DIFF
--- a/.teamcity/Templates/ExamplesTemplate.kt
+++ b/.teamcity/Templates/ExamplesTemplate.kt
@@ -25,7 +25,7 @@ object ExamplesTemplate : Template({
             id = "Run_examples"
             workingDir = "imod-python"
             scriptContent = """
-                set Path=%system.teamcity.build.checkoutDir%\modflow6;%env.Path% 
+                set Path=%system.teamcity.build.checkoutDir%\modflow6;"d:\ProgramData\pixi"
                 pixi run --environment default --frozen examples
             """.trimIndent()
             formatStderrAsError = true

--- a/.teamcity/Templates/UnitTestsTemplate.kt
+++ b/.teamcity/Templates/UnitTestsTemplate.kt
@@ -28,7 +28,7 @@ object UnitTestsTemplate : Template({
             id = "Run_unittests"
             workingDir = "imod-python"
             scriptContent = """
-                set Path=%system.teamcity.build.checkoutDir%\modflow6;%env.Path% 
+                set Path=%system.teamcity.build.checkoutDir%\modflow6;"d:\ProgramData\pixi"
                 pixi run --environment default --frozen unittests
             """.trimIndent()
             formatStderrAsError = true


### PR DESCRIPTION
Fixes #1049

# Description
This PR restricts the PATH environmental variable for critical jobs on the TeamCity agent.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
