### PR TITLE
adding import of filter top and bottom

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+
+[Unreleased- feature branch]
+----------------------------
+
+Changed
+~~~~~~~
+- :function:`open_projectfile_data` now also imports well filter top and bottom.
+
 [Unreleased]
 ------------
 

--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -806,9 +806,9 @@ def _read_package_ipf(
                 df_assoc["x"] = row[1]
                 df_assoc["y"] = row[2]
                 df_assoc["id"] = path_assoc.stem
-                if layer <= 0:
-                    df_assoc["top"] = row[4]
-                    df_assoc["bottom"] = row[5]
+                if "filt_top" in row._fields and "filt_bot" in row._fields:
+                    df_assoc["filt_top"] = row.filt_top
+                    df_assoc["filt_bot"] = row.filt_bot
                 dfs.append(df_assoc)
             df = pd.concat(dfs, ignore_index=True, sort=False)
         df["rate"] = df["rate"] * factor + addition

--- a/imod/tests/test_mf6/test_import_prj.py
+++ b/imod/tests/test_mf6/test_import_prj.py
@@ -192,6 +192,12 @@ def test_import_ipf(tmp_path):
         result_snippet_1[0]["wel-3"]["dataframe"]["rate"]
         == 2 * result_snippet_0[0]["wel-2"]["dataframe"]["rate"] + 1.3
     )
+    assert np.all(result_snippet_1[0]["wel-1"]["dataframe"]["filt_top"] == 11.0)
+    assert np.all(result_snippet_1[0]["wel-1"]["dataframe"]["filt_bot"] == 6.0)
+    assert np.all(result_snippet_1[0]["wel-2"]["dataframe"]["filt_top"] == 11.0)
+    assert np.all(result_snippet_1[0]["wel-2"]["dataframe"]["filt_bot"] == 6.0)
+    assert np.all(result_snippet_1[0]["wel-3"]["dataframe"]["filt_top"] == 11.0)
+    assert np.all(result_snippet_1[0]["wel-3"]["dataframe"]["filt_bot"] == 6.0)
 
 
 def snippet_boundary_condition(factor: float, addition: float):


### PR DESCRIPTION
Fixes #1053 

# Description
On importing wells, the filter top and bottom are now parsed and stored in the project file data structure

# Checklist

- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
