### PR TITLE
Issue #966 negative ibound

### DIFF
--- a/imod/mf6/chd.py
+++ b/imod/mf6/chd.py
@@ -163,7 +163,7 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         ibound = imod5_data["bnd"]["ibound"]
 
         # select locations where ibound < 0
-        data["head"] = data["head"].where(ibound < 0 )
+        data["head"] = data["head"].where(ibound < 0)
 
         # select locations where idomain > 0
         data["head"] = data["head"].where(target_idomain > 0)

--- a/imod/mf6/chd.py
+++ b/imod/mf6/chd.py
@@ -151,7 +151,6 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
     @classmethod
     def from_imod5_ibound(
         cls,
-        key: str,
         imod5_data: dict[str, dict[str, GridDataArray]],
         target_discretization: StructuredDiscretization,
         regridder_types: Optional[RegridMethodType] = None,
@@ -159,10 +158,15 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         target_idomain = target_discretization.dataset["idomain"]
 
         data = {
-            "head": imod5_data[key]["head"],
+            "head": imod5_data["shd"]["head"],
         }
         ibound = imod5_data["bnd"]["ibound"]
-        data["head"] = data["head"].where(ibound < 0)
+
+        # select locations where ibound < 0
+        data["head"] = data["head"].where(ibound < 0 )
+
+        # select locations where idomain > 0
+        data["head"] = data["head"].where(target_idomain > 0)
 
         if regridder_types is None:
             regridder_settings = asdict(cls.get_regrid_methods(), dict_factory=dict)

--- a/imod/mf6/chd.py
+++ b/imod/mf6/chd.py
@@ -149,7 +149,7 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         return errors
 
     @classmethod
-    def from_imod5_data(
+    def from_imod5_ibound(
         cls,
         key: str,
         imod5_data: dict[str, dict[str, GridDataArray]],

--- a/imod/mf6/chd.py
+++ b/imod/mf6/chd.py
@@ -1,17 +1,15 @@
 from dataclasses import asdict
 from typing import Optional
+
 import numpy as np
 
 from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
-from imod.mf6.npf import NodePropertyFlow
 from imod.mf6.regrid.regrid_schemes import ConstantHeadRegridMethod, RegridMethodType
 from imod.mf6.utilities.regrid import RegridderWeightsCache, _regrid_package_data
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA, CONC_DIMS_SCHEMA
-from imod.prepare.topsystem.allocation import ALLOCATION_OPTION
-from imod.prepare.topsystem.conductance import DISTRIBUTING_OPTION
 from imod.schemata import (
     AllInsideNoDataSchema,
     AllNoDataSchema,
@@ -149,7 +147,7 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         errors = super()._validate(schemata, **kwargs)
 
         return errors
-    
+
     @classmethod
     def from_imod5_data(
         cls,
@@ -158,14 +156,13 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         target_discretization: StructuredDiscretization,
         regridder_types: Optional[RegridMethodType] = None,
     ) -> "ConstantHead":
-        
         target_idomain = target_discretization.dataset["idomain"]
 
         data = {
             "head": imod5_data[key]["head"],
         }
         ibound = imod5_data["bnd"]["ibound"]
-        data["head"] = data["head"].where(ibound  < 0)
+        data["head"] = data["head"].where(ibound < 0)
 
         if regridder_types is None:
             regridder_settings = asdict(cls.get_regrid_methods(), dict_factory=dict)
@@ -178,5 +175,4 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
             data, target_idomain, regridder_settings, regrid_context, {}
         )
 
-
-        return ConstantHead(**regridded_package_data)       
+        return ConstantHead(**regridded_package_data)

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -270,14 +270,10 @@ class GroundwaterFlowModel(Modflow6Model):
             result["hfb"] = hfb
 
         # import constant head boundaries
-        imod5_keys = list(imod5_data.keys())
-        chd_keys = [key for key in imod5_keys if key[0:3] == "chd"]
-        for chd_key in chd_keys:
-            chd_pkg = ConstantHead.from_imod5_data(
-                chd_key,
-                imod5_data,
-                dis_pkg,
-                regridder_types=regridder_types,
-            )
-            result[chd_key] = chd_pkg
+        chd_pkg = ConstantHead.from_imod5_ibound(
+            imod5_data,
+            dis_pkg,
+            regridder_types=regridder_types,
+        )
+        result["chd_shd"] = chd_pkg
         return result

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -244,4 +244,15 @@ class GroundwaterFlowModel(Modflow6Model):
             )
             result[drn_key] = drn_pkg
 
+        # import constant head boundaries
+        imod5_keys = list(imod5_data.keys())
+        chd_keys = [key for key in imod5_keys if key[0:3] == "chd"]
+        for chd_key in chd_keys:
+            chd_pkg = ConstantHead.from_imod5_data(
+                chd_key,
+                imod5_data,
+                dis_pkg,
+                regridder_types=regridder_types,
+            )
+            result[chd_key] = chd_pkg
         return result

--- a/imod/tests/test_mf6/test_mf6_chd.py
+++ b/imod/tests/test_mf6/test_mf6_chd.py
@@ -199,14 +199,13 @@ def test_write_concentration_period_data(head_fc, concentration_fc):
 def test_from_ibound(imod5_dataset):
     target_dis = StructuredDiscretization.from_imod5_data(imod5_dataset)
 
-    chd_layer_3 = imod.mf6.ConstantHead.from_imod5_ibound(
-        "chd-3",
+    chd_from_ibound = imod.mf6.ConstantHead.from_imod5_ibound(
         imod5_dataset,
         target_dis,
         regridder_types=None,
     )
-    errors = chd_layer_3._validate(
+    errors = chd_from_ibound._validate(
         imod.mf6.ConstantHead._write_schemata, idomain=target_dis["idomain"]
     )
-    errors.update(chd_layer_3._validate(imod.mf6.ConstantHead._init_schemata))
+    errors.update(chd_from_ibound._validate(imod.mf6.ConstantHead._init_schemata))
     assert len(errors) == 0

--- a/imod/tests/test_mf6/test_mf6_chd.py
+++ b/imod/tests/test_mf6/test_mf6_chd.py
@@ -205,6 +205,8 @@ def test_from_imod5(imod5_dataset, tmp_path):
         target_dis,
         regridder_types=None,
     )
-    errors = chd_layer_3._validate(imod.mf6.ConstantHead._write_schemata, idomain=target_dis["idomain"])
-    errors.update (chd_layer_3._validate(imod.mf6.ConstantHead._init_schemata))
+    errors = chd_layer_3._validate(
+        imod.mf6.ConstantHead._write_schemata, idomain=target_dis["idomain"]
+    )
+    errors.update(chd_layer_3._validate(imod.mf6.ConstantHead._init_schemata))
     assert len(errors) == 0

--- a/imod/tests/test_mf6/test_mf6_chd.py
+++ b/imod/tests/test_mf6/test_mf6_chd.py
@@ -196,10 +196,10 @@ def test_write_concentration_period_data(head_fc, concentration_fc):
 
 
 @pytest.mark.usefixtures("imod5_dataset")
-def test_from_imod5(imod5_dataset):
+def test_from_ibound(imod5_dataset):
     target_dis = StructuredDiscretization.from_imod5_data(imod5_dataset)
 
-    chd_layer_3 = imod.mf6.ConstantHead.from_imod5_data(
+    chd_layer_3 = imod.mf6.ConstantHead.from_imod5_ibound(
         "chd-3",
         imod5_dataset,
         target_dis,

--- a/imod/tests/test_mf6/test_mf6_chd.py
+++ b/imod/tests/test_mf6/test_mf6_chd.py
@@ -194,14 +194,17 @@ def test_write_concentration_period_data(head_fc, concentration_fc):
                 data.count("2") == 1755
             )  # the number 2 is in the concentration data, and in the cell indices.
 
+
 @pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5(imod5_dataset, tmp_path):
-    target_dis = StructuredDiscretization.from_imod5_data(imod5_dataset) 
+    target_dis = StructuredDiscretization.from_imod5_data(imod5_dataset)
 
-    my_chd = imod.mf6.ConstantHead.from_imod5_data(
+    chd_layer_3 = imod.mf6.ConstantHead.from_imod5_data(
         "chd-3",
         imod5_dataset,
         target_dis,
         regridder_types=None,
     )
-    assert my_chd is not None
+    errors = chd_layer_3._validate(imod.mf6.ConstantHead._write_schemata, idomain=target_dis["idomain"])
+    errors.update (chd_layer_3._validate(imod.mf6.ConstantHead._init_schemata))
+    assert len(errors) == 0

--- a/imod/tests/test_mf6/test_mf6_chd.py
+++ b/imod/tests/test_mf6/test_mf6_chd.py
@@ -7,6 +7,7 @@ import pytest
 import xarray as xr
 
 import imod
+from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 
@@ -192,3 +193,15 @@ def test_write_concentration_period_data(head_fc, concentration_fc):
             assert (
                 data.count("2") == 1755
             )  # the number 2 is in the concentration data, and in the cell indices.
+
+@pytest.mark.usefixtures("imod5_dataset")
+def test_from_imod5(imod5_dataset, tmp_path):
+    target_dis = StructuredDiscretization.from_imod5_data(imod5_dataset) 
+
+    my_chd = imod.mf6.ConstantHead.from_imod5_data(
+        "chd-3",
+        imod5_dataset,
+        target_dis,
+        regridder_types=None,
+    )
+    assert my_chd is not None

--- a/imod/tests/test_mf6/test_mf6_chd.py
+++ b/imod/tests/test_mf6/test_mf6_chd.py
@@ -196,7 +196,7 @@ def test_write_concentration_period_data(head_fc, concentration_fc):
 
 
 @pytest.mark.usefixtures("imod5_dataset")
-def test_from_imod5(imod5_dataset, tmp_path):
+def test_from_imod5(imod5_dataset):
     target_dis = StructuredDiscretization.from_imod5_data(imod5_dataset)
 
     chd_layer_3 = imod.mf6.ConstantHead.from_imod5_data(

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -479,7 +479,7 @@ def test_import_from_imod5(imod5_dataset, tmp_path):
         default_simulation_distributing_options,
     )
 
-    simulation["imported_model"] = OutputControl(save_head="last", save_budget="last")
+    simulation["imported_model"]["oc"] = OutputControl(save_head="last", save_budget="last")
 
     simulation.create_time_discretization(["01-01-2003", "02-01-2003"])
 

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -479,7 +479,9 @@ def test_import_from_imod5(imod5_dataset, tmp_path):
         default_simulation_distributing_options,
     )
 
-    simulation["imported_model"]["oc"] = OutputControl(save_head="last", save_budget="last")
+    simulation["imported_model"]["oc"] = OutputControl(
+        save_head="last", save_budget="last"
+    )
 
     simulation.create_time_discretization(["01-01-2003", "02-01-2003"])
 


### PR DESCRIPTION
Fixes #966

# Description
imports a constant head package using the ibound array and the chd-arrays in the imported project file data. 
These chd arrays are provided for the whole grid, but we assign constant head only in those cells that have ibound < 0.


# Checklist

- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
