### PR TITLE
Issue #502 hfb import

### DIFF
--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -1086,17 +1086,19 @@ class LayeredHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
     def from_imod5_dataset(cls, imod5_data: dict[str, dict[str, GridDataArray]]):
         imod5_keys = list(imod5_data.keys())
         hfb_keys = [key for key in imod5_keys if key[0:3] == "hfb"]
-
+        if len(hfb_keys) ==0:
+            raise ValueError("no hfb keys present.")
+        
         first = True
         for hfb_key in hfb_keys:
             hfb_dict = imod5_data[hfb_key]
             if not list(hfb_dict.keys()) == ["geodataframe", "layer"]:
-                raise ValueError
+                raise ValueError("hfb is not a LayeredHorizontalFlowBarrierResistance")
             layer = hfb_dict["layer"]
             geometry_layer = deepcopy(hfb_dict["geodataframe"])
             geometry_layer["layer"] = layer
             if first:
-                compound_dataframe = deepcopy(geometry_layer)
+                compound_dataframe = geometry_layer
                 first = False
             else:
                 compound_dataframe = compound_dataframe._append(geometry_layer)

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -1089,17 +1089,16 @@ class LayeredHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
         if len(hfb_keys) ==0:
             raise ValueError("no hfb keys present.")
         
-        first = True
+        compound_dataframe = None
         for hfb_key in hfb_keys:
             hfb_dict = imod5_data[hfb_key]
             if not list(hfb_dict.keys()) == ["geodataframe", "layer"]:
                 raise ValueError("hfb is not a LayeredHorizontalFlowBarrierResistance")
             layer = hfb_dict["layer"]
-            geometry_layer = deepcopy(hfb_dict["geodataframe"])
+            geometry_layer = hfb_dict["geodataframe"]
             geometry_layer["layer"] = layer
-            if first:
+            if compound_dataframe is None:
                 compound_dataframe = geometry_layer
-                first = False
             else:
                 compound_dataframe = compound_dataframe._append(geometry_layer)
 

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -1095,6 +1095,10 @@ class LayeredHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
             if not list(hfb_dict.keys()) == ["geodataframe", "layer"]:
                 raise ValueError("hfb is not a LayeredHorizontalFlowBarrierResistance")
             layer = hfb_dict["layer"]
+            if layer == 0:
+                raise ValueError(
+                    "assigning to layer 0 is not supported yet for import of HFB's"
+                )
             geometry_layer = hfb_dict["geodataframe"]
             geometry_layer["layer"] = layer
             if compound_dataframe is None:

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -1086,9 +1086,9 @@ class LayeredHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
     def from_imod5_dataset(cls, imod5_data: dict[str, dict[str, GridDataArray]]):
         imod5_keys = list(imod5_data.keys())
         hfb_keys = [key for key in imod5_keys if key[0:3] == "hfb"]
-        if len(hfb_keys) ==0:
+        if len(hfb_keys) == 0:
             raise ValueError("no hfb keys present.")
-        
+
         compound_dataframe = None
         for hfb_key in hfb_keys:
             hfb_dict = imod5_data[hfb_key]

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -1080,5 +1080,25 @@ class LayeredHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
             edge_index,
             idomain,
         )
-
         return barrier_values
+
+    @classmethod
+    def from_imod5_dataset(cls, imod5_data: dict[str, dict[str, GridDataArray]]):
+        imod5_keys = list(imod5_data.keys())
+        hfb_keys = [key for key in imod5_keys if key[0:3] == "hfb"]
+
+        first = True
+        for hfb_key in hfb_keys:
+            hfb_dict = imod5_data[hfb_key]
+            if not list(hfb_dict.keys()) == ["geodataframe", "layer"]:
+                raise ValueError
+            layer = hfb_dict["layer"]
+            geometry_layer = deepcopy(hfb_dict["geodataframe"])
+            geometry_layer["layer"] = layer
+            if first:
+                compound_dataframe = deepcopy(geometry_layer)
+                first = False
+            else:
+                compound_dataframe = compound_dataframe._append(geometry_layer)
+
+        return LayeredHorizontalFlowBarrierResistance(compound_dataframe)

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -11,6 +11,7 @@ from imod.mf6 import ConstantHead
 from imod.mf6.clipped_boundary_condition_creator import create_clipped_boundary
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.drn import Drainage
+from imod.mf6.hfb import LayeredHorizontalFlowBarrierResistance
 from imod.mf6.ic import InitialConditions
 from imod.mf6.model import Modflow6Model
 from imod.mf6.npf import NodePropertyFlow
@@ -244,4 +245,9 @@ class GroundwaterFlowModel(Modflow6Model):
             )
             result[drn_key] = drn_pkg
 
+        # import hfb
+        hfb_keys = [key for key in imod5_keys if key[0:3] == "hfb"]
+        if len(hfb_keys) != 0:
+            hfb = LayeredHorizontalFlowBarrierResistance.from_imod5_dataset(imod5_data)
+            result["hfb"] = hfb
         return result

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -452,7 +452,7 @@ def test_hfb_from_imod5(imod5_dataset, tmp_path):
     )
 
     hfb = LayeredHorizontalFlowBarrierResistance.from_imod5_dataset(imod5_dataset)
-    hfb_pack = hfb.to_mf6_pkg(
+    hfb_package = hfb.to_mf6_pkg(
         target_dis["idomain"], target_dis["top"], target_dis["bottom"], target_npf["k"]
     )
-    pass
+    assert list(np.unique(hfb_package["layer"].values)) == [3, 21]

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -16,7 +16,9 @@ from imod.mf6 import (
     LayeredHorizontalFlowBarrierMultiplier,
     LayeredHorizontalFlowBarrierResistance,
 )
+from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.hfb import to_connected_cells_dataset
+from imod.mf6.npf import NodePropertyFlow
 from imod.mf6.utilities.regrid import RegridderWeightsCache
 from imod.tests.fixtures.flow_basic_fixture import BasicDisSettings
 from imod.typing.grid import ones_like
@@ -440,3 +442,17 @@ def test_set_options(print_input, parameterizable_basic_dis):
     k = ones_like(top)
     mf6_package = hfb.to_mf6_pkg(idomain, top, bottom, k)
     assert mf6_package.dataset["print_input"].values[()] == print_input
+
+
+@pytest.mark.usefixtures("imod5_dataset")
+def test_hfb_from_imod5(imod5_dataset, tmp_path):
+    target_dis = StructuredDiscretization.from_imod5_data(imod5_dataset)
+    target_npf = NodePropertyFlow.from_imod5_data(
+        imod5_dataset, target_dis.dataset["idomain"]
+    )
+
+    hfb = LayeredHorizontalFlowBarrierResistance.from_imod5_dataset(imod5_dataset)
+    hfb_pack = hfb.to_mf6_pkg(
+        target_dis["idomain"], target_dis["top"], target_dis["bottom"], target_npf["k"]
+    )
+    pass

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -479,7 +479,9 @@ def test_import_from_imod5(imod5_dataset, tmp_path):
         default_simulation_distributing_options,
     )
 
-    simulation["imported_model"] = OutputControl(save_head="last", save_budget="last")
+    simulation["imported_model"]["oc"] = OutputControl(
+        save_head="last", save_budget="last"
+    )
 
     simulation.create_time_discretization(["01-01-2003", "02-01-2003"])
 


### PR DESCRIPTION
Fixes #502 

# Description
Converts hfb's from imod5 to mf6, but only in the following cases:

- the hfb has an assgined layer that is not zero
- the hfb is mappable to the LayeredHorizontalFlowBarrierResistance class.

It creates a single mf6 hfb package containing all the hfb's that are present in the model domain area. 
The hfb package is added to the simulation. 

# Checklist

- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
