### PR TITLE
Issue #1079 create python matrix

### DIFF
--- a/.teamcity/Nightly/NightlyProject.kt
+++ b/.teamcity/Nightly/NightlyProject.kt
@@ -28,7 +28,7 @@ object NightlyLint : BuildType({
 object NightlyPipPython : BuildType({
     name = "PipPython"
 
-    templates(PipPythonTemplates)
+    templates(PipPythonTemplate)
 })
 
 object NightlyMyPy : BuildType({

--- a/.teamcity/Nightly/NightlyProject.kt
+++ b/.teamcity/Nightly/NightlyProject.kt
@@ -16,9 +16,7 @@ object NightlyProject : Project({
     buildType(NightlyUnitTests)
     buildType(NightlyExamples)
     buildType(NightlyTests)
-    buildType(NightlyPipPython310)
-    buildType(NightlyPipPython311)
-    buildType(NightlyPipPython312)
+    buildType(NightlyPipPython)
 })
 
 object NightlyLint : BuildType({
@@ -27,22 +25,10 @@ object NightlyLint : BuildType({
     templates(LintTemplate)
 })
 
-object NightlyPipPython310 : BuildType({
-    name = "PipPython310"
+object NightlyPipPython : BuildType({
+    name = "PipPython"
 
-    templates(PipPython310Template)
-})
-
-object NightlyPipPython311 : BuildType({
-    name = "PipPython311"
-
-    templates(PipPython311Template)
-})
-
-object NightlyPipPython312 : BuildType({
-    name = "PipPython312"
-
-    templates(PipPython312Template)
+    templates(PipPythonTemplates)
 })
 
 object NightlyMyPy : BuildType({

--- a/.teamcity/Templates/PipPythonTemplate.kt
+++ b/.teamcity/Templates/PipPythonTemplate.kt
@@ -18,7 +18,7 @@ object PipPythonTemplate : Template({
 
     steps {
         script {
-            name = "Pip install python %python_env%"
+            name = "Pip install python"
             id = "pip_install"
             workingDir = "imod-python"
             scriptContent = """
@@ -36,9 +36,9 @@ object PipPythonTemplate : Template({
         matrix {
             param(
                 "python_env", listOf(
-                    value("py310", label = "3.10"),
-                    value("py311", label = "3.11"),
-                    value("py312", label = "3.12")
+                    value("py310", label = "python 3.10"),
+                    value("py311", label = "python 3.11"),
+                    value("py312", label = "python 3.12")
                 )
             )
         }

--- a/.teamcity/Templates/PipPythonTemplate.kt
+++ b/.teamcity/Templates/PipPythonTemplate.kt
@@ -5,7 +5,7 @@ import jetbrains.buildServer.configs.kotlin.Template
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.matrix
 
-object PipPythonTemplates : Template({
+object PipPythonTemplate : Template({
     name = "PipPythonTemplate"
 
     detectHangingBuilds = false

--- a/.teamcity/Templates/PipPythonTemplates.kt
+++ b/.teamcity/Templates/PipPythonTemplates.kt
@@ -3,37 +3,10 @@ package Templates
 import jetbrains.buildServer.configs.kotlin.DslContext
 import jetbrains.buildServer.configs.kotlin.Template
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
+import jetbrains.buildServer.configs.kotlin.matrix
 
-object PipPython310Template : Template({
-    name = "PipPython310Template"
-
-    detectHangingBuilds = false
-
-    vcs {
-        root(DslContext.settingsRoot, "+:. => imod-python")
-
-        cleanCheckout = true
-    }
-
-    steps {
-        script {
-            name = "Pip install python 3.10"
-            id = "pip_install_py310"
-            workingDir = "imod-python"
-            scriptContent = """
-                    pixi run --environment py310 --frozen test_import
-                """.trimIndent()
-            formatStderrAsError = true
-        }
-    }
-
-    requirements {
-        equals("env.OS", "Windows_NT")
-    }
-})
-
-object PipPython311Template : Template({
-    name = "PipPython311Template"
+object PipPythonTemplates : Template({
+    name = "PipPythonTemplate"
 
     detectHangingBuilds = false
 
@@ -45,11 +18,11 @@ object PipPython311Template : Template({
 
     steps {
         script {
-            name = "Pip install python 3.11"
-            id = "pip_install_py311"
+            name = "Pip install python %python_env%"
+            id = "pip_install"
             workingDir = "imod-python"
             scriptContent = """
-                    pixi run --environment py311 --frozen test_import
+                    pixi run --environment %python_env% --frozen test_import
                 """.trimIndent()
             formatStderrAsError = true
         }
@@ -58,32 +31,16 @@ object PipPython311Template : Template({
     requirements {
         equals("env.OS", "Windows_NT")
     }
-})
 
-object PipPython312Template : Template({
-    name = "PipPython312Template"
-
-    detectHangingBuilds = false
-
-    vcs {
-        root(DslContext.settingsRoot, "+:. => imod-python")
-
-        cleanCheckout = true
-    }
-
-    steps {
-        script {
-            name = "Pip install python 3.12"
-            id = "pip_install_py312"
-            workingDir = "imod-python"
-            scriptContent = """
-                    pixi run --environment py312 --frozen test_import
-                """.trimIndent()
-            formatStderrAsError = true
+    features {
+        matrix {
+            param(
+                "python_env", listOf(
+                    value("py310", label = "3.10"),
+                    value("py311", label = "3.11"),
+                    value("py312", label = "3.12")
+                )
+            )
         }
-    }
-
-    requirements {
-        equals("env.OS", "Windows_NT")
     }
 })

--- a/.teamcity/_Self/MainProject.kt
+++ b/.teamcity/_Self/MainProject.kt
@@ -26,7 +26,7 @@ object MainProject : Project({
     template(MyPyTemplate)
     template(UnitTestsTemplate)
     template(ExamplesTemplate)
-    template(PipPythonTemplates)
+    template(PipPythonTemplate)
 
     features {
         buildTypeCustomChart {
@@ -128,7 +128,7 @@ object Examples : BuildType({
 object PipPython : BuildType({
     name = "PipPython"
 
-    templates(PipPythonTemplates, GitHubIntegrationTemplate)
+    templates(PipPythonTemplate, GitHubIntegrationTemplate)
 })
 
 object Tests : BuildType({

--- a/.teamcity/_Self/MainProject.kt
+++ b/.teamcity/_Self/MainProject.kt
@@ -18,9 +18,7 @@ object MainProject : Project({
     buildType(MyPy)
     buildType(UnitTests)
     buildType(Examples)
-    buildType(PipPython310)
-    buildType(PipPython311)
-    buildType(PipPython312)
+    buildType(PipPython)
     buildType(Tests)
 
     template(GitHubIntegrationTemplate)
@@ -28,9 +26,7 @@ object MainProject : Project({
     template(MyPyTemplate)
     template(UnitTestsTemplate)
     template(ExamplesTemplate)
-    template(PipPython310Template)
-    template(PipPython311Template)
-    template(PipPython312Template)
+    template(PipPythonTemplates)
 
     features {
         buildTypeCustomChart {
@@ -129,22 +125,10 @@ object Examples : BuildType({
     }
 })
 
-object PipPython310 : BuildType({
-    name = "PipPython310"
+object PipPython : BuildType({
+    name = "PipPython"
 
-    templates(PipPython310Template, GitHubIntegrationTemplate)
-})
-
-object PipPython311 : BuildType({
-    name = "PipPython311"
-
-    templates(PipPython311Template, GitHubIntegrationTemplate)
-})
-
-object PipPython312 : BuildType({
-    name = "PipPython312"
-
-    templates(PipPython312Template, GitHubIntegrationTemplate)
+    templates(PipPythonTemplates, GitHubIntegrationTemplate)
 })
 
 object Tests : BuildType({
@@ -181,13 +165,7 @@ object Tests : BuildType({
     }
 
     dependencies {
-        snapshot(PipPython310) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
-        }
-        snapshot(PipPython311) {
-            onDependencyFailure = FailureAction.FAIL_TO_START
-        }
-        snapshot(PipPython312) {
+        snapshot(PipPython) {
             onDependencyFailure = FailureAction.FAIL_TO_START
         }
         snapshot(Examples) {


### PR DESCRIPTION
Fixes #1079

# Description
In the pipeline scripts we have 3 almost identical builds to test that pip install works with different python versions.
By using a build matrix we can test this in a single build allowing us to remove duplicate code.
Is also makes it easy to add/remove python versions to the pipeline script

![image](https://github.com/Deltares/imod-python/assets/77051845/1df27997-2ad6-4c17-9a6a-b5f327495d34)

![image](https://github.com/Deltares/imod-python/assets/77051845/1fca4ee5-e484-4ac4-93b8-d5161be7bc60)


# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
