### PR TITLE
Issue #1072 report faulty ipf during prj read

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -9,6 +9,11 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 [Unreleased]
 ------------
 
+Fixed
+~~~~~
+- :func:`imod.formats.prj.open_projectfile_data` now reports the path to a
+  faulty IPF or IDF file in the error message.
+
 Added
 ~~~~~
 - Added objects with regrid settings. These can be used to provide custom

--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -511,15 +511,21 @@ def _merge_coords(headers: List[Dict[str, Any]]) -> Dict[str, np.ndarray]:
             coords[key].append(value)
     return {k: np.unique(coords[k]) for k in coords}
 
+
 def _try_read_with_func(func, path, *args, **kwargs):
     try:
         return func(path, *args, **kwargs)
     except Exception as e:
         raise type(e)(f"{e}. Error thrown while opening file: {path}")
 
+
 def _create_datarray_from_paths(paths: List[str], headers: List[Dict[str, Any]]):
     da = _try_read_with_func(
-        imod.formats.array_io.reading._load, paths, use_cftime=False, _read=imod.idf._read, headers=headers
+        imod.formats.array_io.reading._load,
+        paths,
+        use_cftime=False,
+        _read=imod.idf._read,
+        headers=headers,
     )
     return da
 
@@ -806,7 +812,9 @@ def _read_package_ipf(
             for row in ipf_df.itertuples():
                 filename = row[indexcol]
                 path_assoc = path.parent.joinpath(f"{filename}.{ext}")
-                df_assoc = _try_read_with_func(imod.ipf.read_associated, path_assoc).iloc[:, :2]
+                df_assoc = _try_read_with_func(
+                    imod.ipf.read_associated, path_assoc
+                ).iloc[:, :2]
                 df_assoc.columns = ["time", "rate"]
                 df_assoc["x"] = row[1]
                 df_assoc["y"] = row[2]

--- a/imod/tests/test_formats/test_prj.py
+++ b/imod/tests/test_formats/test_prj.py
@@ -542,7 +542,7 @@ class TestProjectFile:
         wellpath.rename(wellpath_backup)
         with open(wellpath, mode="w") as f:
             f.write("!@#$(!())\n#*@*!(!())")
-        
+
         with pytest.raises(ValueError, match="wells_l2.ipf"):
             imod.prj.open_projectfile_data(self.prj_path)
 

--- a/imod/tests/test_formats/test_prj.py
+++ b/imod/tests/test_formats/test_prj.py
@@ -534,6 +534,54 @@ class TestProjectFile:
         assert isinstance(content["pcg"], dict)
         assert set(repeats["rch"]) == {datetime(1899, 4, 1), datetime(1899, 10, 1)}
 
+    def test_open_projectfile_data__faulty_well(self):
+        basepath = self.prj_path.parent
+        # Setup faulty well
+        wellpath = basepath / "wells_l2.ipf"
+        wellpath_backup = basepath / "wells_l2.backup"
+        wellpath.rename(wellpath_backup)
+        with open(wellpath, mode="w") as f:
+            f.write("!@#$(!())\n#*@*!(!())")
+        
+        with pytest.raises(ValueError, match="wells_l2.ipf"):
+            imod.prj.open_projectfile_data(self.prj_path)
+
+        # Teardown
+        wellpath.unlink()
+        wellpath_backup.rename(wellpath)
+
+    def test_open_projectfile_data__faulty_grid(self):
+        basepath = self.prj_path.parent
+        # Setup faulty grid
+        gridpath = basepath / "a.idf"
+        gridpath_backup = basepath / "a.backup"
+        gridpath.rename(gridpath_backup)
+        with open(gridpath, mode="w") as f:
+            f.write("!@#$(!())\n#*@*!(!())")
+
+        with pytest.raises(ValueError, match="a.idf"):
+            imod.prj.open_projectfile_data(self.prj_path)
+
+        # Teardown
+        gridpath.unlink()
+        gridpath_backup.rename(gridpath)
+
+    def test_open_projectfile_data__faulty_gen(self):
+        basepath = self.prj_path.parent
+        # Setup faulty gen
+        genpath = basepath / "first.gen"
+        genpath_backup = basepath / "first.backup"
+        genpath.rename(genpath_backup)
+        with open(genpath, mode="w") as f:
+            f.write("!@#$(!())\n#*@*!(!())")
+
+        with pytest.raises(IndexError, match="first.gen"):
+            imod.prj.open_projectfile_data(self.prj_path)
+
+        # Teardown
+        genpath.unlink()
+        genpath_backup.rename(genpath)
+
 
 def test_read_timfile(tmp_path):
     content = textwrap.dedent(


### PR DESCRIPTION
Fixes #1072 

# Description
This PR adds functionality to capture the path of a faulty IPF and IDF file in the error message.
For GEN files, this was already reported, but still added a unittest to verify.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
