### PR TITLE
Issue #598 layered hfb error

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -50,7 +50,10 @@ Changed
   :class:`imod.mf6.regrid.RiverRegridMethod`,
   :class:`imod.mf6.regrid.SpecificStorageRegridMethod`,
   :class:`imod.mf6.regrid.StorageCoefficientRegridMethod`.
-
+- Renamed ``imod.mf6.LayeredHorizontalFlowBarrier`` classes to
+  :class:`imod.mf6.SingleLayerHorizontalFlowBarrierResistance`,
+  :class:`imod.mf6.SingleLayerHorizontalFlowBarrierHydraulicCharacteristic`,
+  :class:`imod.mf6.SingleLayerHorizontalFlowBarrierMultiplier`,
 
 
 [0.17.1] - 2024-05-16

--- a/imod/mf6/__init__.py
+++ b/imod/mf6/__init__.py
@@ -21,9 +21,9 @@ from imod.mf6.hfb import (
     HorizontalFlowBarrierHydraulicCharacteristic,
     HorizontalFlowBarrierMultiplier,
     HorizontalFlowBarrierResistance,
-    LayeredHorizontalFlowBarrierHydraulicCharacteristic,
-    LayeredHorizontalFlowBarrierMultiplier,
-    LayeredHorizontalFlowBarrierResistance,
+    SingleLayerHorizontalFlowBarrierHydraulicCharacteristic,
+    SingleLayerHorizontalFlowBarrierMultiplier,
+    SingleLayerHorizontalFlowBarrierResistance,
 )
 from imod.mf6.ic import InitialConditions
 from imod.mf6.ims import (

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -18,7 +18,7 @@ from imod.mf6.interfaces.ilinedatapackage import ILineDataPackage
 from imod.mf6.mf6_hfb_adapter import Mf6HorizontalFlowBarrier
 from imod.mf6.package import Package
 from imod.mf6.utilities.grid import broadcast_to_full_domain
-from imod.schemata import EmptyIndexesSchema
+from imod.schemata import EmptyIndexesSchema, NUniqueValueSchema
 from imod.typing import GridDataArray
 from imod.util.imports import MissingOptionalModule
 
@@ -283,7 +283,7 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
 
     _period_data = ()
     _init_schemata = {}
-    _write_schemata = {"geometry": [EmptyIndexesSchema()]}
+    _write_schemata = {"geometry": [EmptyIndexesSchema()], "layer": [NUniqueValueSchema(1)]}
 
     def __init__(
         self,
@@ -342,7 +342,6 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
         top: GridDataArray,
         bottom: GridDataArray,
         k: GridDataArray,
-        validate: bool = False,
     ) -> Mf6HorizontalFlowBarrier:
         """
         Write package to Modflow 6 package.
@@ -361,16 +360,11 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
             Grid with bottom of model layers.
         k: GridDataArray
             Grid with hydraulic conductivities.
-        validate: bool
-            Run validation before converting
 
         Returns
         -------
 
         """
-        if validate:
-            self._validate(self._write_schemata)
-
         top, bottom = broadcast_to_full_domain(idomain, top, bottom)
         k = idomain * k
         unstructured_grid, top, bottom, k = (

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -4,11 +4,10 @@ import textwrap
 import typing
 from copy import deepcopy
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
 import cftime
 import numpy as np
-import pandas as pd
 import xarray as xr
 import xugrid as xu
 from fastcore.dispatch import typedispatch
@@ -1097,27 +1096,22 @@ class SingleLayerHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
         return barrier_values
 
     @classmethod
-    def from_imod5_dataset(cls, imod5_data: Dict[str, Dict[str, GridDataArray]]):
+    def from_imod5_dataset(
+        cls, key: str, imod5_data: Dict[str, Dict[str, GridDataArray]]
+    ):
         imod5_keys = list(imod5_data.keys())
-        hfb_keys = [key for key in imod5_keys if key[0:3] == "hfb"]
-        if len(hfb_keys) == 0:
-            raise ValueError("no hfb keys present.")
+        if key not in imod5_keys:
+            raise ValueError("hfb key not present.")
 
-        dataframe_ls: List[gpd.GeoDataFrame] = []
-        for hfb_key in hfb_keys:
-            hfb_dict = imod5_data[hfb_key]
-            if not list(hfb_dict.keys()) == ["geodataframe", "layer"]:
-                raise ValueError(
-                    "hfb is not a SingleLayerHorizontalFlowBarrierResistance"
-                )
-            layer = hfb_dict["layer"]
-            if layer == 0:
-                raise ValueError(
-                    "assigning to layer 0 is not supported yet for import of HFB's"
-                )
-            geometry_layer = hfb_dict["geodataframe"]
-            geometry_layer["layer"] = layer
-            dataframe_ls.append(geometry_layer)
-        compound_dataframe = pd.concat(dataframe_ls, ignore_index=True)
+        hfb_dict = imod5_data[key]
+        if not list(hfb_dict.keys()) == ["geodataframe", "layer"]:
+            raise ValueError("hfb is not a SingleLayerHorizontalFlowBarrierResistance")
+        layer = hfb_dict["layer"]
+        if layer == 0:
+            raise ValueError(
+                "assigning to layer 0 is not supported yet for import of HFB's"
+            )
+        geometry_layer = hfb_dict["geodataframe"]
+        geometry_layer["layer"] = layer
 
-        return cls(compound_dataframe)
+        return cls(geometry_layer)

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -1107,7 +1107,9 @@ class SingleLayerHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
         for hfb_key in hfb_keys:
             hfb_dict = imod5_data[hfb_key]
             if not list(hfb_dict.keys()) == ["geodataframe", "layer"]:
-                raise ValueError("hfb is not a SingleLayerHorizontalFlowBarrierResistance")
+                raise ValueError(
+                    "hfb is not a SingleLayerHorizontalFlowBarrierResistance"
+                )
             layer = hfb_dict["layer"]
             if layer == 0:
                 raise ValueError(

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -768,7 +768,10 @@ class LayeredHorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierB
 
     """
 
-    _write_schemata = {"geometry": [EmptyIndexesSchema()], "layer": [NUniqueValueSchema(1)]}
+    _write_schemata = {
+        "geometry": [EmptyIndexesSchema()],
+        "layer": [NUniqueValueSchema(1)],
+    }
 
     @init_log_decorator()
     def __init__(
@@ -903,7 +906,10 @@ class LayeredHorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
 
     """
 
-    _write_schemata = {"geometry": [EmptyIndexesSchema()], "layer": [NUniqueValueSchema(1)]}
+    _write_schemata = {
+        "geometry": [EmptyIndexesSchema()],
+        "layer": [NUniqueValueSchema(1)],
+    }
 
     @init_log_decorator()
     def __init__(
@@ -1053,7 +1059,10 @@ class LayeredHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
 
     """
 
-    _write_schemata = {"geometry": [EmptyIndexesSchema()], "layer": [NUniqueValueSchema(1)]}
+    _write_schemata = {
+        "geometry": [EmptyIndexesSchema()],
+        "layer": [NUniqueValueSchema(1)],
+    }
 
     @init_log_decorator()
     def __init__(

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -4,7 +4,7 @@ import textwrap
 import typing
 from copy import deepcopy
 from enum import Enum
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import cftime
 import numpy as np
@@ -1097,7 +1097,7 @@ class SingleLayerHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
         return barrier_values
 
     @classmethod
-    def from_imod5_dataset(cls, imod5_data: dict[str, dict[str, GridDataArray]]):
+    def from_imod5_dataset(cls, imod5_data: Dict[str, Dict[str, GridDataArray]]):
         imod5_keys = list(imod5_data.keys())
         hfb_keys = [key for key in imod5_keys if key[0:3] == "hfb"]
         if len(hfb_keys) == 0:

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -283,7 +283,7 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
 
     _period_data = ()
     _init_schemata = {}
-    _write_schemata = {"geometry": [EmptyIndexesSchema()], "layer": [NUniqueValueSchema(1)]}
+    _write_schemata = {"geometry": [EmptyIndexesSchema()]}
 
     def __init__(
         self,
@@ -768,6 +768,8 @@ class LayeredHorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierB
 
     """
 
+    _write_schemata = {"geometry": [EmptyIndexesSchema()], "layer": [NUniqueValueSchema(1)]}
+
     @init_log_decorator()
     def __init__(
         self,
@@ -900,6 +902,8 @@ class LayeredHorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
     >>> hfb = imod.mf6.LayeredHorizontalFlowBarrierMultiplier(barrier_gdf)
 
     """
+
+    _write_schemata = {"geometry": [EmptyIndexesSchema()], "layer": [NUniqueValueSchema(1)]}
 
     @init_log_decorator()
     def __init__(
@@ -1048,6 +1052,8 @@ class LayeredHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
 
 
     """
+
+    _write_schemata = {"geometry": [EmptyIndexesSchema()], "layer": [NUniqueValueSchema(1)]}
 
     @init_log_decorator()
     def __init__(

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -734,7 +734,9 @@ class HorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierBase):
         return barrier_values
 
 
-class SingleLayerHorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierBase):
+class SingleLayerHorizontalFlowBarrierHydraulicCharacteristic(
+    HorizontalFlowBarrierBase
+):
     """
     Horizontal Flow Barrier (HFB) package
 

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -673,7 +673,7 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
 
 class HorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierBase):
     """
-     Horizontal Flow Barrier (HFB) package
+    Horizontal Flow Barrier (HFB) package
 
     Input to the Horizontal Flow Barrier (HFB) Package is read from the file
     that has type "HFB6" in the Name File. Only one HFB Package can be
@@ -734,9 +734,9 @@ class HorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierBase):
         return barrier_values
 
 
-class LayeredHorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierBase):
+class SingleLayerHorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierBase):
     """
-     Horizontal Flow Barrier (HFB) package
+    Horizontal Flow Barrier (HFB) package
 
     Input to the Horizontal Flow Barrier (HFB) Package is read from the file
     that has type "HFB6" in the Name File. Only one HFB Package can be
@@ -748,8 +748,10 @@ class LayeredHorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierB
     geometry: gpd.GeoDataFrame
         Dataframe that describes:
          - geometry: the geometries of the barriers,
-         - hydraulic_characteristic: the hydraulic characteristic of the barriers
-         - layer: model layer for the barrier
+         - hydraulic_characteristic: the hydraulic characteristic of the
+           barriers
+         - layer: model layer for the barrier, only 1 single layer can be
+           entered.
     print_input: bool
 
     Examples
@@ -804,7 +806,7 @@ class LayeredHorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierB
 
 class HorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
     """
-     Horizontal Flow Barrier (HFB) package
+    Horizontal Flow Barrier (HFB) package
 
     Input to the Horizontal Flow Barrier (HFB) Package is read from the file
     that has type "HFB6" in the Name File. Only one HFB Package can be
@@ -870,16 +872,14 @@ class HorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
         return barrier_values
 
 
-class LayeredHorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
+class SingleLayerHorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
     """
-     Horizontal Flow Barrier (HFB) package
+    Horizontal Flow Barrier (HFB) package
 
     Input to the Horizontal Flow Barrier (HFB) Package is read from the file
     that has type "HFB6" in the Name File. Only one HFB Package can be
     specified for a GWF model.
     https://water.usgs.gov/water-resources/software/MODFLOW-6/mf6io_6.2.2.pdf
-
-    If parts of the barrier overlap a layer the multiplier is applied to the entire layer.
 
     Parameters
     ----------
@@ -887,7 +887,8 @@ class LayeredHorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
         Dataframe that describes:
          - geometry: the geometries of the barriers,
          - multiplier: the multiplier of the barriers
-         - layer: model layer for the barrier
+         - layer: model layer for the barrier, only 1 single layer can be
+           entered.
     print_input: bool
 
     Examples
@@ -1024,7 +1025,7 @@ class HorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
         return barrier_values
 
 
-class LayeredHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
+class SingleLayerHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
     """
     Horizontal Flow Barrier (HFB) package
 
@@ -1039,7 +1040,8 @@ class LayeredHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
         Dataframe that describes:
          - geometry: the geometries of the barriers,
          - resistance: the resistance of the barriers
-         - layer: model layer for the barrier
+         - layer: model layer for the barrier, only 1 single layer can be
+           entered.
     print_input: bool
 
     Examples

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -19,7 +19,7 @@ from imod.mf6.interfaces.ilinedatapackage import ILineDataPackage
 from imod.mf6.mf6_hfb_adapter import Mf6HorizontalFlowBarrier
 from imod.mf6.package import Package
 from imod.mf6.utilities.grid import broadcast_to_full_domain
-from imod.schemata import EmptyIndexesSchema, NUniqueValueSchema
+from imod.schemata import EmptyIndexesSchema, MaxNUniqueValuesSchema
 from imod.typing import GridDataArray
 from imod.util.imports import MissingOptionalModule
 
@@ -775,7 +775,7 @@ class SingleLayerHorizontalFlowBarrierHydraulicCharacteristic(
 
     _write_schemata = {
         "geometry": [EmptyIndexesSchema()],
-        "layer": [NUniqueValueSchema(1)],
+        "layer": [MaxNUniqueValuesSchema(1)],
     }
 
     @init_log_decorator()
@@ -912,7 +912,7 @@ class SingleLayerHorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
 
     _write_schemata = {
         "geometry": [EmptyIndexesSchema()],
-        "layer": [NUniqueValueSchema(1)],
+        "layer": [MaxNUniqueValuesSchema(1)],
     }
 
     @init_log_decorator()
@@ -1066,7 +1066,7 @@ class SingleLayerHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
 
     _write_schemata = {
         "geometry": [EmptyIndexesSchema()],
-        "layer": [NUniqueValueSchema(1)],
+        "layer": [MaxNUniqueValuesSchema(1)],
     }
 
     @init_log_decorator()

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -274,7 +274,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
                 elif isinstance(pkg, imod.mf6.HorizontalFlowBarrierBase):
                     top, bottom, idomain = self.__get_domain_geometry()
                     k = self.__get_k()
-                    mf6_hfb_pkg = pkg.to_mf6_pkg(idomain, top, bottom, k, validate)
+                    mf6_hfb_pkg = pkg.to_mf6_pkg(idomain, top, bottom, k)
                     mf6_hfb_pkg.write(
                         pkgname=pkg_name,
                         globaltimes=globaltimes,

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -266,7 +266,9 @@ class GroundwaterFlowModel(Modflow6Model):
         # import hfb
         hfb_keys = [key for key in imod5_keys if key[0:3] == "hfb"]
         if len(hfb_keys) != 0:
-            hfb = SingleLayerHorizontalFlowBarrierResistance.from_imod5_dataset(imod5_data)
+            hfb = SingleLayerHorizontalFlowBarrierResistance.from_imod5_dataset(
+                imod5_data
+            )
             result["hfb"] = hfb
 
         return result

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -266,9 +266,11 @@ class GroundwaterFlowModel(Modflow6Model):
         # import hfb
         hfb_keys = [key for key in imod5_keys if key[0:3] == "hfb"]
         if len(hfb_keys) != 0:
-            hfb = SingleLayerHorizontalFlowBarrierResistance.from_imod5_dataset(
-                imod5_data
-            )
-            result["hfb"] = hfb
+            for hfb_key in hfb_keys:
+                result[hfb_key] = (
+                    SingleLayerHorizontalFlowBarrierResistance.from_imod5_dataset(
+                        hfb_key, imod5_data
+                    )
+                )
 
         return result

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -11,7 +11,7 @@ from imod.mf6 import ConstantHead
 from imod.mf6.clipped_boundary_condition_creator import create_clipped_boundary
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.drn import Drainage
-from imod.mf6.hfb import LayeredHorizontalFlowBarrierResistance
+from imod.mf6.hfb import SingleLayerHorizontalFlowBarrierResistance
 from imod.mf6.ic import InitialConditions
 from imod.mf6.model import Modflow6Model
 from imod.mf6.npf import NodePropertyFlow
@@ -266,7 +266,7 @@ class GroundwaterFlowModel(Modflow6Model):
         # import hfb
         hfb_keys = [key for key in imod5_keys if key[0:3] == "hfb"]
         if len(hfb_keys) != 0:
-            hfb = LayeredHorizontalFlowBarrierResistance.from_imod5_dataset(imod5_data)
+            hfb = SingleLayerHorizontalFlowBarrierResistance.from_imod5_dataset(imod5_data)
             result["hfb"] = hfb
 
         return result

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -203,6 +203,9 @@ class River(BoundaryCondition, IRegridPackage):
 
         Parameters
         ----------
+        key: str
+            Packagename of the package that needs to be converted to river
+            package.
         imod5_data: dict
             Dictionary with iMOD5 data. This can be constructed from the
             :func:`imod.formats.prj.open_projectfile_data` method.

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -505,16 +505,16 @@ class AnyValueSchema(ValueSchema):
 
 class MaxNUniqueValuesSchema(BaseSchema):
     """
-    Schema to validate if amount of unique values is correct.
+    Fails if amount of unique values exceeds a limit.
     """
 
-    def __init__(self, length: int):
-        self.length = length
+    def __init__(self, max_unique_values: int):
+        self.max_unique_values = max_unique_values
 
     def validate(self, obj: GridDataArray, **kwargs) -> None:
-        if len(np.unique(obj)) > self.length:
+        if len(np.unique(obj)) > self.max_unique_values:
             raise ValidationError(
-                f"Amount of unique values exceeds limit of {self.length}"
+                f"Amount of unique values exceeds limit of {self.max_unique_values}"
             )
 
 

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -503,6 +503,17 @@ class AnyValueSchema(ValueSchema):
             )
 
 
+class NUniqueValueSchema(BaseSchema):
+    """
+    Schema to validate if amount of unique values is correct.
+    """
+    def __init__(self, length: int):
+        self.length = length
+
+    def validate(self, obj: GridDataArray, **kwargs) -> None:
+        if len(np.unique(obj)) > self.length:
+            raise ValidationError(f"Amount of unique values exceeds limit of {self.length}")
+
 def _notnull(obj):
     """
     Helper function; does the same as xr.DataArray.notnull. This function is to

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -503,7 +503,7 @@ class AnyValueSchema(ValueSchema):
             )
 
 
-class NUniqueValueSchema(BaseSchema):
+class MaxNUniqueValuesSchema(BaseSchema):
     """
     Schema to validate if amount of unique values is correct.
     """

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -507,12 +507,16 @@ class NUniqueValueSchema(BaseSchema):
     """
     Schema to validate if amount of unique values is correct.
     """
+
     def __init__(self, length: int):
         self.length = length
 
     def validate(self, obj: GridDataArray, **kwargs) -> None:
         if len(np.unique(obj)) > self.length:
-            raise ValidationError(f"Amount of unique values exceeds limit of {self.length}")
+            raise ValidationError(
+                f"Amount of unique values exceeds limit of {self.length}"
+            )
+
 
 def _notnull(obj):
     """

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -514,7 +514,9 @@ def test_hfb_from_imod5(imod5_dataset, tmp_path):
         imod5_dataset, target_dis.dataset["idomain"]
     )
 
-    hfb = SingleLayerHorizontalFlowBarrierResistance.from_imod5_dataset("hfb-3", imod5_dataset)
+    hfb = SingleLayerHorizontalFlowBarrierResistance.from_imod5_dataset(
+        "hfb-3", imod5_dataset
+    )
     hfb_package = hfb.to_mf6_pkg(
         target_dis["idomain"], target_dis["top"], target_dis["bottom"], target_npf["k"]
     )

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -514,8 +514,8 @@ def test_hfb_from_imod5(imod5_dataset, tmp_path):
         imod5_dataset, target_dis.dataset["idomain"]
     )
 
-    hfb = SingleLayerHorizontalFlowBarrierResistance.from_imod5_dataset(imod5_dataset)
+    hfb = SingleLayerHorizontalFlowBarrierResistance.from_imod5_dataset("hfb-3", imod5_dataset)
     hfb_package = hfb.to_mf6_pkg(
         target_dis["idomain"], target_dis["top"], target_dis["bottom"], target_npf["k"]
     )
-    assert list(np.unique(hfb_package["layer"].values)) == [3, 21]
+    assert list(np.unique(hfb_package["layer"].values)) == [7]

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -12,9 +12,9 @@ from imod.mf6 import (
     HorizontalFlowBarrierHydraulicCharacteristic,
     HorizontalFlowBarrierMultiplier,
     HorizontalFlowBarrierResistance,
-    LayeredHorizontalFlowBarrierHydraulicCharacteristic,
-    LayeredHorizontalFlowBarrierMultiplier,
-    LayeredHorizontalFlowBarrierResistance,
+    SingleLayerHorizontalFlowBarrierHydraulicCharacteristic,
+    SingleLayerHorizontalFlowBarrierMultiplier,
+    SingleLayerHorizontalFlowBarrierResistance,
 )
 from imod.mf6.hfb import to_connected_cells_dataset
 from imod.mf6.utilities.regrid import RegridderWeightsCache
@@ -151,10 +151,10 @@ def test_to_mf6_creates_mf6_adapter(
 @pytest.mark.parametrize(
     "barrier_class, barrier_value_name, barrier_value, expected_hydraulic_characteristic",
     [
-        (LayeredHorizontalFlowBarrierResistance, "resistance", 1e3, 1e-3),
-        (LayeredHorizontalFlowBarrierMultiplier, "multiplier", 1.5, -1.5),
+        (SingleLayerHorizontalFlowBarrierResistance, "resistance", 1e3, 1e-3),
+        (SingleLayerHorizontalFlowBarrierMultiplier, "multiplier", 1.5, -1.5),
         (
-            LayeredHorizontalFlowBarrierHydraulicCharacteristic,
+            SingleLayerHorizontalFlowBarrierHydraulicCharacteristic,
             "hydraulic_characteristic",
             1e-3,
             1e-3,
@@ -305,7 +305,7 @@ def test_to_mf6_layered_hfb(mf6_flow_barrier_mock, basic_dis, layer, expected_va
         },
     )
 
-    hfb = LayeredHorizontalFlowBarrierResistance(geometry, print_input)
+    hfb = SingleLayerHorizontalFlowBarrierResistance(geometry, print_input)
 
     # Act.
     _ = hfb.to_mf6_pkg(idomain, top, bottom, k)
@@ -337,7 +337,7 @@ def test_to_mf6_layered_hfb__error():
         },
     )
 
-    hfb = LayeredHorizontalFlowBarrierResistance(geometry, print_input)
+    hfb = SingleLayerHorizontalFlowBarrierResistance(geometry, print_input)
     errors = hfb._validate(hfb._write_schemata)
 
     assert len(errors) > 0

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -485,5 +485,10 @@ def test_import_from_imod5(imod5_dataset, tmp_path):
 
     simulation.create_time_discretization(["01-01-2003", "02-01-2003"])
 
+    # Remove HFB packages outside domain
+    # TODO: Build in support for hfb packages outside domain
+    for hfb_outside in ["hfb-24", "hfb-26"]:
+        simulation["imported_model"].pop(hfb_outside)
+
     # write and validate the simulation.
     simulation.write(tmp_path, binary=False, validate=True)


### PR DESCRIPTION
Fixes #598

# Description
There was some confusion (also by me) about the use of the ``LayeredHorizontalFlowBarrier`` classes, so @HendrikKok explained me they were intended for single layers. I therefore changed the following to clarify:

- Rename to ``SingleLayerHorizontalFlowBarrier`` classes
- Throw ``ValidationError`` if multiple layers are added to dataset
- Added missing test for SingleLayerHorizontalFlowBarrier class

This means multiple SingleLayerHorizontalFlowBarrier need to be added to GroundwaterFlowModel object, whereas MODFLOW 6 only accepts one single HFB. So these have to be merged together. I think the best opportunity for this is to merge the low level ``Mf6HorizontalFlowBarrier`` objects.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
