### PR TITLE
added logging and error messages for well import when

### DIFF
--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -653,6 +653,31 @@ class Well(BoundaryCondition, IPointDataPackage):
         minimum_k: float = 0.1,
         minimum_thickness: float = 1.0,
     ) -> "Well":
+        if "layer" in imod5_data[key].keys():
+            if imod5_data[key]["layer"] != 0:
+                log_msg = textwrap.dedent(
+                    f"""
+                    In well {key} a layer was assigned, but this is not
+                    supported. Assignment will be done based on filter_top and
+                    filter_bottom, and the chosen layer ({imod5_data[key]["layer"]})
+                    will be ignored."""
+                )
+                logger.log(
+                    loglevel=LogLevel.WARNING, message=log_msg, additional_depth=2
+                )
+
+        if (
+            "filt_top" not in imod5_data[key]["dataframe"].columns
+            or "filt_bot" not in imod5_data[key]["dataframe"].columns
+        ):
+            log_msg = textwrap.dedent(
+                f"""
+                In well {key} the filt_top and filt_bot columns were not both found;
+                this is not supported for import."""
+            )
+            logger.log(loglevel=LogLevel.ERROR, message=log_msg, additional_depth=2)
+            raise ValueError(log_msg)
+
         df: pd.DataFrame = imod5_data[key]["dataframe"]
 
         # Groupby unique wells, to get dataframes per time.


### PR DESCRIPTION


Fixes #1095 

# Description
This PR adds logging to well import if the well was assigned to a layer. This layer will not be used and the user is informed of that in the log. 
If the filter_top and filter_bottom properties are not present in the imported dataset, both a log message and an exception is generated, as we can't import the well with this information missing

# Checklist


- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
