### PR TITLE
Start addressing #1116

### DIFF
--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -845,14 +845,17 @@ def _read_package_ipf(
                 times = set()
                 factors = set()
                 additions = set()
+                layers = set()
                 for entry in grouped[path]:
                     times.add(entry["time"])
                     factors.add(entry["factors"])
                     additions.add(entry["addition"])
+                    layers.add(entry["layer"])
 
                 missing_times = all_times - times
                 n_factors = len(factors)
                 n_additions = len(additions)
+                n_layers = len(layers)
                 if missing_times:
                     missing = ", ".join(missing_times)
                     problems[path].append(
@@ -865,6 +868,10 @@ def _read_package_ipf(
                 if n_additions > 1:
                     problems[path].append(
                         f"* More than one addition specified: {', '.join(additions)}"
+                    )
+                if n_layers > 1:
+                    problems[path].append(
+                        f"* More than one layer specified: {', '.join(layers)}"
                     )
 
         message = textwrap.dedent(


### PR DESCRIPTION
This is a start of addressing the issues described in #1116.

I haven't run any of this code, but it does contain most of the ideas. In my mind, this:

* has reasonable demands of the project file;
* gives a relatively clear error message if those demands are not met;
* returns a reasonable result for further processing.

The last point is the most contentious. You have logic for converting the list of dicts with dataframes into a dataset.
What this PR does address is the fact that for the simple IDFs, they have to be "turned off" every next stress period definition: essentially, we are turning the project file + simple IDFs into a time series for each well point too.

However, this requires inserting starting and end times into the dataframes. That could be done here, but it may be easier to do in the subsequent processing step. I find that difficult to judge.
Note that the associated IPFs already have a time column.