### PR TITLE
Issue #1092 merge chd

### DIFF
--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -30,6 +30,7 @@ from imod.mf6.regrid.regrid_schemes import (
 )
 from imod.mf6.riv import River
 from imod.mf6.sto import StorageCoefficient
+from imod.mf6.utilities.chd_concat import concat_layered_chd_packages
 from imod.mf6.utilities.regrid import RegridderWeightsCache
 from imod.mf6.wel import Well
 from imod.prepare.topsystem.default_allocation_methods import (
@@ -344,13 +345,21 @@ class GroundwaterFlowModel(Modflow6Model):
                 regrid_cache,
             )
         else:
+            chd_packages = {}
             for chd_key in chd_keys:
-                result[chd_key] = ConstantHead.from_imod5_data(
+                chd_packages[chd_key] = ConstantHead.from_imod5_data(
                     chd_key,
                     imod5_data,
                     dis_pkg,
                     cast(ConstantHeadRegridMethod, regridder_types.get(chd_key)),
                     regrid_cache,
                 )
+            merged_chd = concat_layered_chd_packages(
+                "chd", chd_packages, remove_merged_packages=True
+            )
+            if merged_chd is not None:
+                result["chd_merged"] = merged_chd
+            for key, chd_package in chd_packages.items():
+                result[key] = chd_package
 
         return result

--- a/imod/mf6/utilities/chd_concat.py
+++ b/imod/mf6/utilities/chd_concat.py
@@ -1,0 +1,48 @@
+from typing import Optional
+
+import xarray as xr
+
+from imod.mf6.chd import ConstantHead
+
+
+def concat_layered_chd_packages(
+    name: str,
+    dict_packages: dict[str, ConstantHead],
+    remove_merged_packages: bool = True,
+) -> Optional[ConstantHead]:
+    """
+
+    Parameters
+    ----------
+    name: str
+        The name of the package that was split over layers.
+        If they are called "chd-1" and so on then set name to "chd
+    dict_packages: dict[str, ConstantHead]
+        dictionary  with package names as key and the packages as values
+    remove_merged_packages: bool = True
+        set to True to remove merged packages from dict_packages
+
+    This function merges chd-packages whose name starts with "name" into a a
+    single chd package. This is aimed at chd packages that are split over
+    layers- so we would have chd-1, chd-2 and so on and these packages would
+    define a chd package for layer 1, 2 and so on. This function merges them
+    into a single chd package. If remove_merged_packages is True, then the
+    packages that are concatenated are removed from the input dictionary, so
+    that this on output only contains the packages that were not merged.
+    """
+
+    candidate_keys = [k for k in dict_packages.keys() if name in k]
+    if len(candidate_keys) == 0:
+        return None
+
+    dataset_list = []
+    for key in candidate_keys:
+        pack = dict_packages[key]
+        dataset_list.append(pack.dataset)
+        if remove_merged_packages:
+            dict_packages.pop(key)
+
+    concat_dataset = xr.concat(
+        dataset_list, dim="layer", compat="equals", data_vars="different"
+    )
+    return ConstantHead._from_dataset(concat_dataset)

--- a/imod/mf6/utilities/chd_concat.py
+++ b/imod/mf6/utilities/chd_concat.py
@@ -16,7 +16,7 @@ def concat_layered_chd_packages(
     ----------
     name: str
         The name of the package that was split over layers.
-        If they are called "chd-1" and so on then set name to "chd
+        If they are called "chd-1" and so on then set name to "chd"
     dict_packages: dict[str, ConstantHead]
         dictionary  with package names as key and the packages as values
     remove_merged_packages: bool = True

--- a/imod/mf6/utilities/chd_concat.py
+++ b/imod/mf6/utilities/chd_concat.py
@@ -31,7 +31,7 @@ def concat_layered_chd_packages(
     that this on output only contains the packages that were not merged.
     """
 
-    candidate_keys = [k for k in dict_packages.keys() if name in k]
+    candidate_keys = [k for k in dict_packages.keys() if name in k[0 : len(name)]]
     if len(candidate_keys) == 0:
         return None
 


### PR DESCRIPTION
Fixes #1092 

# Description
On import, chd packages that were split over layers are merged into a single chd package if the names of these packages are 
"chd-x" where x is a layer number. 
A function for this was added to mf6/utilities and not in the chd package to keep it hidden from users. 

# Checklist

- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
