### PR TITLE
Issue #1045 ghb allocation

### DIFF
--- a/imod/mf6/chd.py
+++ b/imod/mf6/chd.py
@@ -235,6 +235,9 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         regridder_types: ConstantHeadRegridMethod, optional
             Optional dataclass with regridder types for a specific variable.
             Use this to override default regridding methods.
+        regrid_cache:Optional RegridderWeightsCache
+            stores regridder weights for different regridders. Can be used to speed up regridding,
+            if the same regridders are used several times for regridding different arrays.
 
         Returns
         -------

--- a/imod/mf6/dis.py
+++ b/imod/mf6/dis.py
@@ -185,6 +185,9 @@ class StructuredDiscretization(Package, IRegridPackage, IMaskingSettings):
         regridder_types: DiscretizationRegridMethod, optional
             Optional dataclass with regridder types for a specific variable.
             Use this to override default regridding methods.
+        regrid_cache:Optional RegridderWeightsCache
+            stores regridder weights for different regridders. Can be used to speed up regridding,
+            if the same regridders are used several times for regridding different arrays.
 
         Returns
         -------

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -209,6 +209,9 @@ class Drainage(BoundaryCondition, IRegridPackage):
         regridder_types: DrainageRegridMethod, optional
             Optional dataclass with regridder types for a specific variable.
             Use this to override default regridding methods.
+        regrid_cache:Optional RegridderWeightsCache
+            stores regridder weights for different regridders. Can be used to speed up regridding,
+            if the same regridders are used several times for regridding different arrays.
 
         Returns
         -------

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -257,8 +257,7 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
             regridded_package_data["head"] = layered_head
 
             if "layer" in conductance.coords:
-                conductance = conductance.isel({"layer": 0})
-                conductance = conductance.drop_vars("layer")
+                conductance = conductance.isel({"layer": 0}, drop=True)
 
             regridded_package_data["conductance"] = distribute_ghb_conductance(
                 distributing_option,

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -243,7 +243,7 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
             planar_head = regridded_package_data["head"]
             k = target_npf.dataset["k"]
 
-            ghb_alocation = allocate_ghb_cells(
+            ghb_allocation = allocate_ghb_cells(
                 allocation_option,
                 target_idomain == 1,
                 target_top,
@@ -251,7 +251,7 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
                 planar_head,
             )
 
-            layered_head = planar_head.where(ghb_alocation)
+            layered_head = planar_head.where(ghb_allocation)
             layered_head = enforce_dim_order(layered_head)
 
             regridded_package_data["head"] = layered_head
@@ -261,7 +261,7 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
 
             regridded_package_data["conductance"] = distribute_ghb_conductance(
                 distributing_option,
-                ghb_alocation,
+                ghb_allocation,
                 conductance,
                 target_top,
                 target_bottom,

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -14,7 +14,10 @@ from imod.mf6.regrid.regrid_schemes import (
 from imod.mf6.utilities.regrid import RegridderWeightsCache, _regrid_package_data
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA, CONC_DIMS_SCHEMA
 from imod.prepare.topsystem.allocation import ALLOCATION_OPTION, allocate_ghb_cells
-from imod.prepare.topsystem.conductance import DISTRIBUTING_OPTION, distribute_ghb_conductance
+from imod.prepare.topsystem.conductance import (
+    DISTRIBUTING_OPTION,
+    distribute_ghb_conductance,
+)
 from imod.schemata import (
     AllInsideNoDataSchema,
     AllNoDataSchema,
@@ -168,14 +171,13 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         imod5_data: dict[str, dict[str, GridDataArray]],
         period_data: dict[str, list[datetime]],
         target_discretization,
-        target_npf: NodePropertyFlow,        
+        target_npf: NodePropertyFlow,
         time_min: datetime,
         time_max: datetime,
         allocation_option: ALLOCATION_OPTION,
-        distributing_option: DISTRIBUTING_OPTION,  
-        regrid_cache: RegridderWeightsCache = RegridderWeightsCache(),        
+        distributing_option: DISTRIBUTING_OPTION,
+        regrid_cache: RegridderWeightsCache = RegridderWeightsCache(),
         regridder_types: Optional[RegridMethodType] = None,
-      
     ) -> "GeneralHeadBoundary":
         """
         Construct a GeneralHeadBoundary-package from iMOD5 data, loaded with the
@@ -197,7 +199,7 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
             The grid that should be used for the new package. Does not
             need to be identical to one of the input grids.
         target_npf: NodePropertyFlow package
-            The conductivity information, used to compute drainage flux
+            The conductivity information, used to compute GHB flux
         allocation_option: ALLOCATION_OPTION
             allocation option.
         distributing_option: dict[str, DISTRIBUTING_OPTION]
@@ -225,7 +227,6 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         }
         is_planar = is_planar_grid(data["conductance"])
 
-        
         if regridder_types is None:
             regridder_types = GeneralHeadBoundaryRegridMethod()
 
@@ -244,15 +245,15 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
                 target_bottom,
                 head,
             )
-            
+
             regridded_package_data["conductance"] = distribute_ghb_conductance(
                 distributing_option,
                 ghb_alocation,
                 conductance,
                 target_top,
                 target_bottom,
-                k
-            )     
+                k,
+            )
 
         ghb = GeneralHeadBoundary(**regridded_package_data)
         repeat = period_data.get(key)

--- a/imod/mf6/ic.py
+++ b/imod/mf6/ic.py
@@ -121,6 +121,9 @@ class InitialConditions(Package, IRegridPackage):
         regridder_types: RegridMethodType, optional
             Optional dataclass with regridder types for a specific variable.
             Use this to override default regridding methods.
+        regrid_cache:Optional RegridderWeightsCache
+            stores regridder weights for different regridders. Can be used to speed up regridding,
+            if the same regridders are used several times for regridding different arrays.
 
         Returns
         -------

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -6,6 +6,7 @@ from typing import Optional
 import cftime
 import numpy as np
 
+from imod.flow.ghb import GeneralHeadBoundary
 from imod.logging import init_log_decorator
 from imod.logging.logging_decorators import standard_log_decorator
 from imod.mf6 import ConstantHead
@@ -238,8 +239,26 @@ class GroundwaterFlowModel(Modflow6Model):
         result["rch"] = rch_pkg
 
         # now import the non-singleton packages
-        # import drainage
+        # import ghb
         imod5_keys = list(imod5_data.keys())
+        ghb_keys = [key for key in imod5_keys if key[0:3] == "ghb"]
+        for ghb_key in ghb_keys:
+            ghb_pkg = GeneralHeadBoundary.from_imod5_data(
+                ghb_key,
+                imod5_data,
+                period_data,
+                dis_pkg,
+                npf_pkg,      
+                time_min,
+                time_max,
+                allocation_options.ghb,
+                distributing_options.ghb,  
+                regridder_types,                
+            )
+            result[ghb_key] = ghb_pkg
+
+        # import drainage
+
         drainage_keys = [key for key in imod5_keys if key[0:3] == "drn"]
         for drn_key in drainage_keys:
             drn_pkg = Drainage.from_imod5_data(

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -6,13 +6,13 @@ from typing import Optional, cast
 import cftime
 import numpy as np
 
-from imod.flow.ghb import GeneralHeadBoundary
 from imod.logging import init_log_decorator
 from imod.logging.logging_decorators import standard_log_decorator
 from imod.mf6 import ConstantHead
 from imod.mf6.clipped_boundary_condition_creator import create_clipped_boundary
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.drn import Drainage
+from imod.mf6.ghb import GeneralHeadBoundary
 from imod.mf6.hfb import SingleLayerHorizontalFlowBarrierResistance
 from imod.mf6.ic import InitialConditions
 from imod.mf6.model import Modflow6Model
@@ -22,6 +22,7 @@ from imod.mf6.regrid.regrid_schemes import (
     ConstantHeadRegridMethod,
     DiscretizationRegridMethod,
     DrainageRegridMethod,
+    GeneralHeadBoundaryRegridMethod,
     InitialConditionsRegridMethod,
     NodePropertyFlowRegridMethod,
     RechargeRegridMethod,
@@ -285,7 +286,6 @@ class GroundwaterFlowModel(Modflow6Model):
         for wel_key in wel_keys:
             result[wel_key] = Well.from_imod5_data(wel_key, imod5_data, times)
 
-                    
         imod5_keys = list(imod5_data.keys())
         ghb_keys = [key for key in imod5_keys if key[0:3] == "ghb"]
         for ghb_key in ghb_keys:
@@ -295,11 +295,14 @@ class GroundwaterFlowModel(Modflow6Model):
                 period_data,
                 dis_pkg,
                 npf_pkg,
-                time_min,
-                time_max,
+                times[0],
+                times[-1],
                 allocation_options.ghb,
                 distributing_options.ghb,
-                regridder_types,
+                regridder_types=cast(
+                    GeneralHeadBoundaryRegridMethod, regridder_types.get(ghb_key)
+                ),
+                regrid_cache=regrid_cache,
             )
             result[ghb_key] = ghb_pkg
 

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -261,12 +261,12 @@ class GroundwaterFlowModel(Modflow6Model):
                 imod5_data,
                 period_data,
                 dis_pkg,
-                npf_pkg,      
+                npf_pkg,
                 time_min,
                 time_max,
                 allocation_options.ghb,
-                distributing_options.ghb,  
-                regridder_types,                
+                distributing_options.ghb,
+                regridder_types,
             )
             result[ghb_key] = ghb_pkg
 

--- a/imod/mf6/npf.py
+++ b/imod/mf6/npf.py
@@ -479,6 +479,9 @@ class NodePropertyFlow(Package, IRegridPackage):
         regridder_types: RegridMethodType, optional
             Optional dataclass with regridder types for a specific variable.
             Use this to override default regridding methods.
+        regrid_cache:Optional RegridderWeightsCache
+            stores regridder weights for different regridders. Can be used to speed up regridding,
+            if the same regridders are used several times for regridding different arrays.
 
         Returns
         -------

--- a/imod/mf6/rch.py
+++ b/imod/mf6/rch.py
@@ -181,6 +181,9 @@ class Recharge(BoundaryCondition, IRegridPackage):
         regridder_types: RechargeRegridMethod, optional
             Optional dataclass with regridder types for a specific variable.
             Use this to override default regridding methods.
+        regrid_cache:Optional RegridderWeightsCache
+            stores regridder weights for different regridders. Can be used to speed up regridding,
+            if the same regridders are used several times for regridding different arrays.
 
         Returns
         -------

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -230,6 +230,9 @@ class River(BoundaryCondition, IRegridPackage):
         regridder_types: RiverRegridMethod, optional
             Optional dataclass with regridder types for a specific variable.
             Use this to override default regridding methods.
+        regrid_cache:Optional RegridderWeightsCache
+            stores regridder weights for different regridders. Can be used to speed up regridding,
+            if the same regridders are used several times for regridding different arrays.
 
         Returns
         -------

--- a/imod/mf6/sto.py
+++ b/imod/mf6/sto.py
@@ -347,6 +347,9 @@ class StorageCoefficient(StorageBase):
         regridder_types: StorageCoefficientRegridMethod, optional
             Optional dataclass with regridder types for a specific variable.
             Use this to override default regridding methods.
+        regrid_cache:Optional RegridderWeightsCache
+            stores regridder weights for different regridders. Can be used to speed up regridding,
+            if the same regridders are used several times for regridding different arrays.
 
         Returns
         -------

--- a/imod/prepare/topsystem/default_allocation_methods.py
+++ b/imod/prepare/topsystem/default_allocation_methods.py
@@ -38,3 +38,4 @@ class SimulationDistributingOptions:
 
     drn: DISTRIBUTING_OPTION = DISTRIBUTING_OPTION.by_corrected_transmissivity
     riv: DISTRIBUTING_OPTION = DISTRIBUTING_OPTION.by_corrected_transmissivity
+    ghb: DISTRIBUTING_OPTION = DISTRIBUTING_OPTION.by_corrected_transmissivity    

--- a/imod/prepare/topsystem/default_allocation_methods.py
+++ b/imod/prepare/topsystem/default_allocation_methods.py
@@ -38,4 +38,4 @@ class SimulationDistributingOptions:
 
     drn: DISTRIBUTING_OPTION = DISTRIBUTING_OPTION.by_corrected_transmissivity
     riv: DISTRIBUTING_OPTION = DISTRIBUTING_OPTION.by_corrected_transmissivity
-    ghb: DISTRIBUTING_OPTION = DISTRIBUTING_OPTION.by_corrected_transmissivity    
+    ghb: DISTRIBUTING_OPTION = DISTRIBUTING_OPTION.by_corrected_transmissivity

--- a/imod/prepare/topsystem/default_allocation_methods.py
+++ b/imod/prepare/topsystem/default_allocation_methods.py
@@ -20,6 +20,7 @@ class SimulationAllocationOptions:
 
     drn: ALLOCATION_OPTION = ALLOCATION_OPTION.first_active_to_elevation
     riv: ALLOCATION_OPTION = ALLOCATION_OPTION.stage_to_riv_bot
+    ghb: ALLOCATION_OPTION = ALLOCATION_OPTION.at_elevation
 
 
 @dataclass()

--- a/imod/tests/test_mf6/test_mf6_generalheadboundary.py
+++ b/imod/tests/test_mf6/test_mf6_generalheadboundary.py
@@ -8,7 +8,7 @@ from imod.prepare.topsystem.allocation import ALLOCATION_OPTION
 from imod.prepare.topsystem.conductance import DISTRIBUTING_OPTION
 
 
-def test_from_imod5(imod5_dataset_periods, tmp_path):
+def test_from_imod5_non_planar(imod5_dataset_periods, tmp_path):
     period_data = imod5_dataset_periods[1]
     imod5_dataset = imod5_dataset_periods[0]
     target_dis = StructuredDiscretization.from_imod5_data(imod5_dataset, validate=False)
@@ -26,6 +26,37 @@ def test_from_imod5(imod5_dataset_periods, tmp_path):
         time_max=datetime(2022, 2, 2),
         allocation_option=ALLOCATION_OPTION.at_elevation,
         distributing_option=DISTRIBUTING_OPTION.by_crosscut_thickness,
+    )
+
+    assert isinstance(ghb, imod.mf6.GeneralHeadBoundary)
+
+    # write the packages for write validation
+    write_context = WriteContext(simulation_directory=tmp_path, use_binary=False)
+    ghb.write("ghb", [1], write_context)
+
+
+def test_from_imod5_planar(imod5_dataset_periods, tmp_path):
+    period_data = imod5_dataset_periods[1]
+    imod5_dataset = imod5_dataset_periods[0]
+    target_dis = StructuredDiscretization.from_imod5_data(imod5_dataset, validate=False)
+    target_npf = NodePropertyFlow.from_imod5_data(
+        imod5_dataset, target_dis.dataset["idomain"]
+    )
+    imod5_dataset["ghb"]["conductance"] = imod5_dataset["ghb"][
+        "conductance"
+    ].assign_coords({"layer": [0]})
+    imod5_dataset["ghb"]["head"] = imod5_dataset["ghb"]["head"].isel({"layer": 0})
+
+    ghb = imod.mf6.GeneralHeadBoundary.from_imod5_data(
+        "ghb",
+        imod5_dataset,
+        period_data,
+        target_dis,
+        target_npf,
+        time_min=datetime(2002, 2, 2),
+        time_max=datetime(2022, 2, 2),
+        allocation_option=ALLOCATION_OPTION.at_elevation,
+        distributing_option=DISTRIBUTING_OPTION.by_layer_thickness,
     )
 
     assert isinstance(ghb, imod.mf6.GeneralHeadBoundary)

--- a/imod/tests/test_mf6/test_mf6_generalheadboundary.py
+++ b/imod/tests/test_mf6/test_mf6_generalheadboundary.py
@@ -2,22 +2,30 @@ from datetime import datetime
 
 import imod
 from imod.mf6.dis import StructuredDiscretization
+from imod.mf6.npf import NodePropertyFlow
 from imod.mf6.write_context import WriteContext
+from imod.prepare.topsystem.allocation import ALLOCATION_OPTION
+from imod.prepare.topsystem.conductance import DISTRIBUTING_OPTION
 
 
 def test_from_imod5(imod5_dataset_periods, tmp_path):
     period_data = imod5_dataset_periods[1]
     imod5_dataset = imod5_dataset_periods[0]
     target_dis = StructuredDiscretization.from_imod5_data(imod5_dataset, validate=False)
+    target_npf = NodePropertyFlow.from_imod5_data(
+        imod5_dataset, target_dis.dataset["idomain"]
+    )
 
     ghb = imod.mf6.GeneralHeadBoundary.from_imod5_data(
         "ghb",
         imod5_dataset,
         period_data,
         target_dis,
+        target_npf,
         time_min=datetime(2002, 2, 2),
         time_max=datetime(2022, 2, 2),
-        regridder_types=None,
+        allocation_option=ALLOCATION_OPTION.at_elevation,
+        distributing_option=DISTRIBUTING_OPTION.by_crosscut_thickness,
     )
 
     assert isinstance(ghb, imod.mf6.GeneralHeadBoundary)


### PR DESCRIPTION
Fixes #1045

# Description
Enables using allocation options when importing a ghb from imod5 and it is planar (layer=0)

# Checklist

- [X] Links to correct issue
- [ ] Update changelog, if changes affect users
- [X] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [X] Unit tests were added
- [ ] **If feature added**: Added/extended example
