### PR TITLE
Issue #1139 apply factor and addition

### DIFF
--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -522,21 +522,24 @@ def _try_read_with_func(func, path, *args, **kwargs):
         raise type(e)(f"{e}. Error thrown while opening file: {path}")
 
 
-def _create_arithmetic_dataarray(
+def _get_array_transformation_parameters(
     headers: List[Dict[str, Any]], key: str, dim: str
 ) -> xr.DataArray:
-    return xr.DataArray(
-        data=[header[key] for header in headers],
-        dims=(dim,),
-        coords={dim: [header[dim] for header in headers]},
-    )
+    if dim in headers[0].keys():
+        return xr.DataArray(
+            data=[header[key] for header in headers],
+            dims=(dim,),
+            coords={dim: [header[dim] for header in headers]},
+        )
+    else:
+        return headers[0][key]
 
 
 def _create_datarray_from_paths(
     paths: List[str], headers: List[Dict[str, Any]], dim: str
 ) -> xr.DataArray:
-    factor = _create_arithmetic_dataarray(headers, "factor", dim)
-    addition = _create_arithmetic_dataarray(headers, "addition", dim)
+    factor = _get_array_transformation_parameters(headers, "factor", dim)
+    addition = _get_array_transformation_parameters(headers, "addition", dim)
     da = _try_read_with_func(
         imod.formats.array_io.reading._load,
         paths,
@@ -550,8 +553,8 @@ def _create_datarray_from_paths(
 def _create_dataarray_from_values(
     values: List[float], headers: List[Dict[str, Any]], dim: str
 ):
-    factor = _create_arithmetic_dataarray(headers, "factor", dim)
-    addition = _create_arithmetic_dataarray(headers, "addition", dim)
+    factor = _get_array_transformation_parameters(headers, "factor", dim)
+    addition = _get_array_transformation_parameters(headers, "addition", dim)
     coords = _merge_coords(headers)
     firstdims = headers[0]["dims"]
     shape = [len(coord) for coord in coords.values()]

--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -522,7 +522,21 @@ def _try_read_with_func(func, path, *args, **kwargs):
         raise type(e)(f"{e}. Error thrown while opening file: {path}")
 
 
-def _create_datarray_from_paths(paths: List[str], headers: List[Dict[str, Any]]):
+def _create_arithmetic_dataarray(
+    headers: List[Dict[str, Any]], key: str, dim: str
+) -> xr.DataArray:
+    return xr.DataArray(
+        data=[header[key] for header in headers],
+        dims=(dim,),
+        coords={dim: [header[dim] for header in headers]},
+    )
+
+
+def _create_datarray_from_paths(
+    paths: List[str], headers: List[Dict[str, Any]], dim: str
+) -> xr.DataArray:
+    factor = _create_arithmetic_dataarray(headers, "factor", dim)
+    addition = _create_arithmetic_dataarray(headers, "addition", dim)
     da = _try_read_with_func(
         imod.formats.array_io.reading._load,
         paths,
@@ -530,22 +544,30 @@ def _create_datarray_from_paths(paths: List[str], headers: List[Dict[str, Any]])
         _read=imod.idf._read,
         headers=headers,
     )
-    return da
+    return da * factor + addition
 
 
-def _create_dataarray_from_values(values: List[float], headers: List[Dict[str, Any]]):
+def _create_dataarray_from_values(
+    values: List[float], headers: List[Dict[str, Any]], dim: str
+):
+    factor = _create_arithmetic_dataarray(headers, "factor", dim)
+    addition = _create_arithmetic_dataarray(headers, "addition", dim)
     coords = _merge_coords(headers)
     firstdims = headers[0]["dims"]
     shape = [len(coord) for coord in coords.values()]
     da = xr.DataArray(np.reshape(values, shape), dims=firstdims, coords=coords)
-    return da
+    return da * factor + addition
 
 
 def _create_dataarray(
-    paths: List[str], headers: List[Dict[str, Any]], values: List[float]
+    paths: List[str], headers: List[Dict[str, Any]], values: List[float], dim: str
 ) -> xr.DataArray:
     """
     Create a DataArray from a list of IDF paths, or from constant values.
+
+    There are mixed cases possible, where some of the layers or stress periods
+    contain only a single constant value, and the others are specified as IDFs.
+    In that case, we cannot do a straightforward concatenation.
     """
     values_valid = []
     paths_valid = []
@@ -560,54 +582,19 @@ def _create_dataarray(
             paths_valid.append(path)
 
     if paths_valid and values_valid:
-        dap = _create_datarray_from_paths(paths_valid, headers_paths)
+        # Both lists contain entries: mixed case.
+        dap = _create_datarray_from_paths(paths_valid, headers_paths, dim=dim)
         dav = _create_dataarray_from_values(values_valid, headers_values)
         dap.name = "tmp"
         dav.name = "tmp"
         da = xr.merge((dap, dav), join="outer")["tmp"]
     elif paths_valid:
-        da = _create_datarray_from_paths(paths_valid, headers_paths)
+        # Only paths provided
+        da = _create_datarray_from_paths(paths_valid, headers_paths, dim=dim)
     elif values_valid:
-        da = _create_dataarray_from_values(values_valid, headers_values)
+        # Only scalar values provided
+        da = _create_dataarray_from_values(values_valid, headers_values, dim=dim)
 
-    da = apply_factor_and_addition(headers, da)
-    return da
-
-
-def apply_factor_and_addition(headers, da):
-    if not ("layer" in da.coords or "time" in da.dims):
-        factor = headers[0]["factor"]
-        addition = headers[0]["addition"]
-        da = da * factor + addition
-    elif "layer" in da.coords and "time" not in da.dims:
-        da = apply_factor_and_addition_per_layer(headers, da)
-    else:
-        header_per_time = defaultdict(list)
-        for time in da.coords["time"].values:
-            for header in headers:
-                if np.datetime64(header["time"]) == time:
-                    header_per_time[time].append(header)
-
-        for time in da.coords["time"]:
-            da.loc[{"time": time}] = apply_factor_and_addition(
-                header_per_time[np.datetime64(time.values)],
-                da.sel(time=time, drop=True),
-            )
-    return da
-
-
-def apply_factor_and_addition_per_layer(headers, da):
-    layer = da.coords["layer"].values
-    header_per_layer = {}
-    for header in headers:
-        if header["layer"] in header_per_layer.keys():
-            raise ValueError("error in project file: layer repetition")
-        header_per_layer[header["layer"]] = header
-    addition_values = [header_per_layer[lay]["addition"] for lay in layer]
-    factor_values = [header_per_layer[lay]["factor"] for lay in layer]
-    addition = xr.DataArray(addition_values, coords={"layer": layer}, dims=("layer"))
-    factor = xr.DataArray(factor_values, coords={"layer": layer}, dims=("layer",))
-    da = da * factor + addition
     return da
 
 
@@ -631,7 +618,7 @@ def _open_package_idf(
             headers.append(header)
             values.append(value)
 
-        das[variable] = _create_dataarray(paths, headers, values)
+        das[variable] = _create_dataarray(paths, headers, values, dim="layer")
 
     return [das]
 
@@ -758,7 +745,7 @@ def _open_boundary_condition_idf(
         for i, (paths, headers, values) in enumerate(
             zip(system_paths.values(), system_headers.values(), system_values.values())
         ):
-            das[i][variable] = _create_dataarray(paths, headers, values)
+            das[i][variable] = _create_dataarray(paths, headers, values, dim="time")
 
     repeats = sorted(all_repeats)
     return das, repeats


### PR DESCRIPTION
Fixes #1139 

# Description
Loading project files turned out to be a time-sink for project file imports- especially when loading prj-file data with transient arrays such as chd-levels per timestep. 
These arrays were loaded in a function called "apply_factor_and_addition" which accounted for the fact that the user can specify a factor to multiply each array and a constant to add to it. These 2 (factor and addition) can be different for every timestep. 
Now they are applied at an earlier stage, when loading the ipf data. 

No new tests were added, because the tests in  test_import_prj.py already test the application of factors and additions. (this PR is for improving performance and not changing behavior)

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
