### PR TITLE
Issue #1152 metaswap regridding methods

### DIFF
--- a/imod/mf6/utilities/regrid.py
+++ b/imod/mf6/utilities/regrid.py
@@ -265,7 +265,7 @@ def _regrid_like(
         remove_expanded_auxiliary_variables_from_dataset(package)
 
     if regridder_types is None:
-        regridder_settings = package.get_regrid_methods()
+        regridder_settings = asdict(package.get_regrid_methods(), dict_factory=dict)
     else:
         regridder_settings = asdict(regridder_types, dict_factory=dict)
 

--- a/imod/mf6/utilities/regrid.py
+++ b/imod/mf6/utilities/regrid.py
@@ -265,7 +265,11 @@ def _regrid_like(
         remove_expanded_auxiliary_variables_from_dataset(package)
 
     if regridder_types is None:
-        regridder_settings = asdict(package.get_regrid_methods(), dict_factory=dict)
+        regridder_types = package.get_regrid_methods()
+        if isinstance(regridder_types, dict):
+            regridder_settings = regridder_types
+        else:
+            regridder_settings = asdict(regridder_types, dict_factory=dict)
     else:
         regridder_settings = asdict(regridder_types, dict_factory=dict)
 

--- a/imod/tests/test_msw/test_annual_crop_factors.py
+++ b/imod/tests/test_msw/test_annual_crop_factors.py
@@ -41,8 +41,8 @@ def setup_cropfactors():
 
 
 def get_new_grid():
-    x = list( range(100))
-    y = list( range(100, 0, -1))
+    x = list(range(100))
+    y = list(range(100, 0, -1))
     subunit = [0, 1]
     dx = 0.5
     dy = 0.5

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -396,11 +396,11 @@ def preserve_gridtype(func: Callable[P, T]) -> Callable[P, T]:
     return decorator
 
 
-@typedispatch # type: ignore[no-redef]
-def is_empty(object: xr.Dataset) -> bool: 
+@typedispatch  # type: ignore[no-redef]
+def is_empty(object: xr.Dataset) -> bool:
     return len(object.keys()) == 0
 
 
-@typedispatch # type: ignore[no-redef]
-def is_empty(object: object) -> bool: # noqa: F811
+@typedispatch  # type: ignore[no-redef]
+def is_empty(object: object) -> bool:  # noqa: F811
     return False


### PR DESCRIPTION
Fixes #1152 

# Description
makes the metaswap regridding branch compatible with both the dataclass object and the dictionary object to specify regridding methods

# Checklist


- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
