### PR TITLE
Issue #1132 performance hfb

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -15,7 +15,8 @@ Fixed
 - Multiple ``HorizontalFlowBarrier`` objects attached to
   :class:`imod.mf6.GroundwaterFlowModel` are merged into a single horizontal
   flow barrier for MODFLOW 6
-
+- Bug where error would be thrown when barriers in a ``HorizontalFlowBarrier``
+  would be snapped to the same cell edge. These are now summed.
 
 Changed
 ~~~~~~~

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -391,6 +391,13 @@ def _snap_to_grid_and_aggregate(
         Grid to snap lines to
     vardict_agg: dict
         Mapping of variable name to aggregation method
+    
+    Returns
+    -------
+    snapping_dataset: xugrid.UgridDataset
+        Dataset with all variables snapped and aggregated to cell edges
+    edge_index: numpy.array
+        1D array with indices of cell edges that lines were snapped to
     """
     snapping_df = xu.create_snap_to_grid_dataframe(
         barrier_dataframe, grid2d, max_snap_distance=0.5

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -28,7 +28,7 @@ from imod.mf6.utilities.hfb import (
 )
 from imod.schemata import EmptyIndexesSchema, MaxNUniqueValuesSchema
 from imod.typing import GeoDataFrameType, GridDataArray, LineStringType
-from imod.typing.grid import enforce_uda
+from imod.typing.grid import as_ugrid_dataarray
 from imod.util.imports import MissingOptionalModule
 
 if TYPE_CHECKING:
@@ -514,7 +514,7 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
         k = idomain * k
         # Enforce unstructured
         unstructured_grid, top, bottom, k = (
-            enforce_uda(grid) for grid in [idomain, top, bottom, k]
+            as_ugrid_dataarray(grid) for grid in [idomain, top, bottom, k]
         )
         snapped_dataset, edge_index = self._snap_to_grid(idomain)
         edge_index = self.__remove_invalid_edges(unstructured_grid, edge_index)
@@ -810,7 +810,7 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
         if has_layer:
             vardict_agg["layer"] = "first"
         # Create grid from structured
-        grid2d = enforce_uda(idomain.sel(layer=1)).grid
+        grid2d = as_ugrid_dataarray(idomain.sel(layer=1)).grid
 
         return _snap_to_grid_and_aggregate(barrier_dataframe, grid2d, vardict_agg)
 

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -377,7 +377,7 @@ def _prepare_barrier_dataset_for_mf6_adapter(dataset: xr.Dataset) -> xr.Dataset:
 
 
 def _snap_to_grid_and_aggregate(
-    barrier_dataframe: gpd.GeoDataFrame, grid2d: xu.Ugrid2d, vardict_agg: dict[str, str]
+    barrier_dataframe: GeoDataFrameType, grid2d: xu.Ugrid2d, vardict_agg: dict[str, str]
 ) -> tuple[xu.UgridDataset, npt.NDArray]:
     """
     Snap barrier dataframe to grid and aggregate multiple lines with a list of

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -391,7 +391,7 @@ def _snap_to_grid_and_aggregate(
         Grid to snap lines to
     vardict_agg: dict
         Mapping of variable name to aggregation method
-    
+
     Returns
     -------
     snapping_dataset: xugrid.UgridDataset
@@ -405,7 +405,8 @@ def _snap_to_grid_and_aggregate(
     # Map other variables to snapping_df with line indices
     line_index = snapping_df["line_index"]
     vars_to_snap = list(vardict_agg.keys())
-    vars_to_snap.remove("line_index")  # snapping_df already has line_index
+    if "line_index" in vars_to_snap:
+        vars_to_snap.remove("line_index")  # snapping_df already has line_index
     for varname in vars_to_snap:
         snapping_df[varname] = barrier_dataframe[varname].iloc[line_index].to_numpy()
     # Aggregate to grid edges

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -506,7 +506,9 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
         top, bottom = broadcast_to_full_domain(idomain, top, bottom)
         k = idomain * k
         # Enforce unstructured
-        unstructured_grid, top, bottom, k = (enforce_uda(grid) for grid in [idomain, top, bottom, k])
+        unstructured_grid, top, bottom, k = (
+            enforce_uda(grid) for grid in [idomain, top, bottom, k]
+        )
         snapped_dataset, edge_index = self._snap_to_grid(idomain)
         edge_index = self.__remove_invalid_edges(unstructured_grid, edge_index)
 

--- a/imod/tests/test_mf6/test_mf6_LHM.py
+++ b/imod/tests/test_mf6/test_mf6_LHM.py
@@ -1,5 +1,5 @@
 """
-LHM tests, these are pytest marked with 'lhm'.
+LHM tests, these are pytest-marked with 'user_acceptance'.
 
 These require the LHM model to be available on the local drive. The tests looks
 for the path to the projectfile needs to be included in a .env file, with the
@@ -61,7 +61,7 @@ def LHM_imod5_data():
     return simulation
 
 
-@pytest.mark.lhm
+@pytest.mark.user_acceptance
 def test_mf6_LHM_write_HFB(tmp_path):
     logfile_path = tmp_path / "logfile.txt"
     with open(logfile_path, "w") as sys.stdout:

--- a/imod/tests/test_mf6/test_mf6_LHM.py
+++ b/imod/tests/test_mf6/test_mf6_LHM.py
@@ -14,6 +14,8 @@ from imod.mf6.regrid.regrid_schemes import (
     StorageCoefficientRegridMethod,
 )
 from imod.mf6.simulation import Modflow6Simulation
+from imod.mf6.utilities.mf6hfb import merge_hfb_packages
+from imod.mf6.write_context import WriteContext
 from imod.prepare.topsystem.default_allocation_methods import (
     SimulationAllocationOptions,
     SimulationDistributingOptions,
@@ -22,6 +24,34 @@ from imod.prepare.topsystem.default_allocation_methods import (
 LHM_DIR = Path(
     r"c:\Users\engelen\projects_wdir\imod-python\imod5_converter\MODFLOW6_MODEL"
 )
+
+# @pytest.fixture(scope="module")
+def LHM_imod5_data():
+    data = open_projectfile_data(LHM_DIR / "LHM4.3_test.prj")
+
+    imod5_data = data[0]
+    period_data = data[1]
+    default_simulation_allocation_options = SimulationAllocationOptions
+    default_simulation_distributing_options = SimulationDistributingOptions
+
+    regridding_option = {}
+    regridding_option["npf"] = NodePropertyFlowRegridMethod()
+    regridding_option["dis"] = DiscretizationRegridMethod()
+    regridding_option["sto"] = StorageCoefficientRegridMethod()
+    times = pd.date_range(start="1/1/2018", end="12/1/2018", freq="ME")
+
+    simulation = Modflow6Simulation.from_imod5_data(
+        imod5_data,
+        period_data,
+        default_simulation_allocation_options,
+        default_simulation_distributing_options,
+        times,
+        regridding_option,
+    )
+    simulation["imported_model"]["oc"] = OutputControl(
+        save_head="last", save_budget="last"
+    )
+    return simulation
 
 
 def test_mf6_LHM(tmp_path):
@@ -33,32 +63,42 @@ def test_mf6_LHM(tmp_path):
             add_default_file_handler=False,
             add_default_stream_handler=True,
         )
-        data = open_projectfile_data(LHM_DIR / "LHM4.3_test.prj")
-
-        imod5_data = data[0]
-        period_data = data[1]
-        default_simulation_allocation_options = SimulationAllocationOptions
-        default_simulation_distributing_options = SimulationDistributingOptions
-
-        regridding_option = {}
-        regridding_option["npf"] = NodePropertyFlowRegridMethod()
-        regridding_option["dis"] = DiscretizationRegridMethod()
-        regridding_option["sto"] = StorageCoefficientRegridMethod()
-        times = pd.date_range(start="1/1/2018", end="12/1/2018", freq="ME")
-
-        simulation = Modflow6Simulation.from_imod5_data(
-            imod5_data,
-            period_data,
-            default_simulation_allocation_options,
-            default_simulation_distributing_options,
-            times,
-            regridding_option,
-        )
-        simulation["imported_model"]["oc"] = OutputControl(
-            save_head="last", save_budget="last"
-        )
+        simulation = LHM_imod5_data()
 
         for k, package in simulation["imported_model"].items():
             package.dataset.load()
         simulation.write(tmp_path, binary=False, validate=True)
-    pass
+
+
+def test_mf6_LHM_write_HFB(tmp_path):
+    logfile_path = tmp_path / "logfile.txt"
+    with open(logfile_path, "w") as sys.stdout:
+        imod.logging.configure(
+            LoggerType.PYTHON,
+            log_level=LogLevel.DEBUG,
+            add_default_file_handler=False,
+            add_default_stream_handler=True,
+        )
+        simulation = LHM_imod5_data()
+        model = simulation["imported_model"]
+
+        mf6_hfb_ls = []
+        for key, pkg in model.items():
+            if issubclass(type(pkg), imod.mf6.HorizontalFlowBarrierBase):
+                mf6_hfb_ls.append(pkg)
+            pkg.dataset.load()
+
+        top, bottom, idomain = model._Modflow6Model__get_domain_geometry()
+        k = model._Modflow6Model__get_k()
+
+        mf6_hfb = merge_hfb_packages(mf6_hfb_ls, idomain, top, bottom, k)
+
+        times = pd.date_range(start="1/1/2018", end="12/1/2018", freq="ME")
+
+        out_dir = tmp_path / "LHM"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        write_context = WriteContext(out_dir, use_binary=True, use_absolute_paths=False)
+
+        mf6_hfb.write("hfb", times, write_context)
+
+

--- a/imod/tests/test_mf6/test_mf6_LHM.py
+++ b/imod/tests/test_mf6/test_mf6_LHM.py
@@ -14,13 +14,14 @@ from imod.mf6.regrid.regrid_schemes import (
     StorageCoefficientRegridMethod,
 )
 from imod.mf6.simulation import Modflow6Simulation
-from imod.mf6.utilities.mask import mask_arrays
 from imod.prepare.topsystem.default_allocation_methods import (
     SimulationAllocationOptions,
     SimulationDistributingOptions,
 )
 
-LHM_DIR = Path(r"c:\Users\engelen\projects_wdir\imod-python\imod5_converter\MODFLOW6_MODEL")
+LHM_DIR = Path(
+    r"c:\Users\engelen\projects_wdir\imod-python\imod5_converter\MODFLOW6_MODEL"
+)
 
 
 def test_mf6_LHM(tmp_path):
@@ -61,4 +62,3 @@ def test_mf6_LHM(tmp_path):
             package.dataset.load()
         simulation.write(tmp_path, binary=False, validate=True)
     pass
-

--- a/imod/tests/test_mf6/test_mf6_LHM.py
+++ b/imod/tests/test_mf6/test_mf6_LHM.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+import imod
+from imod.formats.prj.prj import open_projectfile_data
+from imod.logging.config import LoggerType
+from imod.logging.loglevel import LogLevel
+from imod.mf6.oc import OutputControl
+from imod.mf6.regrid.regrid_schemes import (
+    DiscretizationRegridMethod,
+    NodePropertyFlowRegridMethod,
+    StorageCoefficientRegridMethod,
+)
+from imod.mf6.simulation import Modflow6Simulation
+from imod.mf6.utilities.mask import mask_arrays
+from imod.prepare.topsystem.default_allocation_methods import (
+    SimulationAllocationOptions,
+    SimulationDistributingOptions,
+)
+
+LHM_DIR = Path(r"c:\Users\engelen\projects_wdir\imod-python\imod5_converter\MODFLOW6_MODEL")
+
+
+def test_mf6_LHM(tmp_path):
+    logfile_path = tmp_path / "logfile.txt"
+    with open(logfile_path, "w") as sys.stdout:
+        imod.logging.configure(
+            LoggerType.PYTHON,
+            log_level=LogLevel.DEBUG,
+            add_default_file_handler=False,
+            add_default_stream_handler=True,
+        )
+        data = open_projectfile_data(LHM_DIR / "LHM4.3_test.prj")
+
+        imod5_data = data[0]
+        period_data = data[1]
+        default_simulation_allocation_options = SimulationAllocationOptions
+        default_simulation_distributing_options = SimulationDistributingOptions
+
+        regridding_option = {}
+        regridding_option["npf"] = NodePropertyFlowRegridMethod()
+        regridding_option["dis"] = DiscretizationRegridMethod()
+        regridding_option["sto"] = StorageCoefficientRegridMethod()
+        times = pd.date_range(start="1/1/2018", end="12/1/2018", freq="ME")
+
+        simulation = Modflow6Simulation.from_imod5_data(
+            imod5_data,
+            period_data,
+            default_simulation_allocation_options,
+            default_simulation_distributing_options,
+            times,
+            regridding_option,
+        )
+        simulation["imported_model"]["oc"] = OutputControl(
+            save_head="last", save_budget="last"
+        )
+
+        for k, package in simulation["imported_model"].items():
+            package.dataset.load()
+        simulation.write(tmp_path, binary=False, validate=True)
+    pass
+

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -728,7 +728,7 @@ def test_combine_linestrings(structured_flow_model):
     mf6_hfb_single = hfb_single.to_mf6_pkg(idomain, top, bottom, k)
     mf6_hfb_triple = hfb_triple.to_mf6_pkg(idomain, top, bottom, k)
 
-    xr.testing.equals(mf6_hfb_single.dataset, mf6_hfb_triple.dataset)
+    xr.testing.assert_equal(mf6_hfb_single.dataset, mf6_hfb_triple.dataset)
 
 
 @pytest.mark.usefixtures("structured_flow_model")

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -697,6 +697,40 @@ def test_hfb_from_imod5(imod5_dataset, tmp_path):
     assert list(np.unique(hfb_package["layer"].values)) == [7]
 
 
+
+
+@pytest.mark.usefixtures("structured_flow_model")
+def test_combine_linestrings(structured_flow_model):
+    dis = structured_flow_model["dis"]
+    top, bottom, idomain = dis["top"], dis["bottom"], dis["idomain"],
+    k = xr.ones_like(idomain)
+
+    barrier_y = [11.0, 5.0, -1.0]
+    barrier_x = [5.0, 5.0, 5.0]
+    line = linestrings(barrier_x, barrier_y)
+
+    geometry_single = gpd.GeoDataFrame(
+        geometry=[line],
+        data={
+            "resistance": [1200.0],
+            "layer": [1],
+        },
+    )
+    geometry_triple = gpd.GeoDataFrame(
+        geometry=[line, line, line],
+        data={
+            "resistance": [400.0, 400.0, 400.0],
+            "layer": [1, 1, 1],
+        },
+    )
+    hfb_single = SingleLayerHorizontalFlowBarrierResistance(geometry_single)
+    hfb_triple = SingleLayerHorizontalFlowBarrierResistance(geometry_triple)
+    mf6_hfb_single = hfb_single.to_mf6_pkg(idomain, top, bottom, k)
+    mf6_hfb_triple = hfb_triple.to_mf6_pkg(idomain, top, bottom, k)
+
+    xr.testing.equals(mf6_hfb_single.dataset, mf6_hfb_triple.dataset)
+
+
 @pytest.mark.usefixtures("structured_flow_model")
 def test_run_multiple_hfbs(tmp_path, structured_flow_model):
     # Single layered model

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -697,12 +697,14 @@ def test_hfb_from_imod5(imod5_dataset, tmp_path):
     assert list(np.unique(hfb_package["layer"].values)) == [7]
 
 
-
-
 @pytest.mark.usefixtures("structured_flow_model")
 def test_combine_linestrings(structured_flow_model):
     dis = structured_flow_model["dis"]
-    top, bottom, idomain = dis["top"], dis["bottom"], dis["idomain"],
+    top, bottom, idomain = (
+        dis["top"],
+        dis["bottom"],
+        dis["idomain"],
+    )
     k = xr.ones_like(idomain)
 
     barrier_y = [11.0, 5.0, -1.0]

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -22,6 +22,7 @@ from imod.mf6.hfb import (
     _extract_mean_hfb_bounds_from_dataframe,
     _make_linestring_from_polygon,
     _prepare_barrier_dataset_for_mf6_adapter,
+    _snap_to_grid_and_aggregate,
     to_connected_cells_dataset,
 )
 from imod.mf6.ims import SolutionPresetSimple
@@ -695,6 +696,41 @@ def test_hfb_from_imod5(imod5_dataset, tmp_path):
         target_dis["idomain"], target_dis["top"], target_dis["bottom"], target_npf["k"]
     )
     assert list(np.unique(hfb_package["layer"].values)) == [7]
+
+
+@pytest.mark.usefixtures("structured_flow_model")
+def test_snap_to_grid_and_aggregate(structured_flow_model):
+    idomain = structured_flow_model["dis"]["idomain"]
+    grid2d = xu.Ugrid2d.from_structured(idomain)
+
+    barrier_y = [11.0, 5.0, -1.0]
+    barrier_x = [5.0, 5.0, 5.0]
+    line = linestrings(barrier_x, barrier_y)
+    layer = [1, 1, 1]
+
+    geometry_triple = gpd.GeoDataFrame(
+        geometry=[line, line, line],
+        data={
+            "resistance": [400.0, 400.0, 400.0],
+            "layer": layer,
+            "line_index": [0, 1, 2],
+        },
+    )
+    geometry_triple = geometry_triple.set_index("line_index")
+
+    vardict_agg = {"resistance": "sum", "layer": "first"}
+
+    snapped_dataset, edge_index = _snap_to_grid_and_aggregate(
+        geometry_triple, grid2d, vardict_agg
+    )
+
+    argwhere_summed_expected = np.array([7, 20, 33, 46, 59, 72], dtype=np.int64)
+    argwhere_summed_actual = np.nonzero((snapped_dataset["resistance"] == 1200).values)[
+        0
+    ]
+
+    np.testing.assert_array_equal(argwhere_summed_actual, argwhere_summed_expected)
+    np.testing.assert_array_equal(edge_index, argwhere_summed_expected)
 
 
 @pytest.mark.usefixtures("structured_flow_model")

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -365,9 +365,11 @@ def enforce_dim_order(grid: xu.UgridDataArray) -> xu.UgridDataArray:  # noqa: F8
     )
 
 
-def _enforce_unstructured(obj: GridDataArray, ugrid2d: xu.Ugrid2d) -> xu.UgridDataArray:
-    """Force obj to unstructured"""
-    return xu.UgridDataArray(xr.DataArray(obj), ugrid2d)
+def _enforce_uda_with_topology(
+    obj: GridDataArray, topology: xu.Ugrid2d
+) -> xu.UgridDataArray:
+    """Force obj and topology to ugrid dataarray"""
+    return xu.UgridDataArray(xr.DataArray(obj), topology)
 
 
 def preserve_gridtype(func: Callable[P, T]) -> Callable[P, T]:
@@ -399,8 +401,8 @@ def preserve_gridtype(func: Callable[P, T]) -> Callable[P, T]:
         if unstructured:
             # Multiple grids returned
             if isinstance(x, tuple):
-                return tuple(_enforce_unstructured(i, grid) for i in x)
-            return _enforce_unstructured(x, grid)
+                return tuple(_enforce_uda_with_topology(i, grid) for i in x)
+            return _enforce_uda_with_topology(x, grid)
         return x
 
     return decorator
@@ -434,16 +436,17 @@ def is_transient_data_grid(
 
 
 @typedispatch
-def enforce_ugrid_da(grid: xr.DataArray) -> xu.UgridDataArray:
+def enforce_uda(grid: xr.DataArray) -> xu.UgridDataArray:
+    """Enforce GridDataArray to UgridDataArray"""
     return xu.UgridDataArray.from_structured(grid)
 
 
 @typedispatch  # type: ignore[no-redef]
-def enforce_ugrid_da(grid: xu.UgridDataArray | xu.UgridDataset) -> xu.UgridDataArray:
+def enforce_uda(grid: xu.UgridDataArray) -> xu.UgridDataArray:  # noqa: F811
+    """Enforce GridDataArray to UgridDataArray"""
     return grid
 
 
 @typedispatch  # type: ignore[no-redef]
-def enforce_ugrid_da(grid: object) -> xu.UgridDataArray:
-    raise TypeError(f"function doesn't support type {type(grid)}")
-
+def enforce_uda(grid: object) -> xu.UgridDataArray:  # noqa: F811
+    raise TypeError(f"Function doesn't support type {type(grid)}")

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -365,7 +365,7 @@ def enforce_dim_order(grid: xu.UgridDataArray) -> xu.UgridDataArray:  # noqa: F8
     )
 
 
-def _enforce_unstructured(obj: GridDataArray, ugrid2d=xu.Ugrid2d) -> xu.UgridDataArray:
+def _enforce_unstructured(obj: GridDataArray, ugrid2d: xu.Ugrid2d) -> xu.UgridDataArray:
     """Force obj to unstructured"""
     return xu.UgridDataArray(xr.DataArray(obj), ugrid2d)
 
@@ -434,14 +434,16 @@ def is_transient_data_grid(
 
 
 @typedispatch
-def enforce_ugrid(grid: xr.DataArray) -> xu.UgridDataArray:
+def enforce_ugrid_da(grid: xr.DataArray) -> xu.UgridDataArray:
     return xu.UgridDataArray.from_structured(grid)
 
-@typedispatch  # type: ignore[no-redef]
-def enforce_ugrid(grid: xu.UgridDataArray | xu.UgridDataset) -> xu.UgridDataArray:
-    return grid
 
 @typedispatch  # type: ignore[no-redef]
-def enforce_ugrid(grid: object) -> xu.UgridDataArray:
+def enforce_ugrid_da(grid: xu.UgridDataArray | xu.UgridDataset) -> xu.UgridDataArray:
+    return grid
+
+
+@typedispatch  # type: ignore[no-redef]
+def enforce_ugrid_da(grid: object) -> xu.UgridDataArray:
     raise TypeError(f"function doesn't support type {type(grid)}")
 

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -365,7 +365,7 @@ def enforce_dim_order(grid: xu.UgridDataArray) -> xu.UgridDataArray:  # noqa: F8
     )
 
 
-def _enforce_uda_with_topology(
+def _as_ugrid_dataarray_with_topology(
     obj: GridDataArray, topology: xu.Ugrid2d
 ) -> xu.UgridDataArray:
     """Force obj and topology to ugrid dataarray"""
@@ -401,8 +401,8 @@ def preserve_gridtype(func: Callable[P, T]) -> Callable[P, T]:
         if unstructured:
             # Multiple grids returned
             if isinstance(x, tuple):
-                return tuple(_enforce_uda_with_topology(i, grid) for i in x)
-            return _enforce_uda_with_topology(x, grid)
+                return tuple(_as_ugrid_dataarray_with_topology(i, grid) for i in x)
+            return _as_ugrid_dataarray_with_topology(x, grid)
         return x
 
     return decorator
@@ -436,17 +436,17 @@ def is_transient_data_grid(
 
 
 @typedispatch
-def enforce_uda(grid: xr.DataArray) -> xu.UgridDataArray:
+def as_ugrid_dataarray(grid: xr.DataArray) -> xu.UgridDataArray:
     """Enforce GridDataArray to UgridDataArray"""
     return xu.UgridDataArray.from_structured(grid)
 
 
 @typedispatch  # type: ignore[no-redef]
-def enforce_uda(grid: xu.UgridDataArray) -> xu.UgridDataArray:  # noqa: F811
+def as_ugrid_dataarray(grid: xu.UgridDataArray) -> xu.UgridDataArray:  # noqa: F811
     """Enforce GridDataArray to UgridDataArray"""
     return grid
 
 
 @typedispatch  # type: ignore[no-redef]
-def enforce_uda(grid: object) -> xu.UgridDataArray:  # noqa: F811
+def as_ugrid_dataarray(grid: object) -> xu.UgridDataArray:  # noqa: F811
     raise TypeError(f"Function doesn't support type {type(grid)}")

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -431,3 +431,17 @@ def is_transient_data_grid(
         if len(grid["time"]) > 1:
             return True
     return False
+
+
+@typedispatch
+def enforce_ugrid(grid: xr.DataArray) -> xu.UgridDataArray:
+    return xu.UgridDataArray.from_structured(grid)
+
+@typedispatch  # type: ignore[no-redef]
+def enforce_ugrid(grid: xu.UgridDataArray | xu.UgridDataset) -> xu.UgridDataArray:
+    return grid
+
+@typedispatch  # type: ignore[no-redef]
+def enforce_ugrid(grid: object) -> xu.UgridDataArray:
+    raise TypeError(f"function doesn't support type {type(grid)}")
+

--- a/pixi.lock
+++ b/pixi.lock
@@ -306,7 +306,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.102-h593d115_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.12.1-py311h4332511_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/occt-7.7.2-novtk_h130ccc2_101.conda
@@ -468,7 +468,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
@@ -758,7 +758,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.102-he7eb89d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.12.1-py311hbafa61a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/occt-7.7.2-all_hd7ce604_201.conda
@@ -898,7 +898,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-renderproto-0.11.1-h0d85af4_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-xextproto-7.3.0-hb7f2c08_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-xproto-7.0.31-h35c211d_1007.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
@@ -1180,7 +1180,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.102-hc42bcbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.12.1-py311hb9542d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/occt-7.7.2-novtk_h5f4376a_101.conda
@@ -1321,7 +1321,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-renderproto-0.11.1-h27ca646_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xextproto-7.3.0-h1a8c8d9_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xproto-7.0.31-h27ca646_1007.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
@@ -1565,7 +1565,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.18-py311h9363f20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/nlohmann_json-3.11.3-h1537add_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.12.1-py311hda3d55a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/occt-7.7.2-novtk_hdfb195f_101.conda
@@ -1717,7 +1717,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-renderproto-0.11.1-hcd874cb_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-xextproto-7.3.0-hcd874cb_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-xproto-7.0.31-hcd874cb_1007.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
@@ -2087,7 +2087,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.102-h593d115_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.60.0-py311h4bc866e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.12.1-py311h4332511_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/occt-7.7.2-novtk_h130ccc2_101.conda
@@ -2284,7 +2284,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
@@ -2628,7 +2628,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.102-he7eb89d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numba-0.60.0-py311h0e5bd6a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numcodecs-0.12.1-py311hbafa61a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/occt-7.7.2-all_hd7ce604_201.conda
@@ -2805,7 +2805,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-renderproto-0.11.1-h0d85af4_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-xextproto-7.3.0-hb7f2c08_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-xproto-7.0.31-h35c211d_1007.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
@@ -3141,7 +3141,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.35-hb7217d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.102-hc42bcbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.60.0-py311h9506ed5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numcodecs-0.12.1-py311hb9542d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/occt-7.7.2-novtk_h5f4376a_101.conda
@@ -3319,7 +3319,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-renderproto-0.11.1-h27ca646_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xextproto-7.3.0-h1a8c8d9_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-xproto-7.0.31-h27ca646_1007.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
@@ -3616,7 +3616,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.60.0-py311h0673bce_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numcodecs-0.12.1-py311hda3d55a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/occt-7.7.2-novtk_hdfb195f_101.conda
@@ -3804,7 +3804,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-renderproto-0.11.1-hcd874cb_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-xextproto-7.3.0-hcd874cb_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-xproto-7.0.31-hcd874cb_1007.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
@@ -22614,23 +22614,23 @@ packages:
   timestamp: 1718888718616
 - kind: conda
   name: numba_celltree
-  version: 0.1.6
+  version: 0.1.8
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.6-pyhd8ed1ab_0.conda
-  sha256: 0ecb9c31a9d6cc23c9099c391ca14645f9b0118f5a22818c88b5091e3d0d27b2
-  md5: fa93424676054b2d1fcc7864c4e68698
+  url: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.1.8-pyhd8ed1ab_0.conda
+  sha256: 4b30d964bf034b41ce14842bf8fa3040b21878c0da1bdec15c5523ab785bc311
+  md5: 02b10d14b2e6693519804fe90d41c589
   depends:
   - numba >=0.50
   - numpy
-  - python >=3.7
+  - python >=3.9
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/numba-celltree?source=conda-forge-mapping
-  size: 32808
-  timestamp: 1672825982456
+  size: 33524
+  timestamp: 1722763371483
 - kind: conda
   name: numcodecs
   version: 0.12.1
@@ -31926,18 +31926,18 @@ packages:
   timestamp: 1607292254607
 - kind: conda
   name: xugrid
-  version: 0.10.0
+  version: 0.11.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.10.0-pyhd8ed1ab_0.conda
-  sha256: cf9b0c63b573405d5ac34a35819d98c10884abb0d49b19af0fc7414f8f44fa00
-  md5: 7ef2f388e3b2adcecfed74591bff2451
+  url: https://conda.anaconda.org/conda-forge/noarch/xugrid-0.11.0-pyhd8ed1ab_0.conda
+  sha256: 1f4bef6a7edb21c173c6b69788a42a46e350275664a79de14dc9efcdb9460627
+  md5: 1d2fe2eccb1568bee8641cdf359ff742
   depends:
   - dask
   - geopandas
   - numba >=0.50
-  - numba_celltree
+  - numba_celltree >=0.1.8
   - numpy
   - pandas
   - pooch
@@ -31949,8 +31949,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/xugrid?source=conda-forge-mapping
-  size: 94214
-  timestamp: 1714580639671
+  size: 94836
+  timestamp: 1722866212176
 - kind: conda
   name: xyzservices
   version: 2024.6.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -362,9 +362,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-4.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.8.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-dotenv-0.5.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.0-he550d4f_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gmsh-4.12.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyh717bed2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
@@ -808,9 +810,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-4.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.8.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-dotenv-0.5.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.0-he7542f4_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gmsh-4.12.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyh717bed2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
@@ -1231,9 +1235,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-4.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.8.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-dotenv-0.5.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.0-h3ba56d0_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gmsh-4.12.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyh717bed2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
@@ -1619,9 +1625,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-4.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.8.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-dotenv-0.5.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gmsh-4.12.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyh717bed2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
@@ -2155,9 +2163,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-4.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.8.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-dotenv-0.5.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.0-he550d4f_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gmsh-4.12.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyh717bed2_0.conda
@@ -2692,9 +2702,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-4.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.8.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-dotenv-0.5.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.0-he7542f4_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gmsh-4.12.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyh717bed2_0.conda
@@ -3206,9 +3218,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-4.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.8.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-dotenv-0.5.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.0-h3ba56d0_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gmsh-4.12.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyh717bed2_0.conda
@@ -3680,9 +3694,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-4.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cases-3.8.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-dotenv-0.5.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gmsh-4.12.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.20.3-pyh717bed2_0.conda
@@ -25902,6 +25918,25 @@ packages:
   size: 25507
   timestamp: 1711411153367
 - kind: conda
+  name: pytest-dotenv
+  version: 0.5.2
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-dotenv-0.5.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 43ab7de6af7b298a9199aea2bf6fa481a3059ba1068dd0967fe3a040ff6e9303
+  md5: 11b16b526f60cc18748c3fe45d10315a
+  depends:
+  - pytest >=5.0.0
+  - python >=3.6
+  - python-dotenv >=0.9.1
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pytest-dotenv?source=conda-forge-mapping
+  size: 7383
+  timestamp: 1606859705188
+- kind: conda
   name: pytest-xdist
   version: 3.6.1
   build: pyhd8ed1ab_0
@@ -26355,6 +26390,23 @@ packages:
   - pkg:pypi/python-dateutil?source=conda-forge-mapping
   size: 222742
   timestamp: 1709299922152
+- kind: conda
+  name: python-dotenv
+  version: 1.0.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
+  sha256: 2d4c80364f03315d606a50eddd493dbacc078e21412c2462c0f781eec49b572c
+  md5: c2997ea9360ac4e015658804a7a84f94
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/python-dotenv?source=conda-forge-mapping
+  size: 24278
+  timestamp: 1706018281544
 - kind: conda
   name: python-fastjsonschema
   version: 2.20.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,7 +23,7 @@ unittests = { cmd = [
     "NUMBA_DISABLE_JIT=1",
     "pytest",
     "-n", "auto",
-    "-m", "not example and not lhm",
+    "-m", "not example and not user_acceptance",
     "--cache-clear",
     "--verbose",
     "--junitxml=unittest_report.xml",
@@ -41,9 +41,11 @@ examples = { cmd = [
     "--verbose",
     "--junitxml=examples_report.xml",
 ], depends_on = ["install"], cwd = "imod/tests" }
+# User acceptance tests, only works when paths to models are located on local
+# drive and are specified in a .env file.
 user_acceptance = { cmd = [
     "pytest",
-    "-m", "lhm",
+    "-m", "user_acceptance",
     "--cache-clear",
     "--verbose",
     "--junitxml=user_acceptance_report.xml",

--- a/pixi.toml
+++ b/pixi.toml
@@ -107,7 +107,7 @@ tqdm = "*"
 twine = "*"
 vtk = { version = ">=9.0", build = "*qt*", channel = "conda-forge" }
 xarray = ">=2023.08.0"
-xugrid = ">=0.10.0"
+xugrid = ">=0.11.0"
 zarr = "*"
 build = "*"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,7 +23,7 @@ unittests = { cmd = [
     "NUMBA_DISABLE_JIT=1",
     "pytest",
     "-n", "auto",
-    "-m", "not example",
+    "-m", "not example and not lhm",
     "--cache-clear",
     "--verbose",
     "--junitxml=unittest_report.xml",
@@ -40,6 +40,13 @@ examples = { cmd = [
     "--cache-clear",
     "--verbose",
     "--junitxml=examples_report.xml",
+], depends_on = ["install"], cwd = "imod/tests" }
+user_acceptance = { cmd = [
+    "pytest",
+    "-m", "lhm",
+    "--cache-clear",
+    "--verbose",
+    "--junitxml=user_acceptance_report.xml",
 ], depends_on = ["install"], cwd = "imod/tests" }
 test_import = { cmd = [
     "python",
@@ -87,6 +94,7 @@ pytest = "<8"   # Newer version incompatible with pytest-cases
 pytest-benchmark = "*"
 pytest-cases = "*"
 pytest-cov = "*"
+pytest-dotenv = "*"
 pytest-xdist = "*"
 python = "3.11"
 python-graphviz = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 markers = [
     "example: marks test as example (deselect with '-m \"not example\"')",
+    "lhm: marks lhm tests (deselect with '-m \"not example\"')",
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 markers = [
     "example: marks test as example (deselect with '-m \"not example\"')",
-    "lhm: marks lhm tests (deselect with '-m \"not example\"')",
+    "user_acceptance: marks user acceptance tests (deselect with '-m \"not user_acceptance\"')",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
Fixes #1132 

# Description
This PR adds the following:

- Increase performance for writing the HFB files, by using new xugrid create_snap_to_grid_dataframe.
- Fixes error when multiple barriers in a single dataset would be snapped to same edge. These lines are now aggregated.
- Add some basic infrastructure for user acceptance test for writing LHM, the path to the LHM projectfile should be set in a .env as LHM_PRJ. This can later be extended to TeamCity.

This reduces the time spent writing the HFB packages from 34 minutes to 12.5 minutes on my local machine. I've profiled the causes of the remaining bottlenecks to writing. I'll post a follow-up issue for that.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
