### PR TITLE
Issue #1166 steady state well import

### DIFF
--- a/imod/formats/ipf.py
+++ b/imod/formats/ipf.py
@@ -17,6 +17,7 @@ import numpy as np
 import pandas as pd
 
 import imod
+from imod.util.time import to_pandas_datetime_series
 
 
 def _infer_delimwhitespace(line, ncol):
@@ -230,15 +231,7 @@ def read_associated(path, kwargs={}):
 
     if nrow > 0 and itype == 1:
         time_column = colnames[0]
-        len_date = len(df[time_column].iloc[0])
-        if len_date == 14:
-            df[time_column] = pd.to_datetime(df[time_column], format="%Y%m%d%H%M%S")
-        elif len_date == 8:
-            df[time_column] = pd.to_datetime(df[time_column], format="%Y%m%d")
-        else:
-            raise ValueError(
-                f"{path.name}: datetime format must be yyyymmddhhmmss or yyyymmdd"
-            )
+        df[time_column] = to_pandas_datetime_series(df[time_column])
     return df
 
 

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -291,11 +291,14 @@ class GroundwaterFlowModel(Modflow6Model):
         imod5_keys = list(imod5_data.keys())
         wel_keys = [key for key in imod5_keys if key[0:3] == "wel"]
         for wel_key in wel_keys:
+            wel_key_truncated = wel_key[:16]
             layer = np.array(imod5_data[wel_key]["layer"])
             if np.any(layer == 0):
-                result[wel_key] = Well.from_imod5_data(wel_key, imod5_data, times)
+                result[wel_key_truncated] = Well.from_imod5_data(
+                    wel_key, imod5_data, times
+                )
             else:
-                result[wel_key] = LayeredWell.from_imod5_data(
+                result[wel_key_truncated] = LayeredWell.from_imod5_data(
                     wel_key, imod5_data, times
                 )
 

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -294,6 +294,8 @@ class GroundwaterFlowModel(Modflow6Model):
         for wel_key in wel_keys:
             wel_key_truncated = wel_key[:16]
             if wel_key_truncated in result.keys():
+                # Remove this when https://github.com/Deltares/imod-python/issues/1167
+                # is resolved
                 msg = textwrap.dedent(
                     f"""Truncated key: '{wel_key_truncated}' already assigned to
                     imported model, please rename wells so that unique names are

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import textwrap
 from datetime import datetime
 from typing import Optional, cast
 
@@ -292,6 +293,15 @@ class GroundwaterFlowModel(Modflow6Model):
         wel_keys = [key for key in imod5_keys if key[0:3] == "wel"]
         for wel_key in wel_keys:
             wel_key_truncated = wel_key[:16]
+            if wel_key_truncated in result.keys():
+                msg = textwrap.dedent(
+                    f"""Truncated key: '{wel_key_truncated}' already assigned to
+                    imported model, please rename wells so that unique names are
+                    formed after they are truncated to 16 characters for MODFLOW
+                    6.
+                    """
+                )
+                raise KeyError(msg)
             layer = np.array(imod5_data[wel_key]["layer"])
             if np.any(layer == 0):
                 result[wel_key_truncated] = Well.from_imod5_data(

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -547,12 +547,15 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
         Wells without associated textfiles are processed as follows:
 
         - When a unassociated well disappears from the next time entry in the
-          projectfile, the well is deactivated by ratting its rate to 0.0. This
+          projectfile, the well is deactivated by setting its rate to 0.0. This
           is to prevent the well being activated again in case of any potential
           forward filling at a later stage by
           :meth:`imod.mf6.Modflow6Simulation.create_time_discretization`
         - Wells assigned to a "steady-state" entry in the projectfile will have
           no "time" dimension in the resulting dataset.
+        - Times beyond the year 2261 are out of bounds for pandas. In associated
+          timeseries these are ignored, instead the last stage is forward
+          filled.
 
         .. note::
             In case you are wondering why is this so complicated? There are two

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -538,6 +538,9 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
           simulation times.
         - When simulation times fall outside well timeseries range, the last
           rate is forward filled.
+        - Projectfile timestamps itsself are not used. Even if assigned to a
+          "steady-state" timestamp, the resulting dataset still uses simulation
+          times.
 
         *Unassociated wells*
 
@@ -548,6 +551,8 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
           is to prevent the well being activated again in case of any potential
           forward filling at a later stage by
           :meth:`imod.mf6.Modflow6Simulation.create_time_discretization`
+        - Wells assigned to a "steady-state" entry in the projectfile will have
+          no "time" dimension in the resulting dataset.
 
         .. note::
             In case you are wondering why is this so complicated? There are two

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -538,7 +538,7 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
           simulation times.
         - When simulation times fall outside well timeseries range, the last
           rate is forward filled.
-        - Projectfile timestamps itsself are not used. Even if assigned to a
+        - Projectfile timestamps are not used. Even if assigned to a
           "steady-state" timestamp, the resulting dataset still uses simulation
           times.
 

--- a/imod/tests/conftest.py
+++ b/imod/tests/conftest.py
@@ -25,6 +25,7 @@ from .fixtures.flow_transport_simulation_fixture import flow_transport_simulatio
 from .fixtures.imod5_well_data import (
     well_duplication_import_prj,
     well_mixed_ipfs,
+    well_out_of_bounds_ipfs,
     well_regular_import_prj,
 )
 from .fixtures.mf6_circle_fixture import (

--- a/imod/tests/fixtures/imod5_well_data.py
+++ b/imod/tests/fixtures/imod5_well_data.py
@@ -269,6 +269,7 @@ def well_mixed_ipfs():
         tmp_path,
     )
 
+
 @pytest.fixture(scope="session")
 def well_out_of_bounds_ipfs():
     tmp_path = imod.util.temporary_directory()

--- a/imod/tests/fixtures/imod5_well_data.py
+++ b/imod/tests/fixtures/imod5_well_data.py
@@ -150,6 +150,23 @@ def other_timeseries_string():
     )
 
 
+def out_of_bounds_timeseries_string():
+    return textwrap.dedent(
+        """\
+    6
+    2
+    DATE,-9999.0
+    MEASUREMENT,-9999.0
+    19811130,-174.1507971461288
+    19811231,-166.7777419354838
+    19820131,-147.6367741935485
+    19820228,-127.3857142857142
+    19820331,-159.2109677419355
+    29991112,-182.7713333333334
+    """
+    )
+
+
 def write_ipf_assoc_files(
     projectfile_str,
     ipf1_str,
@@ -243,6 +260,24 @@ def well_mixed_ipfs():
     ipf_simple_str = ipf_simple_string()
     timeseries_well_str = timeseries_string()
     other_timeseries_well_str = other_timeseries_string()
+
+    return write_ipf_mixed_files(
+        ipf_assoc_str,
+        ipf_simple_str,
+        timeseries_well_str,
+        other_timeseries_well_str,
+        tmp_path,
+    )
+
+@pytest.fixture(scope="session")
+def well_out_of_bounds_ipfs():
+    tmp_path = imod.util.temporary_directory()
+    os.makedirs(tmp_path)
+
+    ipf_assoc_str = ipf1_string_duplication()
+    ipf_simple_str = ipf_simple_string()
+    timeseries_well_str = timeseries_string()
+    other_timeseries_well_str = out_of_bounds_timeseries_string()
 
     return write_ipf_mixed_files(
         ipf_assoc_str,

--- a/imod/tests/test_formats/test_prj_wel.py
+++ b/imod/tests/test_formats/test_prj_wel.py
@@ -903,6 +903,7 @@ def test_from_imod5_data_wells__outside_range(
                 assert "time" not in rate.dims
                 assert "time" not in rate.coords
 
+
 @parametrize("wel_case, expected_dict", argvalues=list(zip(PRJ_ARGS, PKG_ARGS)))
 @parametrize("wel_cls", argvalues=[LayeredWell, Well])
 def test_from_imod5_data_wells__wells_out_of_bounds(

--- a/imod/tests/test_formats/test_prj_wel.py
+++ b/imod/tests/test_formats/test_prj_wel.py
@@ -929,7 +929,7 @@ def test_from_imod5_data_wells__wells_out_of_bounds(
     data, _ = open_projectfile_data(wel_file)
     for wellname in data.keys():
         assert wellname in expected_dict.keys()
-        fails, has_time, _ = expected_dict[wellname]
+        fails, _, _ = expected_dict[wellname]
         if fails:
             with pytest.raises(ValueError):
                 wel_cls.from_imod5_data(wellname, data, times=times)

--- a/imod/tests/test_formats/test_prj_wel.py
+++ b/imod/tests/test_formats/test_prj_wel.py
@@ -19,6 +19,37 @@ from imod.mf6 import LayeredWell, Well
 class WellPrjCases:
     """Cases for projectfile well records"""
 
+    def case_simple__steady_state(self):
+        return dedent(
+            """
+            0001,(WEL),1
+            steady-state
+            001,001
+            1,2, 001, 1.0, 0.0, -999.9900 ,"ipf/simple1.ipf"
+            """
+        )
+
+    def case_associated__steady_state(self):
+        return dedent(
+            """
+            0001,(WEL),1
+            steady-state
+            001,001
+            1,2, 001, 1.0, 0.0, -999.9900 ,"ipf/associated.ipf"
+            """
+        )
+
+    def case_mixed__steady_state(self):
+        return dedent(
+            """
+            0001,(WEL),1
+            steady-state
+            001,002
+            1,2, 001, 1.0, 0.0, -999.9900 ,"ipf/associated.ipf"
+            1,2, 001, 1.0, 0.0, -999.9900 ,"ipf/simple1.ipf"
+            """
+        )
+
     def case_simple__first(self):
         return dedent(
             """
@@ -252,6 +283,46 @@ class WellPrjCases:
 
 class WellReadCases:
     """Expected cases as interpreted by ``imod.formats.prj.open_projectfile_data``"""
+
+    def case_simple__steady_state(self):
+        return {
+            "wel-simple1": {
+                "has_associated": False,
+                "time": [None],
+                "layer": [1],
+                "factor": [1.0],
+                "addition": [0.0],
+            },
+        }
+
+    def case_associated__steady_state(self):
+        return {
+            "wel-associated": {
+                "has_associated": True,
+                "time": [None],
+                "layer": [1],
+                "factor": [1.0],
+                "addition": [0.0],
+            },
+        }
+
+    def case_mixed__steady_state(self):
+        return {
+            "wel-simple1": {
+                "has_associated": False,
+                "time": [None],
+                "layer": [1],
+                "factor": [1.0],
+                "addition": [0.0],
+            },
+            "wel-associated": {
+                "has_associated": True,
+                "time": [None],
+                "layer": [1],
+                "factor": [1.0],
+                "addition": [0.0],
+            },
+        }
 
     def case_simple__first(self):
         return {
@@ -534,88 +605,104 @@ class WellPackageCases:
 
     Returns
     -------
-    fails, {wellname: datetime_set_to_zero}
+    {wellname: (fails, has_time, datetimes_set_to_zero)}
     """
+
+    def case_simple__steady_state(self):
+        return {
+            "wel-simple1": (False, False, []),
+        }
+
+    def case_associated__steady_state(self):
+        return {
+            "wel-associated": (False, True, []),
+        }
+
+    def case_mixed__steady_state(self):
+        return {
+            "wel-associated": (False, True, []),
+            "wel-simple1": (False, False, []),
+        }
 
     def case_simple__first(self):
         return {
-            "wel-simple1": (False, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
         }
 
     def case_simple__first_multi_layer1(self):
         return {
-            "wel-simple1": (False, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
         }
 
     def case_simple__first_multi_layer2(self):
         return {
-            "wel-simple1": (True, []),
+            "wel-simple1": (True, False, []),
         }
 
     def case_simple__all_same(self):
         return {
-            "wel-simple1": (False, []),
+            "wel-simple1": (False, True, []),
         }
 
     def case_simple__all_same_multi_layer1(self):
         return {
-            "wel-simple1": (False, []),
+            "wel-simple1": (False, True, []),
         }
 
     def case_simple__all_same_multi_layer2(self):
         return {
-            "wel-simple1": (True, []),
+            "wel-simple1": (True, False, []),
         }
 
     def case_simple__all_different1(self):
         return {
-            "wel-simple1": (False, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
-            "wel-simple2": (False, [datetime(1982, 3, 1)]),
-            "wel-simple3": (False, []),
+            "wel-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-simple2": (False, True, [datetime(1982, 3, 1)]),
+            "wel-simple3": (False, True, []),
         }
 
     def case_simple__all_different2(self):
         return {
-            "wel-simple1": (False, [datetime(1982, 3, 1)]),
-            "wel-simple2": (False, [datetime(1982, 3, 1)]),
-            "wel-simple3": (False, []),
+            "wel-simple1": (False, True, [datetime(1982, 3, 1)]),
+            "wel-simple2": (False, True, [datetime(1982, 3, 1)]),
+            "wel-simple3": (False, True, []),
         }
 
     def case_simple__all_different3(self):
         return {
-            "wel-simple1": (False, [datetime(1982, 2, 1)]),
-            "wel-simple2": (False, [datetime(1982, 3, 1)]),
-            "wel-simple3": (False, []),
+            "wel-simple1": (False, True, [datetime(1982, 2, 1)]),
+            "wel-simple2": (False, True, [datetime(1982, 3, 1)]),
+            "wel-simple3": (False, True, []),
         }
 
     def case_associated__first(self):
-        return {"wel-associated": (False, [])}
+        return {"wel-associated": (False, True, [])}
 
     def case_associated__all(self):
-        return {"wel-associated": (False, [])}
+        return {"wel-associated": (False, True, [])}
 
     def case_associated__all_varying_factors(self):
-        return {"wel-associated": (True, [])}
+        return {"wel-associated": (True, False, [])}
 
     def case_associated__multiple_layers_different_factors(self):
-        return {"wel-associated": (True, [])}
+        return {"wel-associated": (True, False, [])}
 
     def case_mixed__first(self):
         return {
-            "wel-simple1": (False, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
-            "wel-associated": (False, []),
+            "wel-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-associated": (False, True, []),
         }
 
     def case_mixed__all(self):
         return {
-            "wel-simple1": (False, [datetime(1982, 3, 1)]),
-            "wel-associated": (False, []),
+            "wel-simple1": (False, True, [datetime(1982, 3, 1)]),
+            "wel-associated": (False, True, []),
         }
 
     def case_mixed__associated_second(self):
         return {
-            "wel-simple1": (False, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
-            "wel-associated": (True, []),
+            "wel-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-associated": (True, False, []),
         }
 
 
@@ -715,21 +802,27 @@ def test_from_imod5_data_wells(
     data, _ = open_projectfile_data(wel_file)
     for wellname in data.keys():
         assert wellname in expected_dict.keys()
-        fails, expected_set_to_zero = expected_dict[wellname]
+        fails, has_time, expected_set_to_zero = expected_dict[wellname]
         if fails:
             with pytest.raises(ValueError):
                 wel_cls.from_imod5_data(wellname, data, times=times)
         else:
             well = wel_cls.from_imod5_data(wellname, data, times=times)
             rate = well.dataset["rate"]
-            actual_set_to_zero = [
-                t.values for t in rate.coords["time"] if (rate.sel(time=t) == 0.0).all()
-            ]
-            expected_set_to_zero = [
-                np.datetime64(t, "ns") for t in expected_set_to_zero
-            ]
-            diff = set(actual_set_to_zero) ^ set(expected_set_to_zero)
-            assert len(diff) == 0
+            if has_time:
+                actual_set_to_zero = [
+                    t.values
+                    for t in rate.coords["time"]
+                    if (rate.sel(time=t) == 0.0).all()
+                ]
+                expected_set_to_zero = [
+                    np.datetime64(t, "ns") for t in expected_set_to_zero
+                ]
+                diff = set(actual_set_to_zero) ^ set(expected_set_to_zero)
+                assert len(diff) == 0
+            else:
+                assert "time" not in rate.dims
+                assert "time" not in rate.coords
 
 
 @parametrize("wel_case, expected_dict", argvalues=list(zip(PRJ_ARGS, PKG_ARGS)))
@@ -762,19 +855,25 @@ def test_from_imod5_data_wells__outside_range(
     data, _ = open_projectfile_data(wel_file)
     for wellname in data.keys():
         assert wellname in expected_dict.keys()
-        fails, _ = expected_dict[wellname]
+        fails, has_time, _ = expected_dict[wellname]
         if fails:
             with pytest.raises(ValueError):
                 wel_cls.from_imod5_data(wellname, data, times=times)
         else:
             well = wel_cls.from_imod5_data(wellname, data, times=times)
             rate = well.dataset["rate"]
-            actual_set_to_zero = [
-                t.values for t in rate.coords["time"] if (rate.sel(time=t) == 0.0).all()
-            ]
-            if data[wellname]["has_associated"]:
-                expected_set_to_zero = []
+            if has_time:
+                actual_set_to_zero = [
+                    t.values
+                    for t in rate.coords["time"]
+                    if (rate.sel(time=t) == 0.0).all()
+                ]
+                if data[wellname]["has_associated"]:
+                    expected_set_to_zero = []
+                else:
+                    expected_set_to_zero = [np.datetime64(t, "ns") for t in times[:-1]]
+                diff = set(actual_set_to_zero) ^ set(expected_set_to_zero)
+                assert len(diff) == 0
             else:
-                expected_set_to_zero = [np.datetime64(t, "ns") for t in times[:-1]]
-            diff = set(actual_set_to_zero) ^ set(expected_set_to_zero)
-            assert len(diff) == 0
+                assert "time" not in rate.dims
+                assert "time" not in rate.coords

--- a/imod/util/expand_repetitions.py
+++ b/imod/util/expand_repetitions.py
@@ -56,12 +56,14 @@ def resample_timeseries(well_rate: pd.DataFrame, times: list[datetime]) -> pd.Da
     well_rate:  pd.DataFrame
         input timeseries for well
     times: datetime
-        list of times on which the output datarame should have entries.
+        list of times on which the output dataframe should have entries.
 
     returns:
     --------
     a new dataframe containing a timeseries defined on the times in "times".
     """
+    is_steady_state = len(times) == 0
+
     output_frame = pd.DataFrame(times)
     output_frame = output_frame.rename(columns={0: "time"})
     intermediate_df = pd.merge(
@@ -108,4 +110,15 @@ def resample_timeseries(well_rate: pd.DataFrame, times: list[datetime]) -> pd.Da
 
     columns_to_merge = ["time"] + location_columns
 
-    return pd.merge(output_frame, intermediate_df[columns_to_merge], on="time")
+    if is_steady_state:
+        # Take first element, the slice is to force pandas to return it as
+        # dataframe instead of series.
+        location_dataframe = intermediate_df[location_columns].iloc[slice(0, 1), :]
+        # Concat along columns and drop time column
+        return pd.concat([output_frame, location_dataframe], axis=1).drop(
+            columns="time"
+        )
+    else:
+        return pd.merge(
+            output_frame, intermediate_df[columns_to_merge], on="time", how="left"
+        )

--- a/imod/util/expand_repetitions.py
+++ b/imod/util/expand_repetitions.py
@@ -108,8 +108,6 @@ def resample_timeseries(well_rate: pd.DataFrame, times: list[datetime]) -> pd.Da
     if np.isnan(output_frame["rate"].values[-1]):
         output_frame["rate"].values[-1] = well_rate["rate"].values[-1]
 
-    columns_to_merge = ["time"] + location_columns
-
     if is_steady_state:
         # Take first element, the slice is to force pandas to return it as
         # dataframe instead of series.
@@ -119,6 +117,11 @@ def resample_timeseries(well_rate: pd.DataFrame, times: list[datetime]) -> pd.Da
             columns="time"
         )
     else:
+        columns_to_merge = ["time"] + location_columns
         return pd.merge(
-            output_frame, intermediate_df[columns_to_merge], on="time", how="left"
+            output_frame,
+            intermediate_df[columns_to_merge],
+            on="time",
+            how="left",
+            validate="1:m",
         )

--- a/imod/util/time.py
+++ b/imod/util/time.py
@@ -15,6 +15,17 @@ DATETIME_FORMATS = {
 }
 
 
+def to_pandas_datetime_series(series: pd.Series):
+    """
+    Try pd.to_datetime first with format, which tries converting to pandas
+    datetime with nanosecond as base. This only supports going up to 2261. If
+    this fails, manually convert with seconds as base.
+    """
+    len_date = len(series.iloc[0])
+    format = DATETIME_FORMATS[len_date]
+    return pd.to_datetime(series, format=format, errors="coerce")
+
+
 def to_datetime(s: str) -> datetime.datetime:
     """
     Convert string to datetime. Part of the public API for backwards

--- a/imod/util/time.py
+++ b/imod/util/time.py
@@ -17,9 +17,10 @@ DATETIME_FORMATS = {
 
 def to_pandas_datetime_series(series: pd.Series):
     """
-    Try pd.to_datetime first with format, which tries converting to pandas
-    datetime with nanosecond as base. This only supports going up to 2261. If
-    this fails, manually convert with seconds as base.
+    Convert series to pandas datetime, uses length of first string to find the
+    appropriate format. This takes nanosecond as base. This only supports going
+    up to the year 2261; the function sets dates beyond this year silently to
+    pd.NaT.
     """
     len_date = len(series.iloc[0])
     format = DATETIME_FORMATS[len_date]

--- a/imod/util/time.py
+++ b/imod/util/time.py
@@ -23,8 +23,8 @@ def to_pandas_datetime_series(series: pd.Series):
     pd.NaT.
     """
     len_date = len(series.iloc[0])
-    format = DATETIME_FORMATS[len_date]
-    return pd.to_datetime(series, format=format, errors="coerce")
+    dt_format = DATETIME_FORMATS[len_date]
+    return pd.to_datetime(series, format=dt_format, errors="coerce")
 
 
 def to_datetime(s: str) -> datetime.datetime:


### PR DESCRIPTION
Fixes #1166 and somewhat fixes #1163

# Description
- Moves ``pd.to_datetime`` logic to separate place, use ``errors="coerce"`` setting, which turns datetimes beyond the year 2261 to ``pd.NaT``. These seem to be consequently ignored in the ``resample_timeseries``.
- Truncate well names to max 16 characters
- Support wells defined in "steady-state" entry in the projectfile.
- Add test cases for this.

# Checklist
- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
