### PR TITLE
Issue #1164 cleanup utils

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -51,6 +51,14 @@ Added
   :class:`imod.mf6.HorizontalFlowBarrierHydraulicCharacteristic`.
 - :class:`imod.mf6.LayeredWell` to specify wells directly to layers instead
   assigning them with filter depths.
+- :func:`imod.prepare.cleanup_drn`, :func:`imod.prepare.cleanup_ghb`,
+  :func:`imod.prepare.cleanup_riv`. These are utility functions to clean up
+  drainage, general head boundaries, and rivers, respectively.
+- :meth:`imod.mf6.Drainage.cleanup`,
+  :meth:`imod.mf6.GeneralHeadboundary.cleanup`, :meth:`imod.mf6.River.cleanup`
+  convenience methods to call the corresponding cleanup utility functions with
+  the appropriate arguments.
+
 
 Removed
 ~~~~~~~

--- a/docs/api/mf6.rst
+++ b/docs/api/mf6.rst
@@ -69,8 +69,14 @@ Flow Packages
     Buoyancy
     ConstantHead
     Drainage
+    Drainage.mask
+    Drainage.regrid_like
+    Drainage.cleanup
     Evapotranspiration
     GeneralHeadBoundary
+    GeneralHeadBoundary.mask
+    GeneralHeadBoundary.regrid_like
+    GeneralHeadBoundary.cleanup
     HorizontalFlowBarrierHydraulicCharacteristic
     HorizontalFlowBarrierMultiplier
     HorizontalFlowBarrierResistance
@@ -83,6 +89,9 @@ Flow Packages
     NodePropertyFlow
     Recharge
     River
+    River.mask
+    River.regrid_like
+    River.cleanup
     SpecificStorage
     StorageCoefficient
     UnsaturatedZoneFlow

--- a/docs/api/prepare.rst
+++ b/docs/api/prepare.rst
@@ -47,3 +47,7 @@ Prepare model input
     distribute_drn_conductance
     distribute_ghb_conductance
     distribute_riv_conductance
+
+    cleanup_drn
+    cleanup_ghb
+    cleanup_riv

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -1,12 +1,13 @@
 from copy import deepcopy
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
 from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.dis import StructuredDiscretization
+from imod.mf6.disv import VerticesDiscretization
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.npf import NodePropertyFlow
 from imod.mf6.regrid.regrid_schemes import DrainageRegridMethod
@@ -164,8 +165,11 @@ class Drainage(BoundaryCondition, IRegridPackage):
 
         return errors
 
-    def cleanup(self) -> None:
-        cleaned_dict = self._call_func_on_grids(cleanup_drn)
+    def cleanup(
+        self, dis: Union[StructuredDiscretization, VerticesDiscretization]
+    ) -> None:
+        dis_dict = {var: dis.dataset[var] for var in ["idomain"]}
+        cleaned_dict = self._call_func_on_grids(cleanup_drn, dis_dict)
         super().__init__(cleaned_dict)
 
     @classmethod

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -168,6 +168,14 @@ class Drainage(BoundaryCondition, IRegridPackage):
     def cleanup(
         self, dis: Union[StructuredDiscretization, VerticesDiscretization]
     ) -> None:
+        """
+        Clean up package inplace. This method calls
+        :func:`imod.prepare.cleanup.cleanup_drn`, see documentation of that
+        function for details on cleanup.
+
+        dis: imod.mf6.StructuredDiscretization | imod.mf6.VerticesDiscretization
+            Model discretization package.
+        """
         dis_dict = {var: dis.dataset[var] for var in ["idomain"]}
         cleaned_dict = self._call_func_on_grids(cleanup_drn, dis_dict)
         super().__init__(cleaned_dict)

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 
@@ -165,9 +165,7 @@ class Drainage(BoundaryCondition, IRegridPackage):
 
         return errors
 
-    def cleanup(
-        self, dis: Union[StructuredDiscretization, VerticesDiscretization]
-    ) -> None:
+    def cleanup(self, dis: StructuredDiscretization | VerticesDiscretization) -> None:
         """
         Clean up package inplace. This method calls
         :func:`imod.prepare.cleanup.cleanup_drn`, see documentation of that

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -174,7 +174,7 @@ class Drainage(BoundaryCondition, IRegridPackage):
         dis: imod.mf6.StructuredDiscretization | imod.mf6.VerticesDiscretization
             Model discretization package.
         """
-        dis_dict = {var: dis.dataset[var] for var in ["idomain"]}
+        dis_dict = {"idomain": dis.dataset["idomain"]}
         cleaned_dict = self._call_func_on_grids(cleanup_drn, dis_dict)
         super().__init__(cleaned_dict)
 

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import numpy as np
 
-from imod.logging import init_log_decorator
+from imod.logging import init_log_decorator, standard_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.disv import VerticesDiscretization
@@ -165,6 +165,7 @@ class Drainage(BoundaryCondition, IRegridPackage):
 
         return errors
 
+    @standard_log_decorator()
     def cleanup(self, dis: StructuredDiscretization | VerticesDiscretization) -> None:
         """
         Clean up package inplace. This method calls

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -15,6 +15,7 @@ from imod.mf6.utilities.regrid import (
     _regrid_package_data,
 )
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA, CONC_DIMS_SCHEMA
+from imod.prepare.cleanup import cleanup_drn
 from imod.prepare.topsystem.allocation import ALLOCATION_OPTION, allocate_drn_cells
 from imod.prepare.topsystem.conductance import (
     DISTRIBUTING_OPTION,
@@ -162,6 +163,10 @@ class Drainage(BoundaryCondition, IRegridPackage):
         errors = super()._validate(schemata, **kwargs)
 
         return errors
+
+    def cleanup(self) -> None:
+        cleaned_dict = self._call_func_on_grids(cleanup_drn)
+        super().__init__(cleaned_dict)
 
     @classmethod
     def from_imod5_data(

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -177,7 +177,7 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         dis: imod.mf6.StructuredDiscretization | imod.mf6.VerticesDiscretization
             Model discretization package.
         """
-        dis_dict = {var: dis.dataset[var] for var in ["idomain"]}
+        dis_dict = {"idomain": dis.dataset["idomain"]}
         cleaned_dict = self._call_func_on_grids(cleanup_ghb, dis_dict)
         super().__init__(cleaned_dict)
 

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 
@@ -168,9 +168,7 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
 
         return errors
 
-    def cleanup(
-        self, dis: Union[StructuredDiscretization, VerticesDiscretization]
-    ) -> None:
+    def cleanup(self, dis: StructuredDiscretization | VerticesDiscretization) -> None:
         """
         Clean up package inplace. This method calls
         :func:`imod.prepare.cleanup.cleanup_ghb`, see documentation of that

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -14,6 +14,7 @@ from imod.mf6.regrid.regrid_schemes import (
 )
 from imod.mf6.utilities.regrid import RegridderWeightsCache, _regrid_package_data
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA, CONC_DIMS_SCHEMA
+from imod.prepare.cleanup import cleanup_ghb
 from imod.prepare.topsystem.allocation import ALLOCATION_OPTION, allocate_ghb_cells
 from imod.prepare.topsystem.conductance import (
     DISTRIBUTING_OPTION,
@@ -164,6 +165,10 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         errors = super()._validate(schemata, **kwargs)
 
         return errors
+
+    def cleanup(self) -> None:
+        cleaned_dict = self._call_func_on_grids(cleanup_ghb)
+        super().__init__(cleaned_dict)
 
     @classmethod
     def from_imod5_data(

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import numpy as np
 
-from imod.logging import init_log_decorator
+from imod.logging import init_log_decorator, standard_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.disv import VerticesDiscretization
@@ -168,6 +168,7 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
 
         return errors
 
+    @standard_log_decorator()
     def cleanup(self, dis: StructuredDiscretization | VerticesDiscretization) -> None:
         """
         Clean up package inplace. This method calls

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -171,6 +171,14 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
     def cleanup(
         self, dis: Union[StructuredDiscretization, VerticesDiscretization]
     ) -> None:
+        """
+        Clean up package inplace. This method calls
+        :func:`imod.prepare.cleanup.cleanup_ghb`, see documentation of that
+        function for details on cleanup.
+
+        dis: imod.mf6.StructuredDiscretization | imod.mf6.VerticesDiscretization
+            Model discretization package.
+        """
         dis_dict = {var: dis.dataset[var] for var in ["idomain"]}
         cleaned_dict = self._call_func_on_grids(cleanup_ghb, dis_dict)
         super().__init__(cleaned_dict)

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -1,11 +1,13 @@
 from copy import deepcopy
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
 from imod.logging import init_log_decorator
 from imod.mf6.boundary_condition import BoundaryCondition
+from imod.mf6.dis import StructuredDiscretization
+from imod.mf6.disv import VerticesDiscretization
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.npf import NodePropertyFlow
 from imod.mf6.regrid.regrid_schemes import (
@@ -166,8 +168,11 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
 
         return errors
 
-    def cleanup(self) -> None:
-        cleaned_dict = self._call_func_on_grids(cleanup_ghb)
+    def cleanup(
+        self, dis: Union[StructuredDiscretization, VerticesDiscretization]
+    ) -> None:
+        dis_dict = {var: dis.dataset[var] for var in ["idomain"]}
+        cleaned_dict = self._call_func_on_grids(cleanup_ghb, dis_dict)
         super().__init__(cleaned_dict)
 
     @classmethod

--- a/imod/mf6/interfaces/ipackage.py
+++ b/imod/mf6/interfaces/ipackage.py
@@ -30,3 +30,7 @@ class IPackage(IPackageBase, metaclass=abc.ABCMeta):
     @abstractmethod
     def is_regridding_supported(self) -> bool:
         raise NotImplementedError
+
+    @abstractmethod
+    def cleanup(self):
+        raise NotImplementedError

--- a/imod/mf6/interfaces/ipackage.py
+++ b/imod/mf6/interfaces/ipackage.py
@@ -30,7 +30,3 @@ class IPackage(IPackageBase, metaclass=abc.ABCMeta):
     @abstractmethod
     def is_regridding_supported(self) -> bool:
         raise NotImplementedError
-
-    @abstractmethod
-    def cleanup(self):
-        raise NotImplementedError

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -81,7 +81,7 @@ class Package(PackageBase, IPackage, abc.ABC):
             f"{type(self).__name__}(**{self._pkg_id}.dataset.sel(**selection))"
         )
 
-    def cleanup(self):
+    def cleanup(self, dis: Any):
         raise NotImplementedError("Method not implemented for this package.")
 
     @staticmethod
@@ -633,7 +633,9 @@ class Package(PackageBase, IPackage, abc.ABC):
                 result[name] = self.dataset[name].values[()]
         return result
 
-    def _call_func_on_grids(self, func: Callable) -> dict[str, GridDataArray]:
+    def _call_func_on_grids(
+        self, func: Callable, dis: dict
+    ) -> dict[str, GridDataArray]:
         """
         Call function on dictionary of grids and merge settings back into
         dictionary.
@@ -649,7 +651,7 @@ class Package(PackageBase, IPackage, abc.ABC):
             for varname in grid_varnames
             if varname in self.dataset.keys()
         }
-        cleaned_grids = func(**grids)
+        cleaned_grids = func(**dis, **grids)
         settings = self.get_non_grid_data(grid_varnames)
         return cleaned_grids | settings
 

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -81,6 +81,11 @@ class Package(PackageBase, IPackage, abc.ABC):
             f"{type(self).__name__}(**{self._pkg_id}.dataset.sel(**selection))"
         )
 
+    def cleanup(self):
+        raise NotImplementedError(
+            "Method not implemented for this package."
+        )
+
     @staticmethod
     def _valid(value: Any) -> bool:
         return _is_valid(value)

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -4,7 +4,7 @@ import abc
 import pathlib
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import cftime
 import jinja2
@@ -629,6 +629,22 @@ class Package(PackageBase, IPackage, abc.ABC):
             else:
                 result[name] = self.dataset[name].values[()]
         return result
+
+    def _call_func_on_grids(self, func: Callable) -> dict[str, GridDataArray]:
+        """
+        Call function on dictionary of grids and merge settings back into
+        dictionary.
+
+        Parameters
+        ----------
+        func: Callable
+            Function to call on all grids
+        """
+        grid_varnames = list(self._write_schemata.keys())
+        grids = {varname: self.dataset[varname] for varname in grid_varnames}
+        cleaned_grids = func(**grids)
+        settings = self.get_non_grid_data(grid_varnames)
+        return cleaned_grids | settings
 
     def is_splitting_supported(self) -> bool:
         return True

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -82,9 +82,7 @@ class Package(PackageBase, IPackage, abc.ABC):
         )
 
     def cleanup(self):
-        raise NotImplementedError(
-            "Method not implemented for this package."
-        )
+        raise NotImplementedError("Method not implemented for this package.")
 
     @staticmethod
     def _valid(value: Any) -> bool:
@@ -646,7 +644,11 @@ class Package(PackageBase, IPackage, abc.ABC):
             Function to call on all grids
         """
         grid_varnames = list(self._write_schemata.keys())
-        grids = {varname: self.dataset[varname] for varname in grid_varnames}
+        grids = {
+            varname: self.dataset[varname]
+            for varname in grid_varnames
+            if varname in self.dataset.keys()
+        }
         cleaned_grids = func(**grids)
         settings = self.get_non_grid_data(grid_varnames)
         return cleaned_grids | settings

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from datetime import datetime
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import numpy as np
 import xarray as xr
@@ -186,9 +186,7 @@ class River(BoundaryCondition, IRegridPackage):
 
         return errors
 
-    def cleanup(
-        self, dis: Union[StructuredDiscretization, VerticesDiscretization]
-    ) -> None:
+    def cleanup(self, dis: StructuredDiscretization | VerticesDiscretization) -> None:
         """
         Clean up package inplace. This method calls
         :func:`imod.prepare.cleanup.cleanup_riv`, see documentation of that

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -189,6 +189,14 @@ class River(BoundaryCondition, IRegridPackage):
     def cleanup(
         self, dis: Union[StructuredDiscretization, VerticesDiscretization]
     ) -> None:
+        """
+        Clean up package inplace. This method calls
+        :func:`imod.prepare.cleanup.cleanup_riv`, see documentation of that
+        function for details on cleanup.
+
+        dis: imod.mf6.StructuredDiscretization | imod.mf6.VerticesDiscretization
+            Model discretization package.
+        """
         dis_dict = {var: dis.dataset[var] for var in ["idomain", "bottom"]}
         cleaned_dict = self._call_func_on_grids(cleanup_riv, dis_dict)
         super().__init__(cleaned_dict)

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import xarray as xr
@@ -10,6 +10,7 @@ from imod.logging import init_log_decorator
 from imod.logging.loglevel import LogLevel
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.dis import StructuredDiscretization
+from imod.mf6.disv import VerticesDiscretization
 from imod.mf6.drn import Drainage
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.regrid.regrid_schemes import RiverRegridMethod
@@ -185,8 +186,11 @@ class River(BoundaryCondition, IRegridPackage):
 
         return errors
 
-    def cleanup(self) -> None:
-        cleaned_dict = self._call_func_on_grids(cleanup_riv)
+    def cleanup(
+        self, dis: Union[StructuredDiscretization, VerticesDiscretization]
+    ) -> None:
+        dis_dict = {var: dis.dataset[var] for var in ["idomain", "bottom"]}
+        cleaned_dict = self._call_func_on_grids(cleanup_riv, dis_dict)
         super().__init__(cleaned_dict)
 
     @classmethod

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -195,7 +195,7 @@ class River(BoundaryCondition, IRegridPackage):
         dis: imod.mf6.StructuredDiscretization | imod.mf6.VerticesDiscretization
             Model discretization package.
         """
-        dis_dict = {var: dis.dataset[var] for var in ["idomain", "bottom"]}
+        dis_dict = {"idomain": dis.dataset["idomain"], "bottom": dis.dataset["bottom"]}
         cleaned_dict = self._call_func_on_grids(cleanup_riv, dis_dict)
         super().__init__(cleaned_dict)
 

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -18,6 +18,7 @@ from imod.mf6.utilities.regrid import (
     _regrid_package_data,
 )
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA, CONC_DIMS_SCHEMA
+from imod.prepare.cleanup import cleanup_riv
 from imod.prepare.topsystem.allocation import ALLOCATION_OPTION, allocate_riv_cells
 from imod.prepare.topsystem.conductance import (
     DISTRIBUTING_OPTION,
@@ -183,6 +184,10 @@ class River(BoundaryCondition, IRegridPackage):
         errors = super()._validate(schemata, **kwargs)
 
         return errors
+
+    def cleanup(self) -> None:
+        cleaned_dict = self._call_func_on_grids(cleanup_riv)
+        super().__init__(cleaned_dict)
 
     @classmethod
     def from_imod5_data(

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 
 from imod import logging
-from imod.logging import init_log_decorator
+from imod.logging import init_log_decorator, standard_log_decorator
 from imod.logging.loglevel import LogLevel
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.dis import StructuredDiscretization
@@ -186,6 +186,7 @@ class River(BoundaryCondition, IRegridPackage):
 
         return errors
 
+    @standard_log_decorator()
     def cleanup(self, dis: StructuredDiscretization | VerticesDiscretization) -> None:
         """
         Clean up package inplace. This method calls

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -30,6 +30,7 @@ from imod.mf6.utilities.dataset import remove_inactive
 from imod.mf6.validation import validation_pkg_error_message
 from imod.mf6.write_context import WriteContext
 from imod.prepare import assign_wells
+from imod.prepare.cleanup import cleanup_wel
 from imod.prepare.layer import create_layered_top
 from imod.schemata import (
     AllValueSchema,
@@ -943,6 +944,9 @@ class Well(GridAgnosticWell):
             )
             logger.log(loglevel=LogLevel.ERROR, message=log_msg, additional_depth=2)
             raise ValueError(log_msg)
+
+    def cleanup(self):
+        self.dataset = cleanup_wel(self.dataset)
 
 
 class LayeredWell(GridAgnosticWell):

--- a/imod/prepare/__init__.py
+++ b/imod/prepare/__init__.py
@@ -14,6 +14,7 @@ speed by making use of the Numba compiler, to be able to regrid large datasets.
 """
 
 from imod.prepare import hfb, spatial, subsoil, surface_water
+from imod.prepare.cleanup import cleanup_drn, cleanup_ghb, cleanup_riv
 from imod.prepare.hfb import (
     linestring_to_square_zpolygons,
     linestring_to_trapezoid_zpolygons,

--- a/imod/prepare/cleanup.py
+++ b/imod/prepare/cleanup.py
@@ -1,0 +1,99 @@
+"""Cleanup utilities"""
+
+from enum import Enum
+from typing import Optional
+
+import xarray as xr
+
+from imod.mf6.utilities.mask import mask_arrays
+from imod.schemata import scalar_None
+from imod.typing import GridDataArray
+
+
+class AlignLevelsMode(Enum):
+    TOPDOWN = 0
+    BOTTOMUP = 1
+
+
+def align_nodata(grids: dict[str, xr.DataArray]) -> dict[str, xr.DataArray]:
+    return mask_arrays(grids)
+
+
+def align_interface_levels(
+    top: GridDataArray,
+    bottom: GridDataArray,
+    method: AlignLevelsMode = AlignLevelsMode.TOPDOWN,
+) -> tuple[GridDataArray, GridDataArray]:
+    to_align = top < bottom
+
+    if method == AlignLevelsMode.BOTTOMUP:
+        return top.where(~to_align, bottom), bottom
+    elif method == AlignLevelsMode.TOPDOWN:
+        return top, bottom.where(~to_align, top)
+    else:
+        raise TypeError("")
+
+
+def _cleanup_robin_boundary(grids=dict[str, GridDataArray]) -> dict[str, GridDataArray]:
+    """Cleanup robin boundary condition, with conductance"""
+    conductance = grids["conductance"]
+    concentration = grids["concentration"]
+    # Make conductance cells with erronous values inactive
+    grids["conductance"] = conductance.where(conductance <= 0.0)
+    # Make concentration cells with erronous values inactive
+    if (concentration is not None) or not scalar_None(concentration):
+        grids["concentration"] = concentration.where(concentration < 0.0)
+    else:
+        grids.pop("concentration")
+
+    # Align nodata
+    return align_nodata(grids)
+
+
+def cleanup_riv(
+    stage: GridDataArray,
+    conductance: GridDataArray,
+    bottom_elevation: GridDataArray,
+    concentration: Optional[GridDataArray] = None,
+) -> dict[str, GridDataArray]:
+    # Output dict
+    output_dict = {
+        "stage": stage,
+        "conductance": conductance,
+        "bottom_elevation": bottom_elevation,
+        "concentration": concentration,
+    }
+    output_dict = _cleanup_robin_boundary(output_dict)
+    # Ensure stage above bottom_elevation
+    output_dict["stage"], output_dict["bottom_elevation"] = align_interface_levels(
+        output_dict["stage"], output_dict["bottom_elevation"], AlignLevelsMode.TOPDOWN
+    )
+    return output_dict
+
+
+def cleanup_drn(
+    elevation: GridDataArray,
+    conductance: GridDataArray,
+    concentration: Optional[GridDataArray] = None,
+) -> dict[str, GridDataArray]:
+    # Output dict
+    output_dict = {
+        "elevation": elevation,
+        "conductance": conductance,
+        "concentration": concentration,
+    }
+    return _cleanup_robin_boundary(output_dict)
+
+
+def cleanup_ghb(
+    head: GridDataArray,
+    conductance: GridDataArray,
+    concentration: Optional[GridDataArray] = None,
+) -> dict[str, GridDataArray]:
+    # Output dict
+    output_dict = {
+        "head": head,
+        "conductance": conductance,
+        "concentration": concentration,
+    }
+    return _cleanup_robin_boundary(output_dict)

--- a/imod/prepare/cleanup.py
+++ b/imod/prepare/cleanup.py
@@ -92,7 +92,7 @@ def cleanup_riv(
         Grid with river bottom elevations
     concentration: xarray.DataArray | xugrid.UgridDataArray, optional
         Optional grid with concentrations
-    
+
     Returns
     -------
     dict[str, xarray.DataArray | xugrid.UgridDataArray]
@@ -151,12 +151,12 @@ def cleanup_drn(
         Grid with conductances
     concentration: xarray.DataArray | xugrid.UgridDataArray, optional
         Optional grid with concentrations
-    
+
     Returns
     -------
     dict[str, xarray.DataArray | xugrid.UgridDataArray]
         Dict of cleaned up grids. Has keys: "elevation", "conductance",
-        "concentration".      
+        "concentration".
     """
     # Output dict
     output_dict = {
@@ -193,12 +193,12 @@ def cleanup_ghb(
         Grid with conductances
     concentration: xarray.DataArray | xugrid.UgridDataArray, optional
         Optional grid with concentrations
-    
+
     Returns
     -------
     dict[str, xarray.DataArray | xugrid.UgridDataArray]
         Dict of cleaned up grids. Has keys: "head", "conductance",
-        "concentration".  
+        "concentration".
     """
     # Output dict
     output_dict = {
@@ -212,7 +212,7 @@ def cleanup_ghb(
 def cleanup_wel(wel_ds: GridDataset):
     """
     Clean up wells
-    
+
     - Removes wells where the screen bottom elevation exceeds screen top.
     """
     deactivate = wel_ds["screen_top"] < wel_ds["screen_bottom"]

--- a/imod/prepare/cleanup.py
+++ b/imod/prepare/cleanup.py
@@ -130,8 +130,6 @@ def cleanup_ghb(
     return _cleanup_robin_boundary(output_dict)
 
 
-def cleanup_wel(
-        wel_ds: GridDataset
-):
+def cleanup_wel(wel_ds: GridDataset):
     deactivate = wel_ds["screen_top"] < wel_ds["screen_bottom"]
     return wel_ds.where(~deactivate, drop=True)

--- a/imod/prepare/cleanup.py
+++ b/imod/prepare/cleanup.py
@@ -7,7 +7,7 @@ import xarray as xr
 
 from imod.mf6.utilities.mask import mask_arrays
 from imod.schemata import scalar_None
-from imod.typing import GridDataArray
+from imod.typing import GridDataArray, GridDataset
 
 
 class AlignLevelsMode(Enum):
@@ -35,7 +35,7 @@ def align_interface_levels(
 
 
 def _cleanup_robin_boundary(grids=dict[str, GridDataArray]) -> dict[str, GridDataArray]:
-    """Cleanup robin boundary condition, with conductance"""
+    """Cleanup robin boundary condition (i.e. bc with conductance)"""
     conductance = grids["conductance"]
     concentration = grids["concentration"]
     # Make conductance cells with erronous values inactive
@@ -127,3 +127,10 @@ def cleanup_ghb(
         "concentration": concentration,
     }
     return _cleanup_robin_boundary(output_dict)
+
+
+def cleanup_wel(
+        wel_ds: GridDataset
+):
+    deactivate = wel_ds["screen_top"] < wel_ds["screen_bottom"]
+    return wel_ds.where(~deactivate, drop=True)

--- a/imod/prepare/cleanup.py
+++ b/imod/prepare/cleanup.py
@@ -26,12 +26,13 @@ def align_interface_levels(
 ) -> tuple[GridDataArray, GridDataArray]:
     to_align = top < bottom
 
-    if method == AlignLevelsMode.BOTTOMUP:
-        return top.where(~to_align, bottom), bottom
-    elif method == AlignLevelsMode.TOPDOWN:
-        return top, bottom.where(~to_align, top)
-    else:
-        raise TypeError("")
+    match method:
+        case AlignLevelsMode.BOTTOMUP:
+            return top.where(~to_align, bottom), bottom
+        case AlignLevelsMode.TOPDOWN:
+            return top, bottom.where(~to_align, top)
+        case _:
+            raise TypeError(f"Unmatched case for method, got {method}")
 
 
 def _cleanup_robin_boundary(grids=dict[str, GridDataArray]) -> dict[str, GridDataArray]:
@@ -41,7 +42,7 @@ def _cleanup_robin_boundary(grids=dict[str, GridDataArray]) -> dict[str, GridDat
     # Make conductance cells with erronous values inactive
     grids["conductance"] = conductance.where(conductance > 0.0)
     # Make concentration cells with erronous values inactive
-    if (concentration is not None) or not scalar_None(concentration):
+    if (concentration is not None) and not scalar_None(concentration):
         grids["concentration"] = concentration.where(concentration >= 0.0)
     else:
         grids.pop("concentration")

--- a/imod/prepare/cleanup.py
+++ b/imod/prepare/cleanup.py
@@ -213,6 +213,7 @@ def cleanup_ghb(
     return _cleanup_robin_boundary(idomain, output_dict)
 
 
+@standard_log_decorator()
 def cleanup_wel(wel_ds: GridDataset):
     """
     Clean up wells

--- a/imod/prepare/cleanup.py
+++ b/imod/prepare/cleanup.py
@@ -41,9 +41,9 @@ def _cleanup_robin_boundary(grids=dict[str, GridDataArray]) -> dict[str, GridDat
     concentration = grids["concentration"]
     # Make conductance cells with erronous values inactive
     grids["conductance"] = conductance.where(conductance > 0.0)
-    # Make concentration cells with erronous values inactive
+    # Clip negative concentration cells to 0.0
     if (concentration is not None) and not scalar_None(concentration):
-        grids["concentration"] = concentration.where(concentration >= 0.0)
+        grids["concentration"] = concentration.clip(min=0.0)
     else:
         grids.pop("concentration")
 
@@ -62,7 +62,7 @@ def cleanup_riv(
     doing the following:
 
     - Cells where conductance <= 0 are deactivated.
-    - Cells where concentration < 0 are deactivated.
+    - Cells where concentration < 0 are set to 0.0.
     - Align NoData: If one variable has an inactive cell in one cell, ensure
       this cell is deactivated for all variables.
     - River bottom elevations which exceed river stage are lowered to river
@@ -94,7 +94,7 @@ def cleanup_drn(
     doing the following:
 
     - Cells where conductance <= 0 are deactivated.
-    - Cells where concentration < 0 are deactivated.
+    - Cells where concentration < 0 are set to 0.0.
     - Align NoData: If one variable has an inactive cell in one cell, ensure
       this cell is deactivated for all variables.
     """
@@ -117,7 +117,7 @@ def cleanup_ghb(
     ValidationErrors by doing the following:
 
     - Cells where conductance <= 0 are deactivated.
-    - Cells where concentration < 0 are deactivated.
+    - Cells where concentration < 0 are set to 0.0.
     - Align NoData: If one variable has an inactive cell in one cell, ensure
       this cell is deactivated for all variables.
     """

--- a/imod/prepare/cleanup.py
+++ b/imod/prepare/cleanup.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import xarray as xr
 
+from imod.logging.logging_decorators import standard_log_decorator
 from imod.mf6.utilities.mask import mask_arrays
 from imod.schemata import scalar_None
 from imod.typing import GridDataArray, GridDataset
@@ -56,6 +57,7 @@ def _cleanup_robin_boundary(
     return align_nodata(grids)
 
 
+@standard_log_decorator()
 def cleanup_riv(
     idomain: GridDataArray,
     bottom: GridDataArray,
@@ -125,6 +127,7 @@ def cleanup_riv(
     return output_dict
 
 
+@standard_log_decorator()
 def cleanup_drn(
     idomain: GridDataArray,
     elevation: GridDataArray,
@@ -167,6 +170,7 @@ def cleanup_drn(
     return _cleanup_robin_boundary(idomain, output_dict)
 
 
+@standard_log_decorator()
 def cleanup_ghb(
     idomain: GridDataArray,
     head: GridDataArray,

--- a/imod/prepare/cleanup.py
+++ b/imod/prepare/cleanup.py
@@ -78,6 +78,26 @@ def cleanup_riv(
     - River bottom elevations which exceed river stage are lowered to river
       stage.
 
+    Parameters
+    ----------
+    idomain: xarray.DataArray | xugrid.UgridDataArray
+        MODFLOW 6 model domain. idomain==1 is considered active domain.
+    bottom: xarray.DataArray | xugrid.UgridDataArray
+        Grid with`model bottoms
+    stage: xarray.DataArray | xugrid.UgridDataArray
+        Grid with river stages
+    conductance: xarray.DataArray | xugrid.UgridDataArray
+        Grid with conductances
+    bottom_elevation: xarray.DataArray | xugrid.UgridDataArray
+        Grid with river bottom elevations
+    concentration: xarray.DataArray | xugrid.UgridDataArray, optional
+        Optional grid with concentrations
+    
+    Returns
+    -------
+    dict[str, xarray.DataArray | xugrid.UgridDataArray]
+        Dict of cleaned up grids. Has keys: "stage", "conductance",
+        "bottom_elevation", "concentration".
     """
     # Output dict
     output_dict = {
@@ -90,9 +110,8 @@ def cleanup_riv(
     if (output_dict["stage"] < bottom).any():
         raise ValueError(
             "River stage below bottom of model layer, cannot fix this. "
-            "Probably rivers are assigned to the wrong layer, you can allocate "
-            "to model layers with "
-            "river data to with: "
+            "Probably rivers are assigned to the wrong layer, you can reallocate "
+            "river data to model layers with: "
             "``imod.prepare.topsystem.allocate_riv_cells``."
         )
     # Ensure bottom elevation above model bottom
@@ -121,6 +140,23 @@ def cleanup_drn(
     - Cells outside active domain (idomain==1) are removed.
     - Align NoData: If one variable has an inactive cell in one cell, ensure
       this cell is deactivated for all variables.
+
+    Parameters
+    ----------
+    idomain: xarray.DataArray | xugrid.UgridDataArray
+        MODFLOW 6 model domain. idomain==1 is considered active domain.
+    elevation: xarray.DataArray | xugrid.UgridDataArray
+        Grid with drain elevations
+    conductance: xarray.DataArray | xugrid.UgridDataArray
+        Grid with conductances
+    concentration: xarray.DataArray | xugrid.UgridDataArray, optional
+        Optional grid with concentrations
+    
+    Returns
+    -------
+    dict[str, xarray.DataArray | xugrid.UgridDataArray]
+        Dict of cleaned up grids. Has keys: "elevation", "conductance",
+        "concentration".      
     """
     # Output dict
     output_dict = {
@@ -146,6 +182,23 @@ def cleanup_ghb(
     - Cells outside active domain (idomain==1) are removed.
     - Align NoData: If one variable has an inactive cell in one cell, ensure
       this cell is deactivated for all variables.
+
+    Parameters
+    ----------
+    idomain: xarray.DataArray | xugrid.UgridDataArray
+        MODFLOW 6 model domain. idomain==1 is considered active domain.
+    head: xarray.DataArray | xugrid.UgridDataArray
+        Grid with heads
+    conductance: xarray.DataArray | xugrid.UgridDataArray
+        Grid with conductances
+    concentration: xarray.DataArray | xugrid.UgridDataArray, optional
+        Optional grid with concentrations
+    
+    Returns
+    -------
+    dict[str, xarray.DataArray | xugrid.UgridDataArray]
+        Dict of cleaned up grids. Has keys: "head", "conductance",
+        "concentration".  
     """
     # Output dict
     output_dict = {
@@ -157,6 +210,10 @@ def cleanup_ghb(
 
 
 def cleanup_wel(wel_ds: GridDataset):
-    """ """
+    """
+    Clean up wells
+    
+    - Removes wells where the screen bottom elevation exceeds screen top.
+    """
     deactivate = wel_ds["screen_top"] < wel_ds["screen_bottom"]
     return wel_ds.where(~deactivate, drop=True)

--- a/imod/prepare/cleanup.py
+++ b/imod/prepare/cleanup.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 import xarray as xr
 
-from imod.logging.logging_decorators import standard_log_decorator
 from imod.mf6.utilities.mask import mask_arrays
 from imod.schemata import scalar_None
 from imod.typing import GridDataArray, GridDataset
@@ -57,7 +56,6 @@ def _cleanup_robin_boundary(
     return align_nodata(grids)
 
 
-@standard_log_decorator()
 def cleanup_riv(
     idomain: GridDataArray,
     bottom: GridDataArray,
@@ -127,7 +125,6 @@ def cleanup_riv(
     return output_dict
 
 
-@standard_log_decorator()
 def cleanup_drn(
     idomain: GridDataArray,
     elevation: GridDataArray,
@@ -170,7 +167,6 @@ def cleanup_drn(
     return _cleanup_robin_boundary(idomain, output_dict)
 
 
-@standard_log_decorator()
 def cleanup_ghb(
     idomain: GridDataArray,
     head: GridDataArray,
@@ -213,7 +209,6 @@ def cleanup_ghb(
     return _cleanup_robin_boundary(idomain, output_dict)
 
 
-@standard_log_decorator()
 def cleanup_wel(wel_ds: GridDataset):
     """
     Clean up wells

--- a/imod/prepare/cleanup.py
+++ b/imod/prepare/cleanup.py
@@ -39,10 +39,10 @@ def _cleanup_robin_boundary(grids=dict[str, GridDataArray]) -> dict[str, GridDat
     conductance = grids["conductance"]
     concentration = grids["concentration"]
     # Make conductance cells with erronous values inactive
-    grids["conductance"] = conductance.where(conductance <= 0.0)
+    grids["conductance"] = conductance.where(conductance > 0.0)
     # Make concentration cells with erronous values inactive
     if (concentration is not None) or not scalar_None(concentration):
-        grids["concentration"] = concentration.where(concentration < 0.0)
+        grids["concentration"] = concentration.where(concentration >= 0.0)
     else:
         grids.pop("concentration")
 
@@ -56,6 +56,18 @@ def cleanup_riv(
     bottom_elevation: GridDataArray,
     concentration: Optional[GridDataArray] = None,
 ) -> dict[str, GridDataArray]:
+    """
+    Clean up river data, fixes some common mistakes causing ValidationErrors by
+    doing the following:
+
+    - Cells where conductance <= 0 are deactivated.
+    - Cells where concentration < 0 are deactivated.
+    - Align NoData: If one variable has an inactive cell in one cell, ensure
+      this cell is deactivated for all variables.
+    - River bottom elevations which exceed river stage are lowered to river
+      stage.
+
+    """
     # Output dict
     output_dict = {
         "stage": stage,
@@ -76,6 +88,15 @@ def cleanup_drn(
     conductance: GridDataArray,
     concentration: Optional[GridDataArray] = None,
 ) -> dict[str, GridDataArray]:
+    """
+    Clean up drain data, fixes some common mistakes causing ValidationErrors by
+    doing the following:
+
+    - Cells where conductance <= 0 are deactivated.
+    - Cells where concentration < 0 are deactivated.
+    - Align NoData: If one variable has an inactive cell in one cell, ensure
+      this cell is deactivated for all variables.
+    """
     # Output dict
     output_dict = {
         "elevation": elevation,
@@ -90,6 +111,15 @@ def cleanup_ghb(
     conductance: GridDataArray,
     concentration: Optional[GridDataArray] = None,
 ) -> dict[str, GridDataArray]:
+    """
+    Clean up general head boundary data, fixes some common mistakes causing
+    ValidationErrors by doing the following:
+
+    - Cells where conductance <= 0 are deactivated.
+    - Cells where concentration < 0 are deactivated.
+    - Align NoData: If one variable has an inactive cell in one cell, ensure
+      this cell is deactivated for all variables.
+    """
     # Output dict
     output_dict = {
         "head": head,

--- a/imod/tests/test_mf6/test_mf6_riv.py
+++ b/imod/tests/test_mf6/test_mf6_riv.py
@@ -19,7 +19,6 @@ from imod.schemata import ValidationError
 from imod.typing.grid import ones_like, zeros_like
 
 
-@pytest.fixture(scope="function")
 def make_da():
     x = [5.0, 15.0, 25.0]
     y = [25.0, 15.0, 5.0]
@@ -34,9 +33,8 @@ def make_da():
     )
 
 
-@pytest.fixture(scope="function")
-def dis_dict(make_da):
-    da = make_da
+def dis_dict():
+    da = make_da()
     bottom = da - xr.DataArray(
         data=[1.5, 2.5], dims=("layer",), coords={"layer": [2, 3]}
     )
@@ -44,16 +42,15 @@ def dis_dict(make_da):
     return {"idomain": da.astype(int), "top": da.sel(layer=2), "bottom": bottom}
 
 
-@pytest.fixture(scope="function")
-def riv_dict(make_da):
-    da = make_da
+def riv_dict():
+    da = make_da()
     da[:, 1, 1] = np.nan
 
     bottom = da - xr.DataArray(
         data=[1.0, 2.0], dims=("layer",), coords={"layer": [2, 3]}
     )
 
-    return {"stage": da, "conductance": da, "bottom_elevation": bottom}
+    return {"stage": da, "conductance": da.copy(), "bottom_elevation": bottom}
 
 
 def make_dict_unstructured(d):
@@ -61,19 +58,19 @@ def make_dict_unstructured(d):
 
 
 class RivCases:
-    def case_structured(self, riv_dict):
-        return riv_dict
+    def case_structured(self):
+        return riv_dict()
 
-    def case_unstructured(self, riv_dict):
-        return make_dict_unstructured(riv_dict)
+    def case_unstructured(self):
+        return make_dict_unstructured(riv_dict())
 
 
 class RivDisCases:
-    def case_structured(self, riv_dict, dis_dict):
-        return riv_dict, dis_dict
+    def case_structured(self):
+        return riv_dict(), dis_dict()
 
-    def case_unstructured(self, riv_dict, dis_dict):
-        return make_dict_unstructured(riv_dict), make_dict_unstructured(dis_dict)
+    def case_unstructured(self):
+        return make_dict_unstructured(riv_dict()), make_dict_unstructured(dis_dict())
 
 
 @parametrize_with_cases("riv_data", cases=RivCases)

--- a/imod/tests/test_prepare/test_cleanup.py
+++ b/imod/tests/test_prepare/test_cleanup.py
@@ -74,6 +74,24 @@ def test_cleanup__zero_conductance(riv_data: dict, cleanup_func: Callable):
 
 
 @parametrize_with_cases("riv_data", cases=RivCases)
+@parametrize("cleanup_func", [cleanup_drn, cleanup_ghb, cleanup_riv])
+def test_cleanup__negative_concentration(riv_data: dict, cleanup_func: Callable):
+    data_dict = _rename_data_dict(riv_data, cleanup_func)
+    first_key = next(iter(data_dict.keys()))
+    # Create concentration data
+    data_dict["concentration"] = data_dict[first_key].copy()
+    # Assure conductance not modified by previous tests.
+    np.testing.assert_equal(_first(data_dict["conductance"]), 1.0)
+    idx = _first_index(data_dict["conductance"])
+    # Arrange: Deactivate one cell
+    data_dict["concentration"][idx] = -10.0
+    # Act
+    data_cleaned = cleanup_func(**data_dict)
+    # Assert
+    np.testing.assert_equal(_first(data_cleaned["concentration"]), 0.0)
+
+
+@parametrize_with_cases("riv_data", cases=RivCases)
 def test_cleanup_riv__fix_bottom_elevation(riv_data):
     # Arrange: Set bottom elevation above stage
     riv_data["bottom_elevation"] += 3.0

--- a/imod/tests/test_prepare/test_cleanup.py
+++ b/imod/tests/test_prepare/test_cleanup.py
@@ -1,6 +1,7 @@
 from typing import Callable
 
 import numpy as np
+import pytest
 import xugrid as xu
 from pytest_cases import parametrize, parametrize_with_cases
 
@@ -161,3 +162,17 @@ def test_cleanup_riv__fix_bottom_elevation_to_stage(riv_data: dict, dis_data: di
     np.testing.assert_equal(
         riv_data_cleaned["bottom_elevation"].values, riv_data_cleaned["stage"].values
     )
+
+
+@parametrize_with_cases("riv_data, dis_data", cases=RivDisCases)
+def test_cleanup_riv__raise_error(riv_data: dict, dis_data: dict):
+    """
+    Test if error raised when stage below model layer bottom and see if user is
+    guided to the right prepare function.
+    """
+    dis_dict = _prepare_dis_dict(dis_data, cleanup_riv)
+    # Arrange: Set bottom elevation above stage
+    riv_data["stage"] -= 10.0
+    # Act
+    with pytest.raises(ValueError, match="imod.prepare.topsystem.allocate_riv_cells"):
+        cleanup_riv(**dis_dict, **riv_data)

--- a/imod/tests/test_prepare/test_cleanup.py
+++ b/imod/tests/test_prepare/test_cleanup.py
@@ -1,0 +1,87 @@
+from typing import Callable
+
+import numpy as np
+import xugrid as xu
+from pytest_cases import parametrize, parametrize_with_cases
+
+from imod.prepare.cleanup import cleanup_drn, cleanup_ghb, cleanup_riv
+from imod.tests.test_mf6.test_mf6_riv import RivCases
+from imod.typing import GridDataArray
+
+
+def _first(grid: GridDataArray):
+    """
+    helper function to get first value, regardless of unstructured or
+    structured grid."""
+    return grid.values.ravel()[0]
+
+
+def _first_index(grid: GridDataArray) -> tuple:
+    if isinstance(grid, xu.UgridDataArray):
+        return (0, 0)
+    else:
+        return (0, 0, 0)
+
+
+def _rename_data_dict(data: dict, func: Callable):
+    renamed = data.copy()
+    to_rename = _RENAME_DICT[func]
+    for src, dst in to_rename.items():
+        mv_data = renamed.pop(src)
+        if dst is not None:
+            renamed[dst] = mv_data
+    return renamed
+
+
+_RENAME_DICT = {
+    cleanup_riv: {},
+    cleanup_drn: {"stage": "elevation", "bottom_elevation": None},
+    cleanup_ghb: {"stage": "head", "bottom_elevation": None},
+}
+
+
+@parametrize_with_cases("riv_data", cases=RivCases)
+@parametrize("cleanup_func", [cleanup_drn, cleanup_ghb, cleanup_riv])
+def test_cleanup__align_nodata(riv_data: dict, cleanup_func: Callable):
+    data_dict = _rename_data_dict(riv_data, cleanup_func)
+    # Assure conductance not modified by previous tests.
+    np.testing.assert_equal(_first(data_dict["conductance"]), 1.0)
+    idx = _first_index(data_dict["conductance"])
+    # Arrange: Deactivate one cell
+    first_key = next(iter(data_dict.keys()))
+    data_dict[first_key][idx] = np.nan
+    # Act
+    data_cleaned = cleanup_func(**data_dict)
+    # Assert
+    for key in data_cleaned.keys():
+        np.testing.assert_equal(_first(data_cleaned[key][idx]), np.nan)
+
+
+@parametrize_with_cases("riv_data", cases=RivCases)
+@parametrize("cleanup_func", [cleanup_drn, cleanup_ghb, cleanup_riv])
+def test_cleanup__zero_conductance(riv_data: dict, cleanup_func: Callable):
+    data_dict = _rename_data_dict(riv_data, cleanup_func)
+    # Assure conductance not modified by previous tests.
+    np.testing.assert_equal(_first(data_dict["conductance"]), 1.0)
+    idx = _first_index(data_dict["conductance"])
+    # Arrange: Deactivate one cell
+    data_dict["conductance"][idx] = 0.0
+    # Act
+    data_cleaned = cleanup_func(**data_dict)
+    # Assert
+    for key in data_cleaned.keys():
+        np.testing.assert_equal(_first(data_cleaned[key][idx]), np.nan)
+
+
+@parametrize_with_cases("riv_data", cases=RivCases)
+def test_cleanup_riv__fix_bottom_elevation(riv_data):
+    # Arrange: Set bottom elevation above stage
+    riv_data["bottom_elevation"] += 3.0
+    # Assure conductance not modified by previous tests.
+    np.testing.assert_equal(_first(riv_data["conductance"]), 1.0)
+    # Act
+    riv_data_cleaned = cleanup_riv(**riv_data)
+    # Assert
+    np.testing.assert_equal(
+        riv_data_cleaned["bottom_elevation"].values, riv_data_cleaned["stage"].values
+    )


### PR DESCRIPTION
Fixes #1164


# Description
This implements the following cleanup utilities for the robin boundary conditions, namely the DRN, GHB, and RIV.

- Cleanup helper functions, which are part of the public API (so that people could also use them outside MODFLOW 6)
- Cleanup methods to the River, GeneralHeadBoundary, Drain package for convenience. These call the corresponding helper function. Save the user the hassle of manually finding the right arguments to clean up grids.
- Add a utility method: Call function on grids, which separates grid variables from settings, calls a function on them, and then merges these dicts again.
- Converted the fixtures in ``test_mf6_riv`` to regular functions, as they were used as such anyway. Without this, RivDisCases could not be used outside the ``test_mf6_riv`` module, now it can be imported.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
