### PR TITLE
#1173 Add missing pip buildstep the the Nightly build

### DIFF
--- a/.teamcity/Nightly/NightlyProject.kt
+++ b/.teamcity/Nightly/NightlyProject.kt
@@ -123,6 +123,9 @@ object NightlyTests : BuildType({
     }
 
     dependencies {
+        snapshot(NightlyPipPython) {
+            onDependencyFailure = FailureAction.FAIL_TO_START
+        }
         snapshot(NightlyExamples) {
             onDependencyFailure = FailureAction.FAIL_TO_START
         }


### PR DESCRIPTION
Fixes #1173 

# Description
I noticed that the buildstep to verify that imod can be installed using pip is not being run during the Nightly.
This commit fixes that

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
