### PR TITLE
Issue #1176 assign wells with point filters

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -36,6 +36,8 @@ Changed
   polygons.
 - :func:`open_projectfile_data` now returns well data grouped by ipf name,
   instead of generic, separate number per entry.
+- :class:`imod.mf6.Well` now supports wells which have a filter with zero
+  length, where ``"screen_top"`` equals ``"screen_bottom"``.
 
 Added
 ~~~~~

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -728,7 +728,7 @@ class Well(GridAgnosticWell):
         "screen_bottom": [
             AnyNoDataSchema(),
             EmptyIndexesSchema(),
-            AllValueSchema("<", "screen_top"),
+            AllValueSchema("<=", "screen_top"),
         ],
         "y": [AnyNoDataSchema(), EmptyIndexesSchema()],
         "x": [AnyNoDataSchema(), EmptyIndexesSchema()],

--- a/imod/prepare/wells.py
+++ b/imod/prepare/wells.py
@@ -31,8 +31,11 @@ def compute_point_filter_overlap(bounds_wells, bounds_layers):
     thickness.
     """
     zero_filter_length = bounds_wells[:, 1] == bounds_wells[:, 0]
+    in_layer = (bounds_layers[:, 1] > bounds_wells[:, 1]) & (
+        bounds_layers[:, 0] < bounds_wells[:, 0]
+    )
     layer_thickness = bounds_layers[:, 1] - bounds_layers[:, 0]
-    return zero_filter_length.astype(float) * layer_thickness
+    return zero_filter_length.astype(float) * in_layer.astype(float) * layer_thickness
 
 
 def compute_overlap(wells, top, bottom):
@@ -58,6 +61,7 @@ def compute_overlap(wells, top, bottom):
         layer_bounds,
     )
     return np.maximum(interval_filter_overlap, point_filter_overlap)
+
 
 def locate_wells(
     wells: pd.DataFrame,

--- a/imod/prepare/wells.py
+++ b/imod/prepare/wells.py
@@ -37,14 +37,15 @@ def compute_point_filter_overlap(bounds_wells, bounds_layers):
 
 def compute_overlap(wells, top, bottom):
     # layer bounds shape of (n_well, n_layer, 2)
-    layer_bounds = np.stack((bottom, top), axis=-1).reshape(-1, 2)
+    layer_bounds_stack = np.stack((bottom, top), axis=-1)
     well_bounds = np.broadcast_to(
         np.stack(
             (wells["bottom"].to_numpy(), wells["top"].to_numpy()),
             axis=-1,
         )[np.newaxis, :, :],
-        layer_bounds.shape,
+        layer_bounds_stack.shape,
     ).reshape(-1, 2)
+    layer_bounds = layer_bounds_stack.reshape(-1, 2)
 
     # Deal with filters with a nonzero length
     interval_filter_overlap = compute_vectorized_overlap(

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -90,10 +90,10 @@ class GridAgnosticWellCases:
         return obj, dims_expected, cellid_expected, rate_expected
 
     def case_well_point_filter(self, well_high_lvl_test_data_stationary):
-        x, y, screen_top, _, rate_wel, concentration = (
+        x, y, _, screen_point, rate_wel, concentration = (
             well_high_lvl_test_data_stationary
         )
-        obj = imod.mf6.Well(x, y, screen_top, screen_top, rate_wel, concentration)
+        obj = imod.mf6.Well(x, y, screen_point, screen_point, rate_wel, concentration)
         dims_expected = {
             "ncellid": 8,
             "nmax_cellid": 3,

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -89,6 +89,32 @@ class GridAgnosticWellCases:
         rate_expected = np.array([0.25] * 4 + [0.75] * 4 + [1.0] * 4)
         return obj, dims_expected, cellid_expected, rate_expected
 
+    def case_well_point_filter(self, well_high_lvl_test_data_stationary):
+        x, y, screen_top, _, rate_wel, concentration = (
+            well_high_lvl_test_data_stationary
+        )
+        obj = imod.mf6.Well(x, y, screen_top, screen_top, rate_wel, concentration)
+        dims_expected = {
+            "ncellid": 8,
+            "nmax_cellid": 3,
+            "species": 2,
+        }
+        cellid_expected = np.array(
+            [
+                [1, 1, 9],
+                [1, 2, 9],
+                [1, 1, 8],
+                [1, 2, 8],
+                [2, 3, 7],
+                [2, 4, 7],
+                [2, 3, 6],
+                [2, 4, 6],
+            ],
+            dtype=np.int64,
+        )
+        rate_expected = np.array(np.ones((8,), dtype=np.float32))
+        return obj, dims_expected, cellid_expected, rate_expected
+
     def case_well_transient(self, well_high_lvl_test_data_transient):
         obj = imod.mf6.Well(*well_high_lvl_test_data_transient)
         dims_expected = {
@@ -221,7 +247,7 @@ def test_to_mf6_pkg__validate_filter_top(well_high_lvl_test_data_stationary):
     assert len(errors) == 1
     assert (
         str(errors["screen_bottom"][0])
-        == "not all values comply with criterion: < screen_top"
+        == "not all values comply with criterion: <= screen_top"
     )
 
 


### PR DESCRIPTION
Fixes #1176 

# Description

- Assign wells with point filters (filters with a zero length) to layers. Before, these would be removed in the compute_overlap method.
- Add test case for wells with a point filter
- Set validation so that screen_top can equal screen_bottom

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
