### PR TITLE
Issue #1190 Run Main and Nightly pipelines inside docker containers

### DIFF
--- a/.teamcity/Templates/ExamplesTemplate.kt
+++ b/.teamcity/Templates/ExamplesTemplate.kt
@@ -4,7 +4,9 @@ import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.DslContext
 import jetbrains.buildServer.configs.kotlin.Template
 import jetbrains.buildServer.configs.kotlin.buildFeatures.XmlReport
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.buildFeatures.xmlReport
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object ExamplesTemplate : Template({
@@ -29,18 +31,22 @@ object ExamplesTemplate : Template({
                 pixi run --environment default --frozen examples
             """.trimIndent()
             formatStderrAsError = true
+            dockerImage = "containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.26.1"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus="4""""
+            dockerPull = true
         }
     }
 
     features {
+        dockerSupport {
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_134"
+            }
+        }
         xmlReport {
             reportType = XmlReport.XmlReportType.JUNIT
             rules = "imod-python/imod/tests/*report.xml"
         }
-    }
-
-    requirements {
-        equals("env.OS", "Windows_NT")
-        doesNotExist("container.engine")
     }
 })

--- a/.teamcity/Templates/ExamplesTemplate.kt
+++ b/.teamcity/Templates/ExamplesTemplate.kt
@@ -27,7 +27,7 @@ object ExamplesTemplate : Template({
             id = "Run_examples"
             workingDir = "imod-python"
             scriptContent = """
-                set Path=%system.teamcity.build.checkoutDir%\modflow6;"d:\ProgramData\pixi"
+                SET PATH=%%PATH%%;%system.teamcity.build.checkoutDir%\modflow6
                 pixi run --environment default --frozen examples
             """.trimIndent()
             formatStderrAsError = true

--- a/.teamcity/Templates/LintTemplate.kt
+++ b/.teamcity/Templates/LintTemplate.kt
@@ -2,6 +2,8 @@ package Templates
 
 import jetbrains.buildServer.configs.kotlin.DslContext
 import jetbrains.buildServer.configs.kotlin.Template
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerSupport
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object LintTemplate : Template({
@@ -24,11 +26,17 @@ object LintTemplate : Template({
                     pixi run --environment default --frozen lint 
                 """.trimIndent()
             formatStderrAsError = true
+            dockerImage = "containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.26.1"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerPull = true
         }
     }
 
-    requirements {
-        equals("env.OS", "Windows_NT")
-        doesNotExist("container.engine")
+    features {
+        dockerSupport {
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_134"
+            }
+        }
     }
 })

--- a/.teamcity/Templates/MyPyTemplate.kt
+++ b/.teamcity/Templates/MyPyTemplate.kt
@@ -3,7 +3,9 @@ package Templates
 import jetbrains.buildServer.configs.kotlin.DslContext
 import jetbrains.buildServer.configs.kotlin.Template
 import jetbrains.buildServer.configs.kotlin.buildFeatures.XmlReport
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.buildFeatures.xmlReport
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.failureConditions.BuildFailureOnMetric
 import jetbrains.buildServer.configs.kotlin.failureConditions.failOnMetricChange
@@ -29,6 +31,9 @@ object MyPyTemplate : Template({
                     pixi run --environment default --frozen mypy
                 """.trimIndent()
             formatStderrAsError = true
+            dockerImage = "containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.26.1"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerPull = true
         }
     }
 
@@ -45,14 +50,14 @@ object MyPyTemplate : Template({
     }
 
     features {
+        dockerSupport {
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_134"
+            }
+        }
         xmlReport {
             reportType = XmlReport.XmlReportType.JUNIT
             rules = "imod-python/*.xml"
         }
-    }
-
-    requirements {
-        equals("env.OS", "Windows_NT")
-        doesNotExist("container.engine")
     }
 })

--- a/.teamcity/Templates/PipPythonTemplate.kt
+++ b/.teamcity/Templates/PipPythonTemplate.kt
@@ -2,6 +2,8 @@ package Templates
 
 import jetbrains.buildServer.configs.kotlin.DslContext
 import jetbrains.buildServer.configs.kotlin.Template
+import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerSupport
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.matrix
 
@@ -25,15 +27,18 @@ object PipPythonTemplate : Template({
                     pixi run --environment %python_env% --frozen test_import
                 """.trimIndent()
             formatStderrAsError = true
+            dockerImage = "containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.26.1"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerPull = true
         }
     }
 
-    requirements {
-        equals("env.OS", "Windows_NT")
-        doesNotExist("container.engine")
-    }
-
     features {
+        dockerSupport {
+            loginToRegistry = on {
+                dockerRegistryId = "PROJECT_EXT_134"
+            }
+        }
         matrix {
             param(
                 "python_env", listOf(

--- a/.teamcity/Templates/UnitTestsTemplate.kt
+++ b/.teamcity/Templates/UnitTestsTemplate.kt
@@ -30,7 +30,7 @@ object UnitTestsTemplate : Template({
             id = "Run_unittests"
             workingDir = "imod-python"
             scriptContent = """
-                set Path=%system.teamcity.build.checkoutDir%\modflow6;%env.Path% 
+                SET PATH=%%PATH%%;%system.teamcity.build.checkoutDir%\modflow6
                 pixi run --environment default --frozen unittests
             """.trimIndent()
             formatStderrAsError = true

--- a/.teamcity/Templates/UnitTestsTemplate.kt
+++ b/.teamcity/Templates/UnitTestsTemplate.kt
@@ -30,10 +30,7 @@ object UnitTestsTemplate : Template({
             id = "Run_unittests"
             workingDir = "imod-python"
             scriptContent = """
-                 # Add modflow to the PATH
                 set Path=%system.teamcity.build.checkoutDir%\modflow6;%env.Path% 
-                               
-                # Run unittests
                 pixi run --environment default --frozen unittests
             """.trimIndent()
             formatStderrAsError = true

--- a/.teamcity/Templates/UnitTestsTemplate.kt
+++ b/.teamcity/Templates/UnitTestsTemplate.kt
@@ -36,6 +36,7 @@ object UnitTestsTemplate : Template({
             formatStderrAsError = true
             dockerImage = "containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.26.1"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus="4""""
             dockerPull = true
         }
         powerShell {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ strict = true
 
 # These shouldn't be too much additional work, but may be tricky to
 # get passing if you use a lot of untyped libraries
-disallow_any_generics = true
+disallow_any_generics = false
 
 # These next few are various gradations of forcing use of type annotations
 disallow_untyped_calls = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ strict = true
 
 # These shouldn't be too much additional work, but may be tricky to
 # get passing if you use a lot of untyped libraries
-disallow_any_generics = false
+disallow_any_generics = true
 
 # These next few are various gradations of forcing use of type annotations
 disallow_untyped_calls = false


### PR DESCRIPTION
Fixes #1190 

# Description
The TeamCity buildserver has some quirks making it sometimes hard to reproduce failing tests/build steps locally.
In this PR this issue addressed by running the pipeline scripts in docker containers. 
These docker containers can be run locally as well, making it possible for the developer to reproduce the failing build on their own machine.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
