### PR TITLE
Issue #1196 Make it possible to pin the pipeline to a MODFLOW version

### DIFF
--- a/.teamcity/_Self/MainProject.kt
+++ b/.teamcity/_Self/MainProject.kt
@@ -88,12 +88,17 @@ object MyPy : BuildType({
 object UnitTests : BuildType({
     name = "UnitTests"
 
+    params {
+        param("reverse.dep.Modflow_Modflow6Release.MODFLOW6_Version", "6.5.0")
+        param("reverse.dep.Modflow_Modflow6Release.MODFLOW6_Platform", "win64")
+    }
     templates(UnitTestsTemplate, GitHubIntegrationTemplate)
 
     dependencies {
-        dependency(AbsoluteId("MetaSWAP_Modflow_Modflow6Release642")) {
+        dependency(AbsoluteId("Modflow_Modflow6Release")) {
             snapshot {
                 onDependencyFailure = FailureAction.FAIL_TO_START
+
             }
 
             artifacts {
@@ -112,10 +117,15 @@ object UnitTests : BuildType({
 object Examples : BuildType({
     name = "Examples"
 
+    params {
+        param("reverse.dep.Modflow_Modflow6Release.MODFLOW6_Version", "6.5.0")
+        param("reverse.dep.Modflow_Modflow6Release.MODFLOW6_Platform", "win64")
+    }
+
     templates(ExamplesTemplate, GitHubIntegrationTemplate)
 
     dependencies {
-        dependency(AbsoluteId("MetaSWAP_Modflow_Modflow6Release642")) {
+        dependency(AbsoluteId("Modflow_Modflow6Release")) {
             snapshot {
                 onDependencyFailure = FailureAction.FAIL_TO_START
             }


### PR DESCRIPTION
Fixes #1196

# Description
This PR makes it possible to pin our main pipeline to a specific MODFLOW version.
It has been pinned to version 6.5.0

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
