### PR TITLE
Issue #1199 Fix the PR body text

### DIFF
--- a/.teamcity/Pixi/PixiProject.kt
+++ b/.teamcity/Pixi/PixiProject.kt
@@ -48,9 +48,12 @@ object UpdateDependencies : BuildType({
                       git commit -m "Update pixi.lock"
                       git push -u origin pixi_update_%build.counter%
 
-                      echo Teamcity automatically updated the dependencies defined the pixi.toml file. Please verify that all tests succeed before merging. > body.md
-                      echo. >> body.md
-                      type diff.md >> body.md
+                      echo "Format PR body"
+                      $diff = Get-Content -Path diff.md
+                      Set-Content body.md 'Teamcity automatically updated the dependencies defined the pixi.toml file. Please verify that all tests succeed before merging'
+                      Add-Content -Path body.md -Value "`r`n"
+                      Add-Content -Path body.md -Value $diff
+
                       pixi run --environment default gh pr create --title "[TEAMCITY] Update project dependencies" --body-file body.md --reviewer JoerivanEngelen,Manangka
                       echo "Changes pushed and PR created"
                     }

--- a/.teamcity/Pixi/PixiProject.kt
+++ b/.teamcity/Pixi/PixiProject.kt
@@ -49,10 +49,10 @@ object UpdateDependencies : BuildType({
                       git push -u origin pixi_update_%build.counter%
 
                       echo "Format PR body"
-                      $diff = Get-Content -Path diff.md
+                      ${'$'}diff = Get-Content -Path diff.md
                       Set-Content body.md 'Teamcity automatically updated the dependencies defined the pixi.toml file. Please verify that all tests succeed before merging'
                       Add-Content -Path body.md -Value "`r`n"
-                      Add-Content -Path body.md -Value $diff
+                      Add-Content -Path body.md -Value ${'$'}diff
 
                       pixi run --environment default gh pr create --title "[TEAMCITY] Update project dependencies" --body-file body.md --reviewer JoerivanEngelen,Manangka
                       echo "Changes pushed and PR created"


### PR DESCRIPTION
Fixes #1199

# Description
The message body generated for the pixi update PR is written for Bat files. However the pixi build step is making use of Powershell. This PR converts the body generation to powershell script.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
