### PR TITLE
#1204 Increase used memory size of all buildsteps

### DIFF
--- a/.teamcity/Templates/ExamplesTemplate.kt
+++ b/.teamcity/Templates/ExamplesTemplate.kt
@@ -33,7 +33,7 @@ object ExamplesTemplate : Template({
             formatStderrAsError = true
             dockerImage = "containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.26.1"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
-            dockerRunParameters = """--cpus="4""""
+            dockerRunParameters = """--cpus=8 --memory=32g"""
             dockerPull = true
         }
     }

--- a/.teamcity/Templates/LintTemplate.kt
+++ b/.teamcity/Templates/LintTemplate.kt
@@ -28,6 +28,7 @@ object LintTemplate : Template({
             formatStderrAsError = true
             dockerImage = "containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.26.1"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
             dockerPull = true
         }
     }

--- a/.teamcity/Templates/MyPyTemplate.kt
+++ b/.teamcity/Templates/MyPyTemplate.kt
@@ -33,6 +33,7 @@ object MyPyTemplate : Template({
             formatStderrAsError = true
             dockerImage = "containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.26.1"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
             dockerPull = true
         }
     }

--- a/.teamcity/Templates/PipPythonTemplate.kt
+++ b/.teamcity/Templates/PipPythonTemplate.kt
@@ -29,6 +29,7 @@ object PipPythonTemplate : Template({
             formatStderrAsError = true
             dockerImage = "containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.26.1"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=4 --memory=16g"""
             dockerPull = true
         }
     }

--- a/.teamcity/Templates/UnitTestsTemplate.kt
+++ b/.teamcity/Templates/UnitTestsTemplate.kt
@@ -36,7 +36,7 @@ object UnitTestsTemplate : Template({
             formatStderrAsError = true
             dockerImage = "containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.26.1"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
-            dockerRunParameters = """--cpus="4""""
+            dockerRunParameters = """--cpus=8 --memory=32g"""
             dockerPull = true
         }
         powerShell {


### PR DESCRIPTION
Fixes #1204

# Description
Since a week of 2 we noticed that our build pipeline was getting unstable.

We tried to remedy this with moving our builds to docker containers
This gave us control of what is being installed on the systems that are running our pipelines.
However we noticed that some unittests/examples were still failing.

@JoerivanEngelen found out that the cause of the failing tests is memory related.
After a quick check I discovered that the docker container have a default memory size of 1G which is just not enough.

This PR addresses that. All pipeline steps now have at least 16G. The unit tests and example pipelines have 32G.
I further also increased the number of cores available the build steps. All pipelines have at least 4 cores. The unit tests and example pipelines have 8.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
