### PR TITLE
Issue #1216 iMOD5 convert RCH unit

### DIFF
--- a/imod/mf6/rch.py
+++ b/imod/mf6/rch.py
@@ -8,6 +8,7 @@ from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.regrid.regrid_schemes import RechargeRegridMethod
+from imod.mf6.utilities.imod5_converter import convert_unit_rch_rate
 from imod.mf6.utilities.regrid import RegridderWeightsCache, _regrid_package_data
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA, CONC_DIMS_SCHEMA
 from imod.prepare.topsystem.allocation import ALLOCATION_OPTION, allocate_rch_cells
@@ -193,7 +194,7 @@ class Recharge(BoundaryCondition, IRegridPackage):
         """
         new_idomain = dis_pkg.dataset["idomain"]
         data = {
-            "rate": imod5_data["rch"]["rate"],
+            "rate": convert_unit_rch_rate(imod5_data["rch"]["rate"]),
         }
         new_package_data = {}
 

--- a/imod/mf6/utilities/imod5_converter.py
+++ b/imod/mf6/utilities/imod5_converter.py
@@ -29,12 +29,12 @@ def convert_ibound_to_idomain(
     # Fill the remaining nans at tops and bottoms with 0
     return idomain_float.fillna(0).astype(int)
 
-def convert_unit_rch_rate(
-        rate: xr.DataArray
-    ) -> xr.DataArray:
+
+def convert_unit_rch_rate(rate: xr.DataArray) -> xr.DataArray:
     """Convert recharge from iMOD5's mm/d to m/d"""
     mm_to_m_conversion = 1e-3
     return rate * mm_to_m_conversion
+
 
 def fill_missing_layers(
     source: xr.DataArray, full: xr.DataArray, fillvalue: Union[float | int]

--- a/imod/mf6/utilities/imod5_converter.py
+++ b/imod/mf6/utilities/imod5_converter.py
@@ -29,6 +29,12 @@ def convert_ibound_to_idomain(
     # Fill the remaining nans at tops and bottoms with 0
     return idomain_float.fillna(0).astype(int)
 
+def convert_unit_rch_rate(
+        rate: xr.DataArray
+    ) -> xr.DataArray:
+    """Convert recharge from iMOD5's mm/d to m/d"""
+    mm_to_m_conversion = 1e-3
+    return rate * mm_to_m_conversion
 
 def fill_missing_layers(
     source: xr.DataArray, full: xr.DataArray, fillvalue: Union[float | int]

--- a/imod/tests/test_mf6/test_mf6_rch.py
+++ b/imod/tests/test_mf6/test_mf6_rch.py
@@ -345,9 +345,9 @@ def test_planar_rch_from_imod5_constant(imod5_dataset, tmp_path):
 
     # Assert
     np.testing.assert_allclose(
-        data["rch"]["rate"].mean().values / 1e3, 
+        data["rch"]["rate"].mean().values / 1e3,
         rch.dataset["rate"].mean().values,
-        atol=1e-5
+        atol=1e-5,
     )
     assert "maxbound 33856" in rendered_rch
     assert rendered_rch.count("begin period") == 1
@@ -378,9 +378,9 @@ def test_planar_rch_from_imod5_transient(imod5_dataset, tmp_path):
 
     # assert
     np.testing.assert_allclose(
-        data["rch"]["rate"].mean().values / 1e3, 
+        data["rch"]["rate"].mean().values / 1e3,
         rch.dataset["rate"].mean().values,
-        atol=1e-5
+        atol=1e-5,
     )
     assert rendered_rch.count("begin period") == 3
     assert "maxbound 33856" in rendered_rch
@@ -413,9 +413,9 @@ def test_non_planar_rch_from_imod5_constant(imod5_dataset, tmp_path):
 
     # assert
     np.testing.assert_allclose(
-        data["rch"]["rate"].mean().values / 1e3, 
+        data["rch"]["rate"].mean().values / 1e3,
         rch.dataset["rate"].mean().values,
-        atol=1e-5
+        atol=1e-5,
     )
     assert rendered_rch.count("begin period") == 1
     assert "maxbound 33856" in rendered_rch
@@ -449,9 +449,9 @@ def test_non_planar_rch_from_imod5_transient(imod5_dataset, tmp_path):
 
     # assert
     np.testing.assert_allclose(
-        data["rch"]["rate"].mean().values / 1e3, 
+        data["rch"]["rate"].mean().values / 1e3,
         rch.dataset["rate"].mean().values,
-        atol=1e-5
+        atol=1e-5,
     )
     assert rendered_rch.count("begin period") == 3
     assert "maxbound 33856" in rendered_rch

--- a/imod/tests/test_mf6/test_mf6_rch.py
+++ b/imod/tests/test_mf6/test_mf6_rch.py
@@ -341,9 +341,14 @@ def test_planar_rch_from_imod5_constant(imod5_dataset, tmp_path):
 
     # Act
     rch = imod.mf6.Recharge.from_imod5_data(data, target_discretization)
+    rendered_rch = rch.render(tmp_path, "rch", None, None)
 
     # Assert
-    rendered_rch = rch.render(tmp_path, "rch", None, None)
+    np.testing.assert_allclose(
+        data["rch"]["rate"].mean().values / 1e3, 
+        rch.dataset["rate"].mean().values,
+        atol=1e-5
+    )
     assert "maxbound 33856" in rendered_rch
     assert rendered_rch.count("begin period") == 1
     # teardown
@@ -369,9 +374,14 @@ def test_planar_rch_from_imod5_transient(imod5_dataset, tmp_path):
 
     # act
     rch = imod.mf6.Recharge.from_imod5_data(data, target_discretization)
+    rendered_rch = rch.render(tmp_path, "rch", [0, 1, 2], None)
 
     # assert
-    rendered_rch = rch.render(tmp_path, "rch", [0, 1, 2], None)
+    np.testing.assert_allclose(
+        data["rch"]["rate"].mean().values / 1e3, 
+        rch.dataset["rate"].mean().values,
+        atol=1e-5
+    )
     assert rendered_rch.count("begin period") == 3
     assert "maxbound 33856" in rendered_rch
 
@@ -399,9 +409,14 @@ def test_non_planar_rch_from_imod5_constant(imod5_dataset, tmp_path):
 
     # act
     rch = imod.mf6.Recharge.from_imod5_data(data, target_discretization)
+    rendered_rch = rch.render(tmp_path, "rch", None, None)
 
     # assert
-    rendered_rch = rch.render(tmp_path, "rch", None, None)
+    np.testing.assert_allclose(
+        data["rch"]["rate"].mean().values / 1e3, 
+        rch.dataset["rate"].mean().values,
+        atol=1e-5
+    )
     assert rendered_rch.count("begin period") == 1
     assert "maxbound 33856" in rendered_rch
 
@@ -430,8 +445,13 @@ def test_non_planar_rch_from_imod5_transient(imod5_dataset, tmp_path):
 
     # act
     rch = imod.mf6.Recharge.from_imod5_data(data, target_discretization)
+    rendered_rch = rch.render(tmp_path, "rch", [0, 1, 2], None)
 
     # assert
-    rendered_rch = rch.render(tmp_path, "rch", [0, 1, 2], None)
+    np.testing.assert_allclose(
+        data["rch"]["rate"].mean().values / 1e3, 
+        rch.dataset["rate"].mean().values,
+        atol=1e-5
+    )
     assert rendered_rch.count("begin period") == 3
     assert "maxbound 33856" in rendered_rch


### PR DESCRIPTION
Fixes #1216 

# Description
iMOD5 interprets recharge rate in mm/d, whereas MODFLOW6 is unit consistent, and thus uses m/d. 
This PR adds a conversion function to do that. I updated the tests to also test if this conversion is done.

# Checklist
- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
