### PR TITLE
Issue #1224 Fix the Deploy pipelines

### DIFF
--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -63,6 +63,12 @@ object BuildPackage : BuildType({
 object BuildPages : BuildType({
     name = "Build Pages"
 
+    params {
+        param("env.TEMP", "%system.teamcity.build.checkoutDir%\tmpdir")
+        param("env.TMPDIR", "%system.teamcity.build.checkoutDir%\tmpdir")
+        param("env.TMP", "%system.teamcity.build.checkoutDir%\tmpdir")
+    }
+
     artifactRules = """imod-python\docs\_build\html => documentation.zip"""
 
     vcs {
@@ -273,6 +279,10 @@ object DeployPages : BuildType({
             workingDir = "imod-python"
             scriptContent = """
                 echo on
+                echo "Setup git"
+                git config --global user.email "%env.USERNAME%@%env.USERDNSDOMAIN%"
+                git config --global user.name "%env.USERNAME%"
+
                 echo "Checkout imod-python-pages"
                 git remote set-url origin https://%GH_USER%:%env.GH_TOKEN%@github.com/Deltares/imod-python.git
                 git fetch origin gh-pages


### PR DESCRIPTION
Fixes #1224 

# Description
After making the switch to docker build containers some issues popped up in the deploy pipeline:
- There is an permission issue when writing to the temp directory. Symlinks cant be created. This has been resolved by changing the temp directory to a folder inside the docker container
- Pushing the documentation failed because the git name and email weren't set

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
