### PR TITLE
Issue #1222 validation context

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -48,7 +48,7 @@ Changed
 - :meth:`imod.mf6.Well.to_mf6_pkg` got a new argument:
   ``strict_well_validation``, which controls the behavior for when wells are
   removed entirely during their assignment to layers. This replaces the
-  ``is_partioned`` argument.
+  ``is_partitioned`` argument.
 
 Added
 ~~~~~

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -46,12 +46,9 @@ Changed
   when elevations are above model top for all methods in
   :func:`imod.prepare.ALLOCATION_OPTION`.
 - :meth:`imod.mf6.Well.to_mf6_pkg` got a new argument:
-  ``error_on_well_removal``, which controls the behavior for when wells are
+  ``strict_well_validation``, which controls the behavior for when wells are
   removed entirely during their assignment to layers. This replaces the
-  ``is_partioned`` argument. Note: if ``is_partioned`` was set to True before,
-  this means you need to set ``error_on_removal`` to False now to get the same
-  behavior.
-
+  ``is_partioned`` argument.
 
 Added
 ~~~~~

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -27,6 +27,7 @@ from imod.mf6.utilities.mask import _mask_all_packages
 from imod.mf6.utilities.mf6hfb import merge_hfb_packages
 from imod.mf6.utilities.regrid import RegridderWeightsCache, _regrid_like
 from imod.mf6.validation import pkg_errors_to_status_info
+from imod.mf6.validation_context import ValidationContext
 from imod.mf6.wel import GridAgnosticWell
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
@@ -240,7 +241,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
 
     @standard_log_decorator()
     def write(
-        self, modelname, globaltimes, validate: bool, write_context: WriteContext
+        self, modelname, globaltimes, write_context: WriteContext, validate_context: ValidationContext,
     ) -> StatusInfoBase:
         """
         Write model namefile
@@ -250,7 +251,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         workdir = write_context.simulation_directory
         modeldirectory = workdir / modelname
         Path(modeldirectory).mkdir(exist_ok=True, parents=True)
-        if validate:
+        if validate_context.validate:
             model_status_info = self.validate(modelname)
             if model_status_info.has_errors():
                 return model_status_info
@@ -271,16 +272,12 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
                 if issubclass(type(pkg), GridAgnosticWell):
                     top, bottom, idomain = self.__get_domain_geometry()
                     k = self.__get_k()
-                    error_on_well_removal = (not pkg_write_context.is_partitioned) & (
-                        not pkg_write_context.is_from_imod5
-                    )
                     mf6_well_pkg = pkg.to_mf6_pkg(
                         idomain,
                         top,
                         bottom,
                         k,
-                        validate,
-                        error_on_well_removal,
+                        validate_context,
                     )
                     mf6_well_pkg.write(
                         pkgname=pkg_name,

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -276,7 +276,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
                 if issubclass(type(pkg), GridAgnosticWell):
                     top, bottom, idomain = self.__get_domain_geometry()
                     k = self.__get_k()
-                    mf6_well_pkg = pkg.to_mf6_pkg(
+                    mf6_well_pkg = pkg._to_mf6_pkg(
                         idomain,
                         top,
                         bottom,

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -241,7 +241,11 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
 
     @standard_log_decorator()
     def write(
-        self, modelname, globaltimes, write_context: WriteContext, validate_context: ValidationContext,
+        self,
+        modelname,
+        globaltimes,
+        write_context: WriteContext,
+        validate_context: ValidationContext,
     ) -> StatusInfoBase:
         """
         Write model namefile

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -43,6 +43,7 @@ from imod.mf6.ssm import SourceSinkMixing
 from imod.mf6.statusinfo import NestedStatusInfo
 from imod.mf6.utilities.mask import _mask_all_models
 from imod.mf6.utilities.regrid import _regrid_like
+from imod.mf6.validation_context import ValidationContext
 from imod.mf6.write_context import WriteContext
 from imod.prepare.topsystem.default_allocation_methods import (
     SimulationAllocationOptions,
@@ -253,8 +254,9 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         """
         # create write context
         write_context = WriteContext(directory, binary, use_absolute_paths)
+        validation_context = ValidationContext(validate)
         if self.is_split():
-            write_context.is_partitioned = True
+            validation_context.relax_well_validation = True
 
         # Check models for required content
         for key, model in self.items():

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -98,7 +98,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         self.name = name
         self.directory = None
         self._initialize_template()
-        self._is_from_imod5 = False
+        self._validation_context = ValidationContext()
 
     def __setitem__(self, key, value):
         super().__setitem__(key, value)
@@ -255,11 +255,9 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         """
         # create write context
         write_context = WriteContext(directory, binary, use_absolute_paths)
-        validation_context = ValidationContext(validate)
+        self._validation_context.validate = validate
         if self.is_split():
-            validation_context.relax_well_validation = True
-        if self._is_from_imod5:
-            write_context.is_from_imod5 = True
+            self._validation_context.strict_well_validation = False
 
         # Check models for required content
         for key, model in self.items():
@@ -301,8 +299,8 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
                     value.write(
                         modelname=key,
                         globaltimes=globaltimes,
-                        validate=validate,
                         write_context=model_write_context,
+                        validate_context=self._validation_context,
                     )
                 )
             elif isinstance(value, Package):
@@ -1369,7 +1367,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         -------
         """
         simulation = Modflow6Simulation("imported_simulation")
-        simulation._is_from_imod5 = True
+        simulation._validation_context.strict_well_validation = False
 
         # import GWF model,
         groundwaterFlowModel = GroundwaterFlowModel.from_imod5_data(

--- a/imod/mf6/validation_context.py
+++ b/imod/mf6/validation_context.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ValidationContext:
+    validate: bool = True
+    relax_well_validation: bool = False
+    

--- a/imod/mf6/validation_context.py
+++ b/imod/mf6/validation_context.py
@@ -4,5 +4,4 @@ from dataclasses import dataclass
 @dataclass
 class ValidationContext:
     validate: bool = True
-    relax_well_validation: bool = False
-    
+    strict_well_validation: bool = True

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -418,7 +418,7 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
             Grid with hydraulic conductivities.
         validate: bool, default True
             Run validation before converting
-        strict_well_validation: bool, default False
+        strict_well_validation: bool, default True
             Set well validation strict:
             Throw error if well is removed entirely during its assignment to
             layers.

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -428,7 +428,9 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
         Mf6Wel
             Object with wells as list based input.
         """
-        validation_context = ValidationContext(validate=validate, strict_well_validation=strict_well_validation)
+        validation_context = ValidationContext(
+            validate=validate, strict_well_validation=strict_well_validation
+        )
         return self._to_mf6_pkg(active, top, bottom, k, validation_context)
 
     def _to_mf6_pkg(
@@ -439,7 +441,6 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
         k: GridDataArray,
         validation_context: ValidationContext,
     ) -> Mf6Wel:
-
         if validation_context.validate:
             errors = self._validate(self._write_schemata)
             if len(errors) > 0:

--- a/imod/mf6/write_context.py
+++ b/imod/mf6/write_context.py
@@ -28,7 +28,7 @@ class WriteContext:
          it will be set to the simulation_directrory.
     """
 
-    simulation_directory: Path = Path("."),
+    simulation_directory: Path = Path(".")
     use_binary: bool = False
     use_absolute_paths: bool = False
     write_directory: Optional[Union[str, Path]] = None

--- a/imod/mf6/write_context.py
+++ b/imod/mf6/write_context.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from os.path import relpath
 from pathlib import Path
-from typing import Optional, Union
 
 
 @dataclass

--- a/imod/mf6/write_context.py
+++ b/imod/mf6/write_context.py
@@ -31,7 +31,7 @@ class WriteContext:
     simulation_directory: Path = Path(".")
     use_binary: bool = False
     use_absolute_paths: bool = False
-    write_directory: Optional[Union[str, Path]] = None
+    write_directory: Path = None  # type: ignore
 
     def __post_init__(self):
         self.simulation_directory = Path(self.simulation_directory)

--- a/imod/mf6/write_context.py
+++ b/imod/mf6/write_context.py
@@ -28,23 +28,18 @@ class WriteContext:
          it will be set to the simulation_directrory.
     """
 
-    def __init__(
-        self,
-        simulation_directory: Path = Path("."),
-        use_binary: bool = False,
-        use_absolute_paths: bool = False,
-        write_directory: Optional[Union[str, Path]] = None,
-    ):
-        self.__simulation_directory = Path(simulation_directory)
-        self.__use_binary = use_binary
-        self.__use_absolute_paths = use_absolute_paths
-        self.__write_directory = (
-            Path(write_directory)
-            if write_directory is not None
-            else self.__simulation_directory
+    simulation_directory: Path = Path("."),
+    use_binary: bool = False
+    use_absolute_paths: bool = False
+    write_directory: Optional[Union[str, Path]] = None
+
+    def __post_init__(self):
+        self.simulation_directory = Path(self.simulation_directory)
+        self.write_directory = (
+            Path(self.write_directory)
+            if self.write_directory is not None
+            else self.simulation_directory
         )
-        self.__is_partitioned = False
-        self.__is_from_imod5 = False
 
     def get_formatted_write_directory(self) -> Path:
         """
@@ -53,33 +48,13 @@ class WriteContext:
         be relative to the simulation directory, which makes it usable by MF6.
         """
         if self.use_absolute_paths:
-            return self.__write_directory
-        return Path(relpath(self.write_directory, self.__simulation_directory))
+            return self.write_directory
+        return Path(relpath(self.write_directory, self.simulation_directory))
 
     def copy_with_new_write_directory(self, new_write_directory: Path) -> WriteContext:
         new_context = deepcopy(self)
-        new_context.__write_directory = Path(new_write_directory)
+        new_context.write_directory = Path(new_write_directory)
         return new_context
-
-    @property
-    def simulation_directory(self) -> Path:
-        return self.__simulation_directory
-
-    @property
-    def use_binary(self) -> bool:
-        return self.__use_binary
-
-    @use_binary.setter
-    def use_binary(self, value) -> None:
-        self.__use_binary = value
-
-    @property
-    def use_absolute_paths(self) -> bool:
-        return self.__use_absolute_paths
-
-    @property
-    def write_directory(self) -> Path:
-        return self.__write_directory
 
     @property
     def root_directory(self) -> Path:
@@ -88,22 +63,6 @@ class WriteContext:
         that are in agreement with the use_absolute_paths setting.
         """
         if self.use_absolute_paths:
-            return self.__simulation_directory
+            return self.simulation_directory
         else:
             return Path("")
-
-    @property
-    def is_partitioned(self) -> bool:
-        return self.__is_partitioned
-
-    @is_partitioned.setter
-    def is_partitioned(self, value: bool) -> None:
-        self.__is_partitioned = value
-
-    @property
-    def is_from_imod5(self) -> bool:
-        return self.__is_from_imod5
-
-    @is_from_imod5.setter
-    def is_from_imod5(self, value: bool) -> None:
-        self.__is_from_imod5 = value

--- a/imod/tests/test_mf6/test_circle.py
+++ b/imod/tests/test_mf6/test_circle.py
@@ -9,6 +9,7 @@ import xugrid as xu
 
 import imod
 from imod.logging import LoggerType, LogLevel
+from imod.mf6.validation_context import ValidationContext
 from imod.mf6.write_context import WriteContext
 
 
@@ -57,8 +58,8 @@ def test_gwfmodel_render(circle_model, tmp_path):
     simulation = circle_model
     globaltimes = simulation["time_discretization"]["time"].values
     gwfmodel = simulation["GWF_1"]
-    write_context = WriteContext()
-    actual = gwfmodel.render("GWF_1", write_context)
+    write_context1 = WriteContext()
+    actual = gwfmodel.render("GWF_1", write_context1)
     path = "GWF_1"
     expected = textwrap.dedent(
         f"""\
@@ -77,8 +78,9 @@ def test_gwfmodel_render(circle_model, tmp_path):
             """
     )
     assert actual == expected
-    context = WriteContext(tmp_path)
-    gwfmodel.write("GWF_1", globaltimes, True, context)
+    validation_context = ValidationContext(True)
+    write_context2 = WriteContext(tmp_path)
+    gwfmodel.write("GWF_1", globaltimes, write_context2, validation_context)
     assert (tmp_path / "GWF_1" / "GWF_1.nam").is_file()
     assert (tmp_path / "GWF_1").is_dir()
 
@@ -110,8 +112,8 @@ def test_gwfmodel_render_evt(circle_model_evt, tmp_path):
     simulation = circle_model_evt
     globaltimes = simulation["time_discretization"]["time"].values
     gwfmodel = simulation["GWF_1"]
-    write_context = WriteContext()
-    actual = gwfmodel.render("GWF_1", write_context)
+    write_context1 = WriteContext()
+    actual = gwfmodel.render("GWF_1", write_context1)
     path = "GWF_1"
     expected = textwrap.dedent(
         f"""\
@@ -131,7 +133,8 @@ def test_gwfmodel_render_evt(circle_model_evt, tmp_path):
             """
     )
     assert actual == expected
-    context = WriteContext(tmp_path)
-    gwfmodel.write("GWF_1", globaltimes, True, context)
+    validation_context = ValidationContext(True)
+    write_context2 = WriteContext(tmp_path)
+    gwfmodel.write("GWF_1", globaltimes, write_context2, validation_context)
     assert (tmp_path / "GWF_1" / "GWF_1.nam").is_file()
     assert (tmp_path / "GWF_1").is_dir()

--- a/imod/tests/test_mf6/test_ex01_twri.py
+++ b/imod/tests/test_mf6/test_ex01_twri.py
@@ -8,6 +8,7 @@ import pytest
 import xarray as xr
 
 import imod
+from imod.mf6.validation_context import ValidationContext
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.typing.grid import ones_like
@@ -351,6 +352,7 @@ def test_gwfmodel_render(twri_model, tmp_path):
     globaltimes = simulation["time_discretization"]["time"].values
     gwfmodel = simulation["GWF_1"]
     path = Path(tmp_path.stem).as_posix()
+    validation_context = ValidationContext(tmp_path)
     write_context = WriteContext(tmp_path)
     actual = gwfmodel.render(path, write_context)
     expected = textwrap.dedent(
@@ -373,7 +375,7 @@ def test_gwfmodel_render(twri_model, tmp_path):
             """
     )
     assert actual == expected
-    gwfmodel.write("GWF_1", globaltimes, True, write_context)
+    gwfmodel.write("GWF_1", globaltimes, write_context, validation_context)
     assert (tmp_path / "GWF_1" / "GWF_1.nam").is_file()
     assert (tmp_path / "GWF_1").is_dir()
 

--- a/imod/tests/test_mf6/test_mf6_logging.py
+++ b/imod/tests/test_mf6/test_mf6_logging.py
@@ -10,6 +10,7 @@ import xarray as xr
 
 import imod
 from imod.logging import LoggerType, LogLevel, standard_log_decorator
+from imod.mf6.validation_context import ValidationContext
 from imod.mf6.write_context import WriteContext
 
 out = StringIO()
@@ -80,6 +81,7 @@ def test_write_model_is_logged(
     # arrange
     logfile_path = tmp_path / "logfile.txt"
     transport_model = flow_transport_simulation["tpt_c"]
+    validation_context = ValidationContext()
     write_context = WriteContext(simulation_directory=tmp_path, use_binary=True)
     globaltimes = np.array(
         [
@@ -95,7 +97,9 @@ def test_write_model_is_logged(
             add_default_file_handler=False,
             add_default_stream_handler=True,
         )
-        transport_model.write("model.txt", globaltimes, True, write_context)
+        transport_model.write(
+            "model.txt", globaltimes, write_context, validation_context
+        )
 
     # assert
     with open(logfile_path, "r") as log_file:

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -16,6 +16,7 @@ from imod.mf6 import ConstantHead
 from imod.mf6.model import Modflow6Model
 from imod.mf6.model_gwf import GroundwaterFlowModel
 from imod.mf6.package import Package
+from imod.mf6.validation_context import ValidationContext
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 
@@ -105,6 +106,7 @@ class TestModel:
         model_name = "Test model"
         model = Modflow6Model()
         # create write context
+        validation_context = ValidationContext()
         write_context = WriteContext(tmp_path)
 
         discretization_mock = MagicMock(spec_set=Package)
@@ -119,7 +121,9 @@ class TestModel:
         global_times_mock = MagicMock(spec_set=imod.mf6.TimeDiscretization)
 
         # Act.
-        status = model.write(model_name, global_times_mock, True, write_context)
+        status = model.write(
+            model_name, global_times_mock, write_context, validation_context
+        )
 
         # Assert.
         assert not status.has_errors()
@@ -130,6 +134,7 @@ class TestModel:
         model_name = "Test model"
         model = Modflow6Model()
         # create write context
+        validation_context = ValidationContext()
         write_context = WriteContext(tmp_path)
 
         template_mock = MagicMock(spec_set=Template)
@@ -139,7 +144,9 @@ class TestModel:
         global_times_mock = MagicMock(spec_set=imod.mf6.TimeDiscretization)
 
         # Act.
-        status = model.write(model_name, global_times_mock, True, write_context)
+        status = model.write(
+            model_name, global_times_mock, write_context, validation_context
+        )
 
         # Assert.
         assert status.has_errors()
@@ -150,6 +157,7 @@ class TestModel:
         model_name = "Test model"
         model = Modflow6Model()
         # create write context
+        validation_context = ValidationContext()
         write_context = WriteContext(tmp_path)
 
         discretization_mock = MagicMock(spec_set=Package)
@@ -168,7 +176,7 @@ class TestModel:
 
         # Act.
         status = model.write(
-            model_name, global_times_mock, True, write_context=write_context
+            model_name, global_times_mock, write_context, validation_context
         )
 
         # Assert.
@@ -178,6 +186,7 @@ class TestModel:
         # Arrange.
         tmp_path = tmpdir_factory.mktemp("TestSimulation")
         model_name = "Test model"
+        validation_context = ValidationContext()
         write_context = WriteContext(simulation_directory=tmp_path)
 
         model = Modflow6Model()
@@ -205,7 +214,9 @@ class TestModel:
 
         # Act.
         write_context = WriteContext(tmp_path)
-        status = model.write(model_name, global_times_mock, True, write_context)
+        status = model.write(
+            model_name, global_times_mock, write_context, validation_context
+        )
 
         # Assert.
         assert len(status.errors) == 2

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -532,9 +532,7 @@ def test_from_imod5__strict_well_validation_set(imod5_dataset):
         datelist,
     )
     assert simulation._validation_context.strict_well_validation is False
-    assert (
-        Modflow6Simulation("test")._validation_context.strict_well_validation is True
-    )
+    assert Modflow6Simulation("test")._validation_context.strict_well_validation is True
 
 
 @pytest.mark.unittest_jit

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -511,12 +511,12 @@ def test_import_from_imod5(imod5_dataset, tmp_path):
     simulation.write(tmp_path, binary=False, validate=True)
 
     # Test if simulation attribute appropiately set
-    assert simulation._is_from_imod5 is True
+    assert simulation._validation_context.strict_well_validation is False
 
 
 @pytest.mark.unittest_jit
 @pytest.mark.usefixtures("imod5_dataset")
-def test_is_from_imod5_attribute(imod5_dataset):
+def test_from_imod5__strict_well_validation_set(imod5_dataset):
     imod5_data = imod5_dataset[0]
     period_data = imod5_dataset[1]
     default_simulation_allocation_options = SimulationAllocationOptions
@@ -531,8 +531,10 @@ def test_is_from_imod5_attribute(imod5_dataset):
         default_simulation_distributing_options,
         datelist,
     )
-    assert simulation._is_from_imod5 is True
-    assert Modflow6Simulation("test")._is_from_imod5 is False
+    assert simulation._validation_context.strict_well_validation is False
+    assert (
+        Modflow6Simulation("test")._validation_context.strict_well_validation is True
+    )
 
 
 @pytest.mark.unittest_jit

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -383,9 +383,9 @@ def test_to_mf6_pkg__error_on_well_removal(
     k.loc[{"x": 85.0}] = 1e-3
 
     with pytest.raises(ValidationError, match="x = 81"):
-        wel.to_mf6_pkg(active, top, bottom, k, error_on_well_removal=True)
+        wel.to_mf6_pkg(active, top, bottom, k, strict_well_validation=True)
 
-    mf6_wel = wel.to_mf6_pkg(active, top, bottom, k, error_on_well_removal=False)
+    mf6_wel = wel.to_mf6_pkg(active, top, bottom, k, strict_well_validation=False)
     assert mf6_wel.dataset.sizes["ncellid"] < wel.dataset.sizes["index"]
 
 

--- a/imod/tests/test_mf6/test_well_highlvl.py
+++ b/imod/tests/test_mf6/test_well_highlvl.py
@@ -84,7 +84,7 @@ def test_write_well(tmp_path: Path, grid_data, grid_data_layered, reference_outp
     validation_context = ValidationContext(False)
     write_context = WriteContext(tmp_path)
     mf6_pkg = well._to_mf6_pkg(
-        active, top, bottom, k, write_context, validation_context
+        active, top, bottom, k, validation_context
     )
     mf6_pkg.write("packagename", globaltimes, write_context)
     assert pathlib.Path.exists(tmp_path / "packagename.wel")

--- a/imod/tests/test_mf6/test_well_highlvl.py
+++ b/imod/tests/test_mf6/test_well_highlvl.py
@@ -12,6 +12,7 @@ import imod.tests
 import imod.tests.fixtures
 import imod.tests.fixtures.mf6_circle_fixture
 import imod.tests.fixtures.mf6_twri_fixture
+from imod.mf6.validation_context import ValidationContext
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.tests.fixtures.mf6_small_models_fixture import (
@@ -80,9 +81,10 @@ def test_write_well(tmp_path: Path, grid_data, grid_data_layered, reference_outp
     k = 100.0
     top = ones_like(active.sel(layer=1), dtype=np.float64)
     bottom = grid_data_layered(np.float64, -2.0, 10)
+    validation_context = ValidationContext(False)
     write_context = WriteContext(tmp_path)
-    mf6_pkg = well.to_mf6_pkg(
-        active, top, bottom, k, False, write_context.is_partitioned
+    mf6_pkg = well._to_mf6_pkg(
+        active, top, bottom, k, write_context, validation_context
     )
     mf6_pkg.write("packagename", globaltimes, write_context)
     assert pathlib.Path.exists(tmp_path / "packagename.wel")

--- a/imod/tests/test_mf6/test_well_highlvl.py
+++ b/imod/tests/test_mf6/test_well_highlvl.py
@@ -83,9 +83,7 @@ def test_write_well(tmp_path: Path, grid_data, grid_data_layered, reference_outp
     bottom = grid_data_layered(np.float64, -2.0, 10)
     validation_context = ValidationContext(False)
     write_context = WriteContext(tmp_path)
-    mf6_pkg = well._to_mf6_pkg(
-        active, top, bottom, k, validation_context
-    )
+    mf6_pkg = well._to_mf6_pkg(active, top, bottom, k, validation_context)
     mf6_pkg.write("packagename", globaltimes, write_context)
     assert pathlib.Path.exists(tmp_path / "packagename.wel")
     assert pathlib.Path.exists(tmp_path / "packagename" / "wel.dat")

--- a/pixi.toml
+++ b/pixi.toml
@@ -42,7 +42,6 @@ unittests_jit = { cmd = [
     "--junitxml=unittest_jit_report.xml",
 ], depends_on = ["install"], cwd = "imod/tests" }
 examples = { cmd = [
-    "NUMBA_DISABLE_JIT=1",
     "pytest",
     "-n", "auto",
     "-m", "example",


### PR DESCRIPTION
Fixes #1222

# Description
- Add a ``ValidationContext`` dataclass
- Add a ``_validation_context`` attribute to ``Modflow6Simulation``; this replaces the ``_is_from_imod5`` attribute.
- The ``ValidationContext`` contains an attribute for strict well checks, turned on by default. This is set to False when calling ``from_imod5`` or for split simulations.
- Adds a ``_to_mf6_pkg`` method in a similar design as proposed in #1223, this to preserve public API.
- Refactor ``WriteContext``, to make it a dataclass again. I had to ignore type annotation for ``write_directory``, otherwise MyPy would throw errors. The whole property shebang presumably started with MyPy throwing errors. Reverting it back to a dataclass reduces the lines of code considerably, which makes it more maintainable.
- Use jit for examples run, this speeds them up considerably. The examples ran into a TimeOut on TeamCity, and this reduces the change of that happening again.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
