### PR TITLE
Issue #1228 align signatures from imod5 data

### DIFF
--- a/imod/mf6/chd.py
+++ b/imod/mf6/chd.py
@@ -155,7 +155,7 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         cls,
         key: str,
         imod5_data: dict[str, dict[str, GridDataArray]],
-        target_discretization: StructuredDiscretization,
+        target_dis: StructuredDiscretization,
         regridder_types: Optional[ConstantHeadRegridMethod] = None,
         regrid_cache: RegridderWeightsCache = RegridderWeightsCache(),
     ) -> "ConstantHead":
@@ -183,7 +183,7 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         imod5_data: dict
             Dictionary with iMOD5 data. This can be constructed from the
             :func:`imod.formats.prj.open_projectfile_data` method.
-        target_discretization:  StructuredDiscretization package
+        target_dis:  StructuredDiscretization package
             The grid that should be used for the new package. Does not
             need to be identical to one of the input grids.
         regridder_types: RegridMethodType, optional
@@ -197,7 +197,7 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         return cls._from_head_data(
             imod5_data[key]["head"],
             imod5_data["bnd"]["ibound"],
-            target_discretization,
+            target_dis,
             regridder_types,
             regrid_cache,
         )
@@ -207,7 +207,7 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
     def from_imod5_shd_data(
         cls,
         imod5_data: dict[str, dict[str, GridDataArray]],
-        target_discretization: StructuredDiscretization,
+        target_dis: StructuredDiscretization,
         regridder_types: Optional[ConstantHeadRegridMethod] = None,
         regrid_cache: RegridderWeightsCache = RegridderWeightsCache(),
     ) -> "ConstantHead":
@@ -230,7 +230,7 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         imod5_data: dict
             Dictionary with iMOD5 data. This can be constructed from the
             :func:`imod.formats.prj.open_projectfile_data` method.
-        target_discretization:  StructuredDiscretization package
+        target_dis:  StructuredDiscretization package
             The grid that should be used for the new package. Does not
             need to be identical to one of the input grids.
         regridder_types: ConstantHeadRegridMethod, optional
@@ -247,7 +247,7 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         return cls._from_head_data(
             imod5_data["shd"]["head"],
             imod5_data["bnd"]["ibound"],
-            target_discretization,
+            target_dis,
             regridder_types,
             regrid_cache,
         )
@@ -257,11 +257,11 @@ class ConstantHead(BoundaryCondition, IRegridPackage):
         cls,
         head: GridDataArray,
         ibound: GridDataArray,
-        target_discretization: StructuredDiscretization,
+        target_dis: StructuredDiscretization,
         regridder_types: Optional[ConstantHeadRegridMethod] = None,
         regrid_cache: RegridderWeightsCache = RegridderWeightsCache(),
     ) -> "ConstantHead":
-        target_idomain = target_discretization.dataset["idomain"]
+        target_idomain = target_dis.dataset["idomain"]
 
         if regridder_types is None:
             regridder_types = ConstantHead.get_regrid_methods()

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -187,10 +187,10 @@ class Drainage(BoundaryCondition, IRegridPackage):
         period_data: dict[str, list[datetime]],
         target_discretization: StructuredDiscretization,
         target_npf: NodePropertyFlow,
-        allocation_option: ALLOCATION_OPTION,
-        distributing_option: DISTRIBUTING_OPTION,
         time_min: datetime,
         time_max: datetime,
+        allocation_option: ALLOCATION_OPTION,
+        distributing_option: DISTRIBUTING_OPTION,
         regridder_types: Optional[DrainageRegridMethod] = None,
         regrid_cache: RegridderWeightsCache = RegridderWeightsCache(),
     ) -> "Drainage":

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -185,7 +185,7 @@ class Drainage(BoundaryCondition, IRegridPackage):
         key: str,
         imod5_data: dict[str, dict[str, GridDataArray]],
         period_data: dict[str, list[datetime]],
-        target_discretization: StructuredDiscretization,
+        target_dis: StructuredDiscretization,
         target_npf: NodePropertyFlow,
         time_min: datetime,
         time_max: datetime,
@@ -210,7 +210,7 @@ class Drainage(BoundaryCondition, IRegridPackage):
         period_data: dict
             Dictionary with iMOD5 period data. This can be constructed from the
             :func:`imod.formats.prj.open_projectfile_data` method.
-        target_discretization:  StructuredDiscretization package
+        target_dis:  StructuredDiscretization package
             The grid that should be used for the new package. Does not
             need to be identical to one of the input grids.
         target_npf: NodePropertyFlow package
@@ -235,9 +235,9 @@ class Drainage(BoundaryCondition, IRegridPackage):
         A Modflow 6 Drainage package.
         """
 
-        target_top = target_discretization.dataset["top"]
-        target_bottom = target_discretization.dataset["bottom"]
-        target_idomain = target_discretization.dataset["idomain"]
+        target_top = target_dis.dataset["top"]
+        target_bottom = target_dis.dataset["bottom"]
+        target_idomain = target_dis.dataset["idomain"]
 
         data = {
             "elevation": imod5_data[key]["elevation"],

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -194,8 +194,8 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         time_max: datetime,
         allocation_option: ALLOCATION_OPTION,
         distributing_option: DISTRIBUTING_OPTION,
-        regrid_cache: RegridderWeightsCache = RegridderWeightsCache(),
         regridder_types: Optional[RegridMethodType] = None,
+        regrid_cache: RegridderWeightsCache = RegridderWeightsCache(),
     ) -> "GeneralHeadBoundary":
         """
         Construct a GeneralHeadBoundary-package from iMOD5 data, loaded with the

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -188,7 +188,7 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         key: str,
         imod5_data: dict[str, dict[str, GridDataArray]],
         period_data: dict[str, list[datetime]],
-        target_discretization,
+        target_dis: StructuredDiscretization,
         target_npf: NodePropertyFlow,
         time_min: datetime,
         time_max: datetime,
@@ -213,7 +213,7 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         period_data: dict
             Dictionary with iMOD5 period data. This can be constructed from the
             :func:`imod.formats.prj.open_projectfile_data` method.
-        target_discretization:  StructuredDiscretization package
+        target_dis:  StructuredDiscretization package
             The grid that should be used for the new package. Does not
             need to be identical to one of the input grids.
         target_npf: NodePropertyFlow package
@@ -237,11 +237,11 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         -------
         A  Modflow 6 GeneralHeadBoundary packages.
         """
-        target_top = target_discretization.dataset["top"]
-        target_bottom = target_discretization.dataset["bottom"]
-        target_idomain = target_discretization.dataset["idomain"]
+        target_top = target_dis.dataset["top"]
+        target_bottom = target_dis.dataset["bottom"]
+        target_idomain = target_dis.dataset["idomain"]
 
-        idomain = target_discretization.dataset["idomain"]
+        idomain = target_dis.dataset["idomain"]
         data = {
             "head": imod5_data[key]["head"],
             "conductance": imod5_data[key]["conductance"],

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -345,10 +345,10 @@ class GroundwaterFlowModel(Modflow6Model):
                 period_data,
                 dis_pkg,
                 npf_pkg,
+                times[0],
+                times[-1],
                 allocation_options.drn,
                 distributing_option=distributing_options.drn,
-                time_min=times[0],
-                time_max=times[-1],
                 regridder_types=cast(
                     DrainageRegridMethod, regridder_types.get(drn_key)
                 ),
@@ -364,6 +364,7 @@ class GroundwaterFlowModel(Modflow6Model):
                 imod5_data,
                 period_data,
                 dis_pkg,
+                npf_pkg,
                 times[0],
                 times[-1],
                 allocation_options.riv,

--- a/imod/mf6/rch.py
+++ b/imod/mf6/rch.py
@@ -160,7 +160,7 @@ class Recharge(BoundaryCondition, IRegridPackage):
     def from_imod5_data(
         cls,
         imod5_data: dict[str, dict[str, GridDataArray]],
-        dis_pkg: StructuredDiscretization,
+        target_dis: StructuredDiscretization,
         regridder_types: Optional[RechargeRegridMethod] = None,
         regrid_cache: RegridderWeightsCache = RegridderWeightsCache(),
     ) -> "Recharge":
@@ -177,7 +177,7 @@ class Recharge(BoundaryCondition, IRegridPackage):
         imod5_data: dict
             Dictionary with iMOD5 data. This can be constructed from the
             :func:`imod.formats.prj.open_projectfile_data` method.
-        dis_pkg: GridDataArray
+        target_dis: GridDataArray
             The discretization package for the simulation. Its grid does not
             need to be identical to one of the input grids.
         regridder_types: RechargeRegridMethod, optional
@@ -192,7 +192,7 @@ class Recharge(BoundaryCondition, IRegridPackage):
         Modflow 6 rch package.
 
         """
-        new_idomain = dis_pkg.dataset["idomain"]
+        new_idomain = target_dis.dataset["idomain"]
         data = {
             "rate": convert_unit_rch_rate(imod5_data["rch"]["rate"]),
         }

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -211,8 +211,8 @@ class River(BoundaryCondition, IRegridPackage):
         target_npf: NodePropertyFlow,
         time_min: datetime,
         time_max: datetime,
-        allocation_option_riv: ALLOCATION_OPTION,
-        distributing_option_riv: DISTRIBUTING_OPTION,
+        allocation_option: ALLOCATION_OPTION,
+        distributing_option: DISTRIBUTING_OPTION,
         regridder_types: Optional[RiverRegridMethod] = None,
         regrid_cache: RegridderWeightsCache = RegridderWeightsCache(),
     ) -> Tuple[Optional["River"], Optional[Drainage]]:
@@ -292,7 +292,7 @@ class River(BoundaryCondition, IRegridPackage):
 
         if is_planar_conductance:
             riv_allocation = allocate_riv_cells(
-                allocation_option_riv,
+                allocation_option,
                 target_idomain == 1,
                 target_top,
                 target_bottom,
@@ -301,7 +301,7 @@ class River(BoundaryCondition, IRegridPackage):
             )
 
             regridded_package_data["conductance"] = distribute_riv_conductance(
-                distributing_option_riv,
+                distributing_option,
                 riv_allocation[0],
                 conductance,
                 target_top,

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -207,7 +207,7 @@ class River(BoundaryCondition, IRegridPackage):
         key: str,
         imod5_data: dict[str, dict[str, GridDataArray]],
         period_data: dict[str, list[datetime]],
-        target_discretization: StructuredDiscretization,
+        target_dis: StructuredDiscretization,
         target_npf: NodePropertyFlow,
         time_min: datetime,
         time_max: datetime,
@@ -235,7 +235,7 @@ class River(BoundaryCondition, IRegridPackage):
         period_data: dict
             Dictionary with iMOD5 period data. This can be constructed from the
             :func:`imod.formats.prj.open_projectfile_data` method.
-        target_discretization:  StructuredDiscretization package
+        target_dis:  StructuredDiscretization package
             The grid that should be used for the new package. Does not
             need to be identical to one of the input grids.
         time_min: datetime
@@ -263,9 +263,9 @@ class River(BoundaryCondition, IRegridPackage):
 
         logger = logging.logger
         # gather discretrizations
-        target_top = target_discretization.dataset["top"]
-        target_bottom = target_discretization.dataset["bottom"]
-        target_idomain = target_discretization.dataset["idomain"]
+        target_top = target_dis.dataset["top"]
+        target_bottom = target_dis.dataset["bottom"]
+        target_idomain = target_dis.dataset["idomain"]
         target_k = target_npf.dataset["k"]
 
         # gather input data

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -13,6 +13,7 @@ from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.disv import VerticesDiscretization
 from imod.mf6.drn import Drainage
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
+from imod.mf6.npf import NodePropertyFlow
 from imod.mf6.regrid.regrid_schemes import RiverRegridMethod
 from imod.mf6.utilities.regrid import (
     RegridderWeightsCache,
@@ -207,6 +208,7 @@ class River(BoundaryCondition, IRegridPackage):
         imod5_data: dict[str, dict[str, GridDataArray]],
         period_data: dict[str, list[datetime]],
         target_discretization: StructuredDiscretization,
+        target_npf: NodePropertyFlow,
         time_min: datetime,
         time_max: datetime,
         allocation_option_riv: ALLOCATION_OPTION,
@@ -264,6 +266,7 @@ class River(BoundaryCondition, IRegridPackage):
         target_top = target_discretization.dataset["top"]
         target_bottom = target_discretization.dataset["bottom"]
         target_idomain = target_discretization.dataset["idomain"]
+        target_k = target_npf.dataset["k"]
 
         # gather input data
         data = {
@@ -303,7 +306,7 @@ class River(BoundaryCondition, IRegridPackage):
                 conductance,
                 target_top,
                 target_bottom,
-                conductance,
+                target_k,
                 regridded_package_data["stage"],
                 regridded_package_data["bottom_elevation"],
             )

--- a/imod/tests/test_mf6/test_mf6_riv.py
+++ b/imod/tests/test_mf6/test_mf6_riv.py
@@ -13,6 +13,7 @@ from pytest_cases import parametrize_with_cases
 import imod
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.disv import VerticesDiscretization
+from imod.mf6.npf import NodePropertyFlow
 from imod.mf6.write_context import WriteContext
 from imod.prepare.topsystem.allocation import ALLOCATION_OPTION
 from imod.prepare.topsystem.conductance import DISTRIBUTING_OPTION
@@ -458,12 +459,15 @@ def test_import_river_from_imod5(imod5_dataset, tmp_path):
     period_data = imod5_dataset[1]
     globaltimes = [np.datetime64("2000-01-01")]
     target_dis = StructuredDiscretization.from_imod5_data(imod5_data)
+    grid = target_dis.dataset["idomain"]
+    target_npf = NodePropertyFlow.from_imod5_data(imod5_data, grid)
 
     (riv, drn) = imod.mf6.River.from_imod5_data(
         "riv-1",
         imod5_data,
         period_data,
         target_dis,
+        target_npf,
         time_min=datetime(2000, 1, 1),
         time_max=datetime(2002, 1, 1),
         allocation_option_riv=ALLOCATION_OPTION.at_elevation,
@@ -495,6 +499,8 @@ def test_import_river_from_imod5_infiltration_factors(imod5_dataset):
     imod5_data = imod5_dataset[0]
     period_data = imod5_dataset[1]
     target_dis = StructuredDiscretization.from_imod5_data(imod5_data)
+    grid = target_dis.dataset["idomain"]
+    target_npf = NodePropertyFlow.from_imod5_data(imod5_data, grid)
 
     original_infiltration_factor = imod5_data["riv-1"]["infiltration_factor"]
     imod5_data["riv-1"]["infiltration_factor"] = ones_like(original_infiltration_factor)
@@ -504,6 +510,7 @@ def test_import_river_from_imod5_infiltration_factors(imod5_dataset):
         imod5_data,
         period_data,
         target_dis,
+        target_npf,
         time_min=datetime(2000, 1, 1),
         time_max=datetime(2002, 1, 1),
         allocation_option_riv=ALLOCATION_OPTION.at_elevation,
@@ -522,6 +529,7 @@ def test_import_river_from_imod5_infiltration_factors(imod5_dataset):
         imod5_data,
         period_data,
         target_dis,
+        target_npf,
         time_min=datetime(2000, 1, 1),
         time_max=datetime(2002, 1, 1),
         allocation_option_riv=ALLOCATION_OPTION.at_elevation,
@@ -540,6 +548,8 @@ def test_import_river_from_imod5_period_data(imod5_dataset_periods):
     imod5_data = imod5_dataset_periods[0]
     imod5_periods = imod5_dataset_periods[1]
     target_dis = StructuredDiscretization.from_imod5_data(imod5_data, validate=False)
+    grid = target_dis.dataset["idomain"]
+    target_npf = NodePropertyFlow.from_imod5_data(imod5_data, grid)
 
     original_infiltration_factor = imod5_data["riv-1"]["infiltration_factor"]
     imod5_data["riv-1"]["infiltration_factor"] = ones_like(original_infiltration_factor)
@@ -549,6 +559,7 @@ def test_import_river_from_imod5_period_data(imod5_dataset_periods):
         imod5_data,
         imod5_periods,
         target_dis,
+        target_npf,
         datetime(2002, 2, 2),
         datetime(2022, 2, 2),
         ALLOCATION_OPTION.at_elevation,
@@ -567,6 +578,7 @@ def test_import_river_from_imod5_period_data(imod5_dataset_periods):
         imod5_data,
         imod5_periods,
         target_dis,
+        target_npf,
         datetime(2002, 2, 2),
         datetime(2022, 2, 2),
         ALLOCATION_OPTION.at_elevation,

--- a/imod/tests/test_mf6/test_mf6_riv.py
+++ b/imod/tests/test_mf6/test_mf6_riv.py
@@ -470,8 +470,8 @@ def test_import_river_from_imod5(imod5_dataset, tmp_path):
         target_npf,
         time_min=datetime(2000, 1, 1),
         time_max=datetime(2002, 1, 1),
-        allocation_option_riv=ALLOCATION_OPTION.at_elevation,
-        distributing_option_riv=DISTRIBUTING_OPTION.by_crosscut_thickness,
+        allocation_option=ALLOCATION_OPTION.at_elevation,
+        distributing_option=DISTRIBUTING_OPTION.by_crosscut_thickness,
         regridder_types=None,
     )
 
@@ -513,8 +513,8 @@ def test_import_river_from_imod5_infiltration_factors(imod5_dataset):
         target_npf,
         time_min=datetime(2000, 1, 1),
         time_max=datetime(2002, 1, 1),
-        allocation_option_riv=ALLOCATION_OPTION.at_elevation,
-        distributing_option_riv=DISTRIBUTING_OPTION.by_crosscut_thickness,
+        allocation_option=ALLOCATION_OPTION.at_elevation,
+        distributing_option=DISTRIBUTING_OPTION.by_crosscut_thickness,
         regridder_types=None,
     )
 
@@ -532,8 +532,8 @@ def test_import_river_from_imod5_infiltration_factors(imod5_dataset):
         target_npf,
         time_min=datetime(2000, 1, 1),
         time_max=datetime(2002, 1, 1),
-        allocation_option_riv=ALLOCATION_OPTION.at_elevation,
-        distributing_option_riv=DISTRIBUTING_OPTION.by_crosscut_thickness,
+        allocation_option=ALLOCATION_OPTION.at_elevation,
+        distributing_option=DISTRIBUTING_OPTION.by_crosscut_thickness,
         regridder_types=None,
     )
 


### PR DESCRIPTION
Fixes #1228

# Description
- Provides hydraulic conductivity ("k") to distribute_riv_conductances instead of the riv conductance, which is entirely wrong.
- Align ``Drainage`` and ``River`` signatures, which should be nearly the same.
- Align arg names and order

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
