### PR TITLE
Issue #1230 distribut drn elevation equals surface level

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -43,7 +43,7 @@ Changed
 - :func:`imod.prepare.allocate_drn_cells`,
   :func:`imod.prepare.allocate_ghb_cells`,
   :func:`imod.prepare.allocate_riv_cells`, now allocate to the first model layer
-  when elevations are above model top for all methods in
+  when elevations are above or equal to model top for all methods in
   :func:`imod.prepare.ALLOCATION_OPTION`.
 - :meth:`imod.mf6.Well.to_mf6_pkg` got a new argument:
   ``strict_well_validation``, which controls the behavior for when wells are

--- a/imod/prepare/topsystem/conductance.py
+++ b/imod/prepare/topsystem/conductance.py
@@ -363,10 +363,10 @@ def _compute_crosscut_thickness(
         corrected_thickness = thickness - (bc_bottom - bottom)
         # Set top layer to 1.0, where top exceeds bc_bottom
         top_layer_label = {"layer": min(top_layered.coords["layer"])}
-        is_above_surface = top_layered.loc[top_layer_label] < bc_bottom
+        is_below_surface = top_layered.loc[top_layer_label] > bc_bottom
         corrected_thickness.loc[top_layer_label] = corrected_thickness.loc[
             top_layer_label
-        ].where(is_above_surface, 1.0)
+        ].where(is_below_surface, 1.0)
         thickness = thickness.where(~lower_layer_bc, corrected_thickness)
 
     thickness = thickness.where(~outside, 0.0)
@@ -420,7 +420,7 @@ def _distribute_weights__by_corrected_transmissivity(
     # these to 1.0.
     top_layer_index = {"layer": min(top_layered.coords["layer"])}
     F_top_layer = F.loc[top_layer_index]
-    F.loc[top_layer_index] = F_top_layer.where(F_top_layer >= 0.0, 1.0)
+    F.loc[top_layer_index] = F_top_layer.where(F_top_layer > 0.0, 1.0)
 
     transmissivity_corrected = transmissivity * F
     return transmissivity_corrected / transmissivity_corrected.sum(dim="layer")

--- a/imod/tests/test_prepare/test_topsystem.py
+++ b/imod/tests/test_prepare/test_topsystem.py
@@ -327,6 +327,34 @@ def test_distribute_drn_conductance__above_surface_level(
 
 
 @parametrize_with_cases(
+    argnames="active,top,bottom,elevation",
+    prefix="drn_",
+)
+@parametrize_with_cases(
+    argnames="option,allocated_layer,_", prefix="distribution_", has_tag="drn"
+)
+def test_distribute_drn_conductance__equal_to_surface_level(
+    active, top, bottom, elevation, option, allocated_layer, _
+):
+    allocated_layer.data = np.array([True, False, False, False])
+    expected = [1.0, np.nan, np.nan, np.nan]
+    allocated = enforce_dim_order(active & allocated_layer)
+    k = xr.DataArray(
+        [2.0, 2.0, 1.0, 1.0], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
+    )
+
+    conductance = zeros_like(elevation) + 1.0
+    elevation = zeros_like(elevation) + top
+
+    actual_da = distribute_drn_conductance(
+        option, allocated, conductance, top, bottom, k, elevation
+    )
+    actual = take_nth_layer_column(actual_da, 0)
+
+    np.testing.assert_equal(actual, expected)
+
+
+@parametrize_with_cases(
     argnames="active,top,bottom,stage,bottom_elevation",
     prefix="riv_",
 )
@@ -354,6 +382,41 @@ def test_distribute_riv_conductance__above_surface_level(
         k,
         stage + 100.0,
         bottom_elevation + 100.0,
+    )
+    actual = take_nth_layer_column(actual_da, 0)
+
+    np.testing.assert_equal(actual, expected)
+
+
+@parametrize_with_cases(
+    argnames="active,top,bottom,stage,bottom_elevation",
+    prefix="riv_",
+)
+@parametrize_with_cases(
+    argnames="option,allocated_layer,_", prefix="distribution_", has_tag="riv"
+)
+def test_distribute_riv_conductance__equal_to_surface_level(
+    active, top, bottom, stage, bottom_elevation, option, allocated_layer, _
+):
+    allocated_layer.data = np.array([True, False, False, False])
+    expected = [1.0, np.nan, np.nan, np.nan]
+    allocated = enforce_dim_order(active & allocated_layer)
+    k = xr.DataArray(
+        [2.0, 2.0, 1.0, 1.0], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
+    )
+
+    conductance = zeros_like(bottom_elevation) + 1.0
+    elevation = zeros_like(bottom_elevation) + top
+
+    actual_da = distribute_riv_conductance(
+        option,
+        allocated,
+        conductance,
+        top,
+        bottom,
+        k,
+        elevation,
+        elevation,
     )
     actual = take_nth_layer_column(actual_da, 0)
 

--- a/imod/tests/test_prepare/test_topsystem_cases.py
+++ b/imod/tests/test_prepare/test_topsystem_cases.py
@@ -23,7 +23,7 @@ def time_da():
 
 def riv_structured_transient(basic_dis__topsystem):
     ibound, top, bottom = basic_dis__topsystem
-    top = top.sel(layer=1)
+    top = top.sel(layer=1, drop=True)
     elevation = zeros_like(ibound.sel(layer=1), dtype=np.float64)
     # Deactivate second cell
     elevation[1, 1] = np.nan
@@ -36,6 +36,7 @@ def riv_structured_transient(basic_dis__topsystem):
 
 def riv_unstructured_transient(basic_disv__topsystem):
     ibound, top, bottom = basic_disv__topsystem
+    top = top.sel(layer=1, drop=True)
     elevation = zeros_like(ibound.sel(layer=1), dtype=np.float64)
     # Deactivate second cell
     elevation[1] = np.nan
@@ -49,7 +50,7 @@ def riv_unstructured_transient(basic_disv__topsystem):
 
 def riv_structured(basic_dis__topsystem):
     ibound, top, bottom = basic_dis__topsystem
-    top = top.sel(layer=1)
+    top = top.sel(layer=1, drop=True)
     elevation = zeros_like(ibound.sel(layer=1), dtype=np.float64)
     # Deactivate second cell
     elevation[1, 1] = np.nan
@@ -61,6 +62,7 @@ def riv_structured(basic_dis__topsystem):
 
 def riv_unstructured(basic_disv__topsystem):
     ibound, top, bottom = basic_disv__topsystem
+    top = top.sel(layer=1, drop=True)
     elevation = zeros_like(ibound.sel(layer=1), dtype=np.float64)
     # Deactivate second cell
     elevation[1] = np.nan
@@ -72,7 +74,7 @@ def riv_unstructured(basic_disv__topsystem):
 
 def drn_structured(basic_dis__topsystem):
     ibound, top, bottom = basic_dis__topsystem
-    top = top.sel(layer=1)
+    top = top.sel(layer=1, drop=True)
     elevation = zeros_like(ibound.sel(layer=1), dtype=np.float64)
     # Deactivate second cell
     elevation[1, 1] = np.nan
@@ -83,6 +85,7 @@ def drn_structured(basic_dis__topsystem):
 
 def drn_unstructured(basic_disv__topsystem):
     ibound, top, bottom = basic_disv__topsystem
+    top = top.sel(layer=1, drop=True)
     elevation = zeros_like(ibound.sel(layer=1), dtype=np.float64)
     # Deactivate second cell
     elevation[1] = np.nan
@@ -93,7 +96,7 @@ def drn_unstructured(basic_disv__topsystem):
 
 def ghb_structured(basic_dis__topsystem):
     ibound, top, bottom = basic_dis__topsystem
-    top = top.sel(layer=1)
+    top = top.sel(layer=1, drop=True)
     elevation = zeros_like(ibound.sel(layer=1), dtype=np.float64)
     # Deactivate second cell
     elevation[1, 1] = np.nan
@@ -104,6 +107,7 @@ def ghb_structured(basic_dis__topsystem):
 
 def ghb_unstructured(basic_disv__topsystem):
     ibound, top, bottom = basic_disv__topsystem
+    top = top.sel(layer=1, drop=True)
     elevation = zeros_like(ibound.sel(layer=1), dtype=np.float64)
     # Deactivate second cell
     elevation[1] = np.nan


### PR DESCRIPTION
Fixes #1230

# Description
- Fix bug where distributed conductances were dropped when their elevation equalled surface level
- In topsystem test cases, make sure "layer" coordinate is dropped consistently amongst cases.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
