### PR TITLE
Use apply_ufunc in `imod.prepare.fill`. Fixes #1237

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -6,6 +6,23 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+Unreleased
+----------
+
+Fixed
+~~~~~
+
+- :func:`imod.prepare.fill` previously assigned to the result of an xarray
+  ``.sel`` operation. This might not work for dask backed data and has been
+  fixed.
+
+Changed
+~~~~~~~
+
+- :func:`imod.prepare.fill` now takes a ``dims`` argument instead of ``by``,
+  and will fill over N dimensions. Secondly, the function no longer takes
+  an ``invalid`` argument, but instead always treats NaNs as missing.
+
 0.17.2
 ------
 

--- a/imod/prepare/spatial.py
+++ b/imod/prepare/spatial.py
@@ -63,7 +63,7 @@ def _fill_np(data, invalid):
     return data[tuple(indices)]
 
 
-def fill(da, dims=("y", "x"), invalid=None):
+def fill(da, invalid=None, dims=("y", "x")):
     """
     Replace the value of invalid ``da`` cells (indicated by ``invalid``)
     using basic nearest neighbour interpolation.

--- a/imod/tests/test_spatial.py
+++ b/imod/tests/test_spatial.py
@@ -47,8 +47,8 @@ def test_round_extent():
 
 
 def test_fill():
-    da = xr.DataArray([np.nan, 1.0, 2.0], {"x": [1, 2, 3]}, ("x",))
-    expected = xr.DataArray([1.0, 1.0, 2.0], {"x": [1, 2, 3]}, ("x",))
+    da = xr.DataArray([[np.nan, 1.0, 2.0]], {"x": [1, 2, 3], "y": [1]}, ("y", "x"))
+    expected = xr.DataArray([[1.0, 1.0, 2.0]], {"x": [1, 2, 3], "y": [1]}, ("y", "x"))
     actual = imod.prepare.spatial.fill(da)
     assert actual.identical(expected)
 
@@ -64,8 +64,8 @@ def test_fill():
     expected_x = xr.DataArray(
         [[2.0, 2.0, 1.0], [2.0, 2.0, 2.0]], {"x": [1, 2, 3], "y": [1, 2]}, ("y", "x")
     )
-    actual_x = imod.prepare.spatial.fill(da, by="x")
-    actual_y = imod.prepare.spatial.fill(da, by="y")
+    actual_x = imod.prepare.spatial.fill(da, dims=("y",))
+    actual_y = imod.prepare.spatial.fill(da, dims=("x",))
     assert actual_x.identical(expected_x)
     assert actual_y.identical(expected_y)
 


### PR DESCRIPTION
Fixes #1237.

This is unfortunately a breaking change, but keeping the previous API makes the logic a lot more complicated (and arguably makes the function worse).

For example, keeping the `invalid` (might need a better name too) as a DataArray almost surely requires including it in the broadcasting logic of `apply_ufunc`.