### PR TITLE
Issue #1242 Avoid swapping of FRF and FFF in open_cbc for 2D grids

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -12,8 +12,9 @@ Unreleased
 Fixed
 ~~~~~
 
-- Fix `imod.mf6.open_cbc`: it failed with ``flowja=False`` on budget output for
+- `imod.mf6.open_cbc` failing with ``flowja=False`` on budget output for
   DISV models if the model contained inactive cells.
+- `imod.mf6.open_cbc` now works for 2D and 1D models. 
 - :func:`imod.prepare.fill` previously assigned to the result of an xarray
   ``.sel`` operation. This might not work for dask backed data and has been
   addressed.

--- a/imod/mf6/out/dis.py
+++ b/imod/mf6/out/dis.py
@@ -307,7 +307,7 @@ def dis_indices(
             d = j - i
             if d <= 0:  # left, back, upper
                 continue
-            elif d == 1:  # right neighbor
+            elif d == 1 and ncol > 1:  # right neighbor
                 right[i] = nzi
             elif d == ncol:  # front neighbor
                 front[i] = nzi

--- a/imod/mf6/out/dis.py
+++ b/imod/mf6/out/dis.py
@@ -309,7 +309,7 @@ def dis_indices(
                 continue
             elif d == 1 and ncol > 1:  # right neighbor
                 right[i] = nzi
-            elif d == ncol:  # front neighbor
+            elif d == ncol and ncells_per_layer > 1:  # front neighbor
                 front[i] = nzi
             elif d == ncells_per_layer:  # lower neighbor
                 lower[i] = nzi

--- a/imod/tests/test_mf6/test_mf6_out.py
+++ b/imod/tests/test_mf6/test_mf6_out.py
@@ -146,7 +146,7 @@ def test_dis_indices__single_column():
     # +---+
     ia = np.array([1, 2, 4, 6, 7])
     ja = np.array([2, 1, 3, 2, 4, 3])
-    # nja index      0  1  2  3  4  5
+    # nja index    0  1  2  3  4  5
     ncells = 4
     nlayer = 1
     nrow = 4
@@ -174,6 +174,51 @@ def test_dis_indices__single_column():
         ]
     )
     assert np.allclose(front[0], front_expected)
+
+
+def test_dis_indices__single_row_column():
+    # Note: ia and ja use 1-based indexing as produced by modflow6!
+    # Cell numbering, vertical-view:
+    #
+    # +---+
+    # | 1 |
+    # +---+
+    # | 2 |
+    # +---+
+    # | 3 |
+    # +---+
+    # | 4 |
+    # +---+
+    ia = np.array([1, 2, 4, 6, 7])
+    ja = np.array([2, 1, 3, 2, 4, 3])
+    # nja index    0  1  2  3  4  5
+    ncells = 4
+    nlayer = 4
+    nrow = 1
+    ncol = 1
+    right, front, lower = imod.mf6.out.dis.dis_indices(
+        ia, ja, ncells, nlayer, nrow, ncol
+    )
+    assert right.shape == front.shape == lower.shape == (nlayer, nrow, ncol)
+    assert (right == -1).all()  # No right connections
+    assert (front == -1).all()  # No front connections
+    lower_expected = np.array(
+        [
+            [
+                0,
+            ],
+            [
+                2,
+            ],
+            [
+                4,
+            ],
+            [
+                -1,
+            ],
+        ]
+    )
+    assert np.allclose(lower[:, 0], lower_expected)
 
 
 def test_dis_indices__idomain():

--- a/imod/tests/test_mf6/test_mf6_out.py
+++ b/imod/tests/test_mf6/test_mf6_out.py
@@ -144,9 +144,9 @@ def test_dis_indices__single_column():
     # +---+
     # | 4 |
     # +---+
-    
     ia = np.array([1, 2, 4, 6, 7])
     ja = np.array([2, 1, 3, 2, 4, 3])
+    # nja index      0  1  2  3  4  5
     ncells = 4
     nlayer = 1
     nrow = 4
@@ -156,22 +156,25 @@ def test_dis_indices__single_column():
     )
     assert right.shape == front.shape == lower.shape == (nlayer, nrow, ncol)
     assert (lower == -1).all()  # No lower connections
-    right_expected = np.array(
-        [
-            [-1, -1, -1, -1],
-        ]
-    )
-    assert (right == -1).all()
+    assert (right == -1).all()  # No right connections
     front_expected = np.array(
         [
-            [2,],
-            [3,],
-            [4,],
-            [-1,],
+            [
+                0,
+            ],
+            [
+                2,
+            ],
+            [
+                4,
+            ],
+            [
+                -1,
+            ],
         ]
     )
     assert np.allclose(front[0], front_expected)
-    
+
 
 def test_dis_indices__idomain():
     # Note: ia and ja use 1-based indexing as produced by modflow6!

--- a/imod/tests/test_mf6/test_mf6_out.py
+++ b/imod/tests/test_mf6/test_mf6_out.py
@@ -131,6 +131,48 @@ def test_dis_indices():
     assert np.allclose(front[0], front_expected)
 
 
+def test_dis_indices__single_column():
+    # Note: ia and ja use 1-based indexing as produced by modflow6!
+    # Cell numbering, top-view:
+    #
+    # +---+
+    # | 1 |
+    # +---+
+    # | 2 |
+    # +---+
+    # | 3 |
+    # +---+
+    # | 4 |
+    # +---+
+    
+    ia = np.array([1, 2, 4, 6, 7])
+    ja = np.array([2, 1, 3, 2, 4, 3])
+    ncells = 4
+    nlayer = 1
+    nrow = 4
+    ncol = 1
+    right, front, lower = imod.mf6.out.dis.dis_indices(
+        ia, ja, ncells, nlayer, nrow, ncol
+    )
+    assert right.shape == front.shape == lower.shape == (nlayer, nrow, ncol)
+    assert (lower == -1).all()  # No lower connections
+    right_expected = np.array(
+        [
+            [-1, -1, -1, -1],
+        ]
+    )
+    assert (right == -1).all()
+    front_expected = np.array(
+        [
+            [2,],
+            [3,],
+            [4,],
+            [-1,],
+        ]
+    )
+    assert np.allclose(front[0], front_expected)
+    
+
 def test_dis_indices__idomain():
     # Note: ia and ja use 1-based indexing as produced by modflow6!
     # Cell numbering, cross-section:

--- a/imod/tests/test_mf6/test_mf6_out.py
+++ b/imod/tests/test_mf6/test_mf6_out.py
@@ -209,15 +209,15 @@ def test_dis_indices__idomain():
     right, front, lower = imod.mf6.out.dis.dis_indices(
         ia, ja, ncells, nlayer, nrow, ncol
     )
-    assert (front == -1).all()  # No front connections
-    right_expected = np.array(
+    assert (right == -1).all()  # No right connection
+    front_expected = np.array(
         [
             [0, 3, -1],
             [-1, -1, -1],
             [9, 12, -1],
         ]
     )
-    assert np.allclose(right.reshape(nlayer, nrow), right_expected)
+    assert np.allclose(front.reshape(nlayer, nrow), front_expected)
     lower_expected = np.array(
         [
             [1, 4, -1],


### PR DESCRIPTION
Fixes #1242 and #159

Fixes swapping budget output:

Case 1: FRF to FFF in cases ncol == 1
Case 2: FLF to FFF  in case numer of cell per layer == 1

Added tests for single column model (2D) and single column and row (1D) model.

# Description
<!---
Thanks for opening a PR!

Please add your description here of changes made and how they are going to
resolve the linked issue 
-->

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
