### PR TITLE
Issue #728 metaswap grid agnostic well

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -7,6 +7,17 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
 
+[Unreleased - feature branch]
+-----------------------------
+
+Changed
+~~~~~~~
+
+- :class:`imod.msw.CouplingMapping` and :class:`imod.msw.Sprinkling` now take
+  the :class:`imod.mf6.mf6_wel_adapter.Mf6Wel` as well argument instead of the
+  deprecated :class:`imod.mf6.WellDisStructured`.
+
+
 [Unreleased]
 ------------
 

--- a/imod/mf6/mf6_wel_adapter.py
+++ b/imod/mf6/mf6_wel_adapter.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Optional
 import numpy as np
 
 from imod.mf6.boundary_condition import BoundaryCondition
+from imod.mf6.interfaces.ipackage import IPackage
 from imod.schemata import DTypeSchema
 
 # FUTURE: There was an idea to autogenerate modflow 6 adapters.
@@ -24,7 +25,7 @@ from imod.schemata import DTypeSchema
 # https://github.com/Deltares/xugrid/blob/main/xugrid/core/wrap.py#L90
 
 
-class Mf6Wel(BoundaryCondition):
+class Mf6Wel(BoundaryCondition, IPackage):
     """
     Package resembling input for Modflow 6 List Input. This class has
     methods for the modflow 6 wel packages with time component.

--- a/imod/mf6/mf6_wel_adapter.py
+++ b/imod/mf6/mf6_wel_adapter.py
@@ -86,7 +86,7 @@ class Mf6Wel(BoundaryCondition):
             dsvar[var] = ds[var]
         arrdict["var_values"] = dsvar
 
-        arrdict["cellid_names"] = ds.coords["nmax_cellid"].values
+        arrdict["cellid_names"] = ds.coords["dim_cellid"].values
         arrdict["nrow"] = ds.coords["ncellid"].size
         arrdict["cellid"] = ds["cellid"]
 
@@ -100,7 +100,7 @@ class Mf6Wel(BoundaryCondition):
         # Initialize the structured array
         recarr = np.empty(arrdict["nrow"], dtype=sparse_dtype)
         for cellid_name in arrdict["cellid_names"]:
-            recarr[cellid_name] = arrdict["cellid"].sel(nmax_cellid=cellid_name).values
+            recarr[cellid_name] = arrdict["cellid"].sel(dim_cellid=cellid_name).values
 
         for var in arrdict["data_vars"]:
             recarr[var] = arrdict["var_values"][var]

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -218,6 +218,78 @@ def get_all_imod5_prj_well_times(imod5_data: dict) -> list[datetime]:
     return sorted(set(wel_times_flat))
 
 
+def derive_cellid_from_points(
+    dst_grid: GridDataArray,
+    x: list,
+    y: list,
+    layer: list,
+) -> GridDataArray:
+    """
+    Create DataArray with Modflow6 cell identifiers based on x, y coordinates
+    in a dataframe. For structured grid this DataArray contains 3 columns:
+    ``layer, row, column``. For unstructured grids, this contains 2 columns:
+    ``layer, cell2d``.
+    See also: https://water.usgs.gov/water-resources/software/MODFLOW-6/mf6io_6.4.0.pdf#page=35
+
+    Note
+    ----
+    The "layer" coordinate should already be provided in the dataframe.
+    To determine the layer coordinate based on screen depts, look at
+    :func:`imod.prepare.wells.assign_wells`.
+
+    Parameters
+    ----------
+    dst_grid: {xr.DataArray, xu.UgridDataArray}
+        Destination grid to map the points to based on their x and y coordinates.
+    x: {list, np.array}
+        array-like with x-coordinates
+    y: {list, np.array}
+        array-like with y-coordinates
+    layer: {list, np.array}
+        array-like with layer-coordinates
+
+    Returns
+    -------
+    cellid : xr.DataArray
+        2D DataArray with a ``ncellid`` rows and 3 to 2 columns, depending
+        on whether on a structured or unstructured grid."""
+
+    # Find indices belonging to x, y coordinates
+    indices_cell2d = points_indices(dst_grid, out_of_bounds="ignore", x=x, y=y)
+    # Convert cell2d indices from 0-based to 1-based.
+    indices_cell2d = {dim: index + 1 for dim, index in indices_cell2d.items()}
+    # Prepare layer indices, for later concatenation
+
+    if isinstance(dst_grid, xu.UgridDataArray):
+        indices_layer = xr.DataArray(
+            layer, coords=indices_cell2d["mesh2d_nFaces"].coords
+        )
+        face_dim = dst_grid.ugrid.grid.face_dimension
+        indices_cell2d_dims = [face_dim]
+        cell2d_coords = ["cell2d"]
+    else:
+        indices_layer = xr.DataArray(layer, coords=indices_cell2d["x"].coords)
+        indices_cell2d_dims = ["y", "x"]
+        cell2d_coords = ["row", "column"]
+
+    # Prepare cellid array of the right shape.
+    cellid_ls = [indices_layer] + [indices_cell2d[dim] for dim in indices_cell2d_dims]
+    cellid = xr.concat(cellid_ls, dim="nmax_cellid")
+    # Rename generic dimension name "index" to ncellid.
+    cellid = cellid.rename(index="ncellid")
+    # Put dimensions in right order after concatenation.
+    cellid = cellid.transpose("ncellid", "nmax_cellid")
+    # Assign extra coordinate names.
+    coords = {
+        "nmax_cellid": ["layer"] + cell2d_coords,
+        "x": ("ncellid", x),
+        "y": ("ncellid", y),
+    }
+    cellid = cellid.assign_coords(coords=coords)
+
+    return cellid
+
+
 class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
     """
     Abstract base class for grid agnostic wells
@@ -248,7 +320,7 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
         df_for_cellid = assigned_wells.groupby("index").first()
         d_for_cellid = df_for_cellid[["x", "y", "layer"]].to_dict("list")
 
-        return self._derive_cellid_from_points(like, **d_for_cellid)
+        return derive_cellid_from_points(like, **d_for_cellid)
 
     def _create_dataset_vars(
         self, assigned_wells: pd.DataFrame, cellid: xr.DataArray
@@ -274,80 +346,6 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
         ds_vars = ds_vars.assign_coords(**{"ncellid": cellid.coords["ncellid"].values})
 
         return ds_vars
-
-    @staticmethod
-    def _derive_cellid_from_points(
-        dst_grid: GridDataArray,
-        x: list,
-        y: list,
-        layer: list,
-    ) -> GridDataArray:
-        """
-        Create DataArray with Modflow6 cell identifiers based on x, y coordinates
-        in a dataframe. For structured grid this DataArray contains 3 columns:
-        ``layer, row, column``. For unstructured grids, this contains 2 columns:
-        ``layer, cell2d``.
-        See also: https://water.usgs.gov/water-resources/software/MODFLOW-6/mf6io_6.4.0.pdf#page=35
-
-        Note
-        ----
-        The "layer" coordinate should already be provided in the dataframe.
-        To determine the layer coordinate based on screen depts, look at
-        :func:`imod.prepare.wells.assign_wells`.
-
-        Parameters
-        ----------
-        dst_grid: {xr.DataArray, xu.UgridDataArray}
-            Destination grid to map the points to based on their x and y coordinates.
-        x: {list, np.array}
-            array-like with x-coordinates
-        y: {list, np.array}
-            array-like with y-coordinates
-        layer: {list, np.array}
-            array-like with layer-coordinates
-
-        Returns
-        -------
-        cellid : xr.DataArray
-            2D DataArray with a ``ncellid`` rows and 3 to 2 columns, depending
-            on whether on a structured or unstructured grid."""
-
-        # Find indices belonging to x, y coordinates
-        indices_cell2d = points_indices(dst_grid, out_of_bounds="ignore", x=x, y=y)
-        # Convert cell2d indices from 0-based to 1-based.
-        indices_cell2d = {dim: index + 1 for dim, index in indices_cell2d.items()}
-        # Prepare layer indices, for later concatenation
-
-        if isinstance(dst_grid, xu.UgridDataArray):
-            indices_layer = xr.DataArray(
-                layer, coords=indices_cell2d["mesh2d_nFaces"].coords
-            )
-            face_dim = dst_grid.ugrid.grid.face_dimension
-            indices_cell2d_dims = [face_dim]
-            cell2d_coords = ["cell2d"]
-        else:
-            indices_layer = xr.DataArray(layer, coords=indices_cell2d["x"].coords)
-            indices_cell2d_dims = ["y", "x"]
-            cell2d_coords = ["row", "column"]
-
-        # Prepare cellid array of the right shape.
-        cellid_ls = [indices_layer] + [
-            indices_cell2d[dim] for dim in indices_cell2d_dims
-        ]
-        cellid = xr.concat(cellid_ls, dim="nmax_cellid")
-        # Rename generic dimension name "index" to ncellid.
-        cellid = cellid.rename(index="ncellid")
-        # Put dimensions in right order after concatenation.
-        cellid = cellid.transpose("ncellid", "nmax_cellid")
-        # Assign extra coordinate names.
-        coords = {
-            "nmax_cellid": ["layer"] + cell2d_coords,
-            "x": ("ncellid", x),
-            "y": ("ncellid", y),
-        }
-        cellid = cellid.assign_coords(coords=coords)
-
-        return cellid
 
     def render(self, directory, pkgname, globaltimes, binary):
         raise NotImplementedError(

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -317,8 +317,8 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
 
         # Groupby index and select first, to unset any duplicate records
         # introduced by the multi-indexed "time" dimension.
-        df_for_cellid = assigned_wells.groupby("index").first()
-        d_for_cellid = df_for_cellid[["x", "y", "layer"]].to_dict("list")
+        unique_assigned_wells = assigned_wells.groupby("index").first()
+        d_for_cellid = unique_assigned_wells[["x", "y", "layer"]].to_dict("list")
 
         return derive_cellid_from_points(like, **d_for_cellid)
 

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -274,14 +274,14 @@ def derive_cellid_from_points(
 
     # Prepare cellid array of the right shape.
     cellid_ls = [indices_layer] + [indices_cell2d[dim] for dim in indices_cell2d_dims]
-    cellid = xr.concat(cellid_ls, dim="nmax_cellid")
+    cellid = xr.concat(cellid_ls, dim="dim_cellid")
     # Rename generic dimension name "index" to ncellid.
     cellid = cellid.rename(index="ncellid")
     # Put dimensions in right order after concatenation.
-    cellid = cellid.transpose("ncellid", "nmax_cellid")
+    cellid = cellid.transpose("ncellid", "dim_cellid")
     # Assign extra coordinate names.
     coords = {
-        "nmax_cellid": ["layer"] + cell2d_coords,
+        "dim_cellid": ["layer"] + cell2d_coords,
         "x": ("ncellid", x),
         "y": ("ncellid", y),
     }

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, cast
 
 import numpy as np
 import pandas as pd
@@ -8,6 +8,7 @@ from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.mf6_wel_adapter import Mf6Wel
 from imod.msw.fixed_format import VariableMetaData
 from imod.msw.pkgbase import MetaSwapPackage
+from imod.typing import IntArray
 
 
 class CouplerMapping(MetaSwapPackage):
@@ -69,7 +70,7 @@ class CouplerMapping(MetaSwapPackage):
 
         self.dataset["mod_id"].values[:, idomain_top_active.values] = mod_id_1d
 
-    def _render(self, file, index, svat):
+    def _render(self, file, index, svat: xr.DataArray):
         self._create_mod_id_rch(svat)
         # package check only possible after calling _create_mod_id_rch
         self._pkgcheck()
@@ -101,13 +102,14 @@ class CouplerMapping(MetaSwapPackage):
 
     def _create_well_id(
         self, svat: xr.DataArray
-    ) -> tuple[np.ndarray[int], np.ndarray[int], np.ndarray[int]]:
+    ) -> tuple[IntArray, IntArray, IntArray]:
         """
         Get modflow indices, svats, and layer number for the wells
         """
         n_subunit = svat["subunit"].size
 
-        well_cellid = self.well["cellid"]
+        well = cast(Mf6Wel, self.well)
+        well_cellid = well.dataset["cellid"]
         if len(well_cellid.coords["dim_cellid"]) != 3:
             raise TypeError("Coupling to unstructured grids is not supported.")
 

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -103,22 +103,22 @@ class CouplerMapping(MetaSwapPackage):
         """
         n_subunit = svat["subunit"].size
 
-        well_mf_cellid = self.well["cellid"]
-        if len(well_mf_cellid.coords["nmax_cellid"]) != 3:
+        cellid = self.well["cellid"]
+        if len(cellid.coords["nmax_cellid"]) != 3:
             raise TypeError("Coupling to unstructured grids is not supported.")
 
-        well_layer = well_mf_cellid[0]
-        well_row = well_mf_cellid[1] - 1
-        well_column = well_mf_cellid[2] - 1
+        well_layer = cellid.sel(nmax_cellid="layer").data
+        well_row = cellid.sel(nmax_cellid="row").data - 1
+        well_column = cellid.sel(nmax_cellid="column").data - 1
 
         n_mod = self.idomain_active.sum()
         mod_id = xr.full_like(self.idomain_active, 0, dtype=np.int64)
-        mod_id.values[self.idomain_active.values] = np.arange(1, n_mod + 1)
+        mod_id.data[self.idomain_active.data] = np.arange(1, n_mod + 1)
 
-        well_mod_id = mod_id[well_layer - 1, well_row, well_column]
+        well_mod_id = mod_id.data[well_layer - 1, well_row, well_column]
         well_mod_id = np.tile(well_mod_id, (n_subunit, 1))
 
-        well_svat = svat.values[:, well_row, well_column]
+        well_svat = svat.data[:, well_row, well_column]
 
         well_active = well_svat != 0
 

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -21,7 +21,7 @@ class CouplerMapping(MetaSwapPackage):
     ----------
     modflow_dis: StructuredDiscretization
         Modflow 6 structured discretization
-    well: WellDisStructured (optional)
+    well: Mf6Wel (optional)
         If given, this parameter describes sprinkling of SVAT units from MODFLOW
         cells.
     """

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -108,12 +108,12 @@ class CouplerMapping(MetaSwapPackage):
         n_subunit = svat["subunit"].size
 
         well_cellid = self.well["cellid"]
-        if len(well_cellid.coords["nmax_cellid"]) != 3:
+        if len(well_cellid.coords["dim_cellid"]) != 3:
             raise TypeError("Coupling to unstructured grids is not supported.")
 
-        well_layer = well_cellid.sel(nmax_cellid="layer").data
-        well_row = well_cellid.sel(nmax_cellid="row").data - 1
-        well_column = well_cellid.sel(nmax_cellid="column").data - 1
+        well_layer = well_cellid.sel(dim_cellid="layer").data
+        well_row = well_cellid.sel(dim_cellid="row").data - 1
+        well_column = well_cellid.sel(dim_cellid="column").data - 1
 
         n_mod = self.idomain_active.sum()
         mod_id = xr.full_like(self.idomain_active, 0, dtype=np.int64)

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -99,7 +99,9 @@ class CouplerMapping(MetaSwapPackage):
 
         return self.write_dataframe_fixed_width(file, dataframe)
 
-    def _create_well_id(self, svat):
+    def _create_well_id(
+        self, svat: xr.DataArray
+    ) -> tuple[np.ndarray[int], np.ndarray[int], np.ndarray[int]]:
         """
         Get modflow indices, svats, and layer number for the wells
         """

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -45,6 +45,8 @@ class CouplerMapping(MetaSwapPackage):
     ):
         super().__init__()
 
+        if well and (not isinstance(well, Mf6Wel)):
+            raise TypeError(rf"well not of type 'Mf6Wel', got '{type(well)}'")
         self.well = well
         # Test if equal or larger than 1, to ignore idomain == -1 as well. Don't
         # assign to self.dataset, as grid extent might differ from svat when

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -105,13 +105,13 @@ class CouplerMapping(MetaSwapPackage):
         """
         n_subunit = svat["subunit"].size
 
-        cellid = self.well["cellid"]
-        if len(cellid.coords["nmax_cellid"]) != 3:
+        well_cellid = self.well["cellid"]
+        if len(well_cellid.coords["nmax_cellid"]) != 3:
             raise TypeError("Coupling to unstructured grids is not supported.")
 
-        well_layer = cellid.sel(nmax_cellid="layer").data
-        well_row = cellid.sel(nmax_cellid="row").data - 1
-        well_column = cellid.sel(nmax_cellid="column").data - 1
+        well_layer = well_cellid.sel(nmax_cellid="layer").data
+        well_row = well_cellid.sel(nmax_cellid="row").data - 1
+        well_column = well_cellid.sel(nmax_cellid="column").data - 1
 
         n_mod = self.idomain_active.sum()
         mod_id = xr.full_like(self.idomain_active, 0, dtype=np.int64)

--- a/imod/msw/sprinkling.py
+++ b/imod/msw/sprinkling.py
@@ -22,7 +22,7 @@ class Sprinkling(MetaSwapPackage):
     max_abstraction_surfacewater: array of floats (xr.DataArray)
         Describes the maximum abstraction of surfacewater to SVAT units in m3
         per day. This array must not have a subunit coordinate.
-    well: WellDisStructured
+    well: Mf6Wel
         Describes the sprinkling of SVAT units coming groundwater.
     """
 

--- a/imod/msw/sprinkling.py
+++ b/imod/msw/sprinkling.py
@@ -60,6 +60,8 @@ class Sprinkling(MetaSwapPackage):
         super().__init__()
         self.dataset["max_abstraction_groundwater_m3_d"] = max_abstraction_groundwater
         self.dataset["max_abstraction_surfacewater_m3_d"] = max_abstraction_surfacewater
+        if not isinstance(well, Mf6Wel):
+            raise TypeError(rf"well not of type 'Mf6Wel', got '{type(well)}'")
         self.well = well
 
         self._pkgcheck()

--- a/imod/msw/sprinkling.py
+++ b/imod/msw/sprinkling.py
@@ -67,13 +67,13 @@ class Sprinkling(MetaSwapPackage):
         self._pkgcheck()
 
     def _render(self, file, index, svat):
-        cellid = self.well["cellid"]
-        if len(cellid.coords["nmax_cellid"]) != 3:
+        well_cellid = self.well["cellid"]
+        if len(well_cellid.coords["nmax_cellid"]) != 3:
             raise TypeError("Coupling to unstructured grids is not supported.")
 
-        well_layer = cellid.sel(nmax_cellid="layer").data
-        well_row = cellid.sel(nmax_cellid="row").data - 1
-        well_column = cellid.sel(nmax_cellid="column").data - 1
+        well_layer = well_cellid.sel(nmax_cellid="layer").data
+        well_row = well_cellid.sel(nmax_cellid="row").data - 1
+        well_column = well_cellid.sel(nmax_cellid="column").data - 1
 
         n_subunit = svat["subunit"].size
 

--- a/imod/msw/sprinkling.py
+++ b/imod/msw/sprinkling.py
@@ -65,17 +65,17 @@ class Sprinkling(MetaSwapPackage):
         self._pkgcheck()
 
     def _render(self, file, index, svat):
-        well_mf_cellid = self.well["cellid"]
-        if len(well_mf_cellid.coords["nmax_cellid"]) != 3:
+        cellid = self.well["cellid"]
+        if len(cellid.coords["nmax_cellid"]) != 3:
             raise TypeError("Coupling to unstructured grids is not supported.")
 
-        well_layer = well_mf_cellid[0]
-        well_row = well_mf_cellid[1] - 1
-        well_column = well_mf_cellid[2] - 1
+        well_layer = cellid.sel(nmax_cellid="layer").data
+        well_row = cellid.sel(nmax_cellid="row").data - 1
+        well_column = cellid.sel(nmax_cellid="column").data - 1
 
         n_subunit = svat["subunit"].size
 
-        well_svat = svat.values[:, well_row, well_column]
+        well_svat = svat.data[:, well_row, well_column]
         well_active = well_svat != 0
 
         # Tile well_layers for each subunit
@@ -84,7 +84,7 @@ class Sprinkling(MetaSwapPackage):
         data_dict = {"svat": well_svat[well_active], "layer": layer[well_active]}
 
         for var in self._without_subunit:
-            well_arr = self.dataset[var].values[well_row, well_column]
+            well_arr = self.dataset[var].data[well_row, well_column]
             well_arr = np.tile(well_arr, (n_subunit, 1))
             data_dict[var] = well_arr[well_active]
 

--- a/imod/msw/sprinkling.py
+++ b/imod/msw/sprinkling.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from imod.mf6.wel import WellDisStructured
+from imod.mf6.mf6_wel_adapter import Mf6Wel
 from imod.msw.fixed_format import VariableMetaData
 from imod.msw.pkgbase import MetaSwapPackage
 
@@ -55,7 +55,7 @@ class Sprinkling(MetaSwapPackage):
         self,
         max_abstraction_groundwater: xr.DataArray,
         max_abstraction_surfacewater: xr.DataArray,
-        well: WellDisStructured,
+        well: Mf6Wel,
     ):
         super().__init__()
         self.dataset["max_abstraction_groundwater_m3_d"] = max_abstraction_groundwater
@@ -65,9 +65,13 @@ class Sprinkling(MetaSwapPackage):
         self._pkgcheck()
 
     def _render(self, file, index, svat):
-        well_row = self.well["row"] - 1
-        well_column = self.well["column"] - 1
-        well_layer = self.well["layer"]
+        well_mf_cellid = self.well["cellid"]
+        if len(well_mf_cellid.coords["nmax_cellid"]) != 3:
+            raise TypeError("Coupling to unstructured grids is not supported.")
+
+        well_layer = well_mf_cellid[0]
+        well_row = well_mf_cellid[1] - 1
+        well_column = well_mf_cellid[2] - 1
 
         n_subunit = svat["subunit"].size
 

--- a/imod/msw/sprinkling.py
+++ b/imod/msw/sprinkling.py
@@ -68,12 +68,12 @@ class Sprinkling(MetaSwapPackage):
 
     def _render(self, file, index, svat):
         well_cellid = self.well["cellid"]
-        if len(well_cellid.coords["nmax_cellid"]) != 3:
+        if len(well_cellid.coords["dim_cellid"]) != 3:
             raise TypeError("Coupling to unstructured grids is not supported.")
 
-        well_layer = well_cellid.sel(nmax_cellid="layer").data
-        well_row = well_cellid.sel(nmax_cellid="row").data - 1
-        well_column = well_cellid.sel(nmax_cellid="column").data - 1
+        well_layer = well_cellid.sel(dim_cellid="layer").data
+        well_row = well_cellid.sel(dim_cellid="row").data - 1
+        well_column = well_cellid.sel(dim_cellid="column").data - 1
 
         n_subunit = svat["subunit"].size
 

--- a/imod/tests/fixtures/mf6_welltest_fixture.py
+++ b/imod/tests/fixtures/mf6_welltest_fixture.py
@@ -18,8 +18,8 @@ def mf6wel_test_data_stationary():
             [2, 4, 6],
         ],
     )
-    coords = {"ncellid": np.arange(8) + 1, "nmax_cellid": ["layer", "row", "column"]}
-    cellid = xr.DataArray(cellid_values, coords=coords, dims=("ncellid", "nmax_cellid"))
+    coords = {"ncellid": np.arange(8) + 1, "dim_cellid": ["layer", "row", "column"]}
+    cellid = xr.DataArray(cellid_values, coords=coords, dims=("ncellid", "dim_cellid"))
     rate = xr.DataArray(
         [1.0] * 8, coords={"ncellid": np.arange(8) + 1}, dims=("ncellid",)
     )
@@ -40,8 +40,8 @@ def mf6wel_test_data_transient():
             [2, 4, 6],
         ],
     )
-    coords = {"ncellid": np.arange(8) + 1, "nmax_cellid": ["layer", "row", "column"]}
-    cellid = xr.DataArray(cellid_values, coords=coords, dims=("ncellid", "nmax_cellid"))
+    coords = {"ncellid": np.arange(8) + 1, "dim_cellid": ["layer", "row", "column"]}
+    cellid = xr.DataArray(cellid_values, coords=coords, dims=("ncellid", "dim_cellid"))
 
     rate = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
 

--- a/imod/tests/fixtures/msw_model_fixture.py
+++ b/imod/tests/fixtures/msw_model_fixture.py
@@ -5,6 +5,8 @@ import xarray as xr
 from numpy import nan
 
 from imod import mf6, msw
+from imod.mf6.mf6_wel_adapter import Mf6Wel
+from imod.mf6.wel import derive_cellid_from_points
 
 
 def make_coupled_mf6_model():
@@ -75,14 +77,13 @@ def make_coupled_mf6_model():
     # Create wells
     wel_layer = 3
 
-    ix = np.tile(np.arange(ncol) + 1, nrow)
-    iy = np.repeat(np.arange(nrow) + 1, ncol)
-    rate = np.zeros(ix.shape)
-    layer = np.full_like(ix, wel_layer)
+    well_x = np.tile(x, nrow)
+    well_y = np.repeat(y, ncol)
+    well_rate = np.zeros(well_x.shape)
+    well_layer = np.full_like(well_x, wel_layer)
 
-    gwf_model["wells_msw"] = mf6.WellDisStructured(
-        layer=layer, row=iy, column=ix, rate=rate
-    )
+    cellids = derive_cellid_from_points(idomain, well_x, well_y, well_layer)
+    gwf_model["well_msw"] = Mf6Wel(cellids, well_rate)
 
     # Attach it to a simulation
     simulation = mf6.Modflow6Simulation("test")
@@ -192,12 +193,13 @@ def make_msw_model():
 
     wel_layer = 3
 
-    ix = np.tile(np.arange(ncol) + 1, nrow)
-    iy = np.repeat(np.arange(nrow) + 1, ncol)
-    rate = np.zeros(ix.shape)
-    layer = np.full_like(ix, wel_layer)
+    well_x = np.tile(x, nrow)
+    well_y = np.repeat(y, ncol)
+    well_rate = np.zeros(well_x.shape)
+    well_layer = np.full_like(well_x, wel_layer)
 
-    well = mf6.WellDisStructured(layer=layer, row=iy, column=ix, rate=rate)
+    cellids = derive_cellid_from_points(active, well_x, well_y, well_layer).astype(int)
+    well = Mf6Wel(cellids, well_rate)
 
     # %% Modflow 6
     dz = np.array([1, 10, 100])

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -37,9 +37,9 @@ times = [
 class GridAgnosticWellCases:
     def case_well_stationary(self, well_high_lvl_test_data_stationary):
         obj = imod.mf6.Well(*well_high_lvl_test_data_stationary)
-        dims_expected = {
+        sizes_expected = {
             "ncellid": 8,
-            "nmax_cellid": 3,
+            "dim_cellid": 3,
             "species": 2,
         }
         cellid_expected = np.array(
@@ -56,7 +56,7 @@ class GridAgnosticWellCases:
             dtype=np.int64,
         )
         rate_expected = np.array(np.ones((8,), dtype=np.float32))
-        return obj, dims_expected, cellid_expected, rate_expected
+        return obj, sizes_expected, cellid_expected, rate_expected
 
     def case_well_stationary_multilevel(self, well_high_lvl_test_data_stationary):
         x, y, screen_top, _, rate_wel, concentration = (
@@ -64,9 +64,9 @@ class GridAgnosticWellCases:
         )
         screen_bottom = [-20.0] * 8
         obj = imod.mf6.Well(x, y, screen_top, screen_bottom, rate_wel, concentration)
-        dims_expected = {
+        sizes_expected = {
             "ncellid": 12,
-            "nmax_cellid": 3,
+            "dim_cellid": 3,
             "species": 2,
         }
         cellid_expected = np.array(
@@ -87,16 +87,16 @@ class GridAgnosticWellCases:
             dtype=np.int64,
         )
         rate_expected = np.array([0.25] * 4 + [0.75] * 4 + [1.0] * 4)
-        return obj, dims_expected, cellid_expected, rate_expected
+        return obj, sizes_expected, cellid_expected, rate_expected
 
     def case_well_point_filter(self, well_high_lvl_test_data_stationary):
         x, y, screen_point, _, rate_wel, concentration = (
             well_high_lvl_test_data_stationary
         )
         obj = imod.mf6.Well(x, y, screen_point, screen_point, rate_wel, concentration)
-        dims_expected = {
+        sizes_expected = {
             "ncellid": 8,
-            "nmax_cellid": 3,
+            "dim_cellid": 3,
             "species": 2,
         }
         cellid_expected = np.array(
@@ -113,14 +113,14 @@ class GridAgnosticWellCases:
             dtype=np.int64,
         )
         rate_expected = np.array(np.ones((8,), dtype=np.float32))
-        return obj, dims_expected, cellid_expected, rate_expected
+        return obj, sizes_expected, cellid_expected, rate_expected
 
     def case_well_transient(self, well_high_lvl_test_data_transient):
         obj = imod.mf6.Well(*well_high_lvl_test_data_transient)
-        dims_expected = {
+        sizes_expected = {
             "ncellid": 8,
             "time": 5,
-            "nmax_cellid": 3,
+            "dim_cellid": 3,
             "species": 2,
         }
         cellid_expected = np.array(
@@ -137,15 +137,15 @@ class GridAgnosticWellCases:
             dtype=np.int64,
         )
         rate_expected = np.outer(np.ones((8,), dtype=np.float32), np.arange(5) + 1)
-        return obj, dims_expected, cellid_expected, rate_expected
+        return obj, sizes_expected, cellid_expected, rate_expected
 
     def case_layered_well_stationary(self, well_high_lvl_test_data_stationary):
         x, y, _, _, rate_wel, concentration = well_high_lvl_test_data_stationary
         layer = [1, 1, 1, 1, 2, 2, 2, 2]
         obj = imod.mf6.LayeredWell(x, y, layer, rate_wel, concentration)
-        dims_expected = {
+        sizes_expected = {
             "ncellid": 8,
-            "nmax_cellid": 3,
+            "dim_cellid": 3,
             "species": 2,
         }
         cellid_expected = np.array(
@@ -162,16 +162,16 @@ class GridAgnosticWellCases:
             dtype=np.int64,
         )
         rate_expected = np.array(np.ones((8,), dtype=np.float32))
-        return obj, dims_expected, cellid_expected, rate_expected
+        return obj, sizes_expected, cellid_expected, rate_expected
 
     def case_layered_well_transient(self, well_high_lvl_test_data_transient):
         x, y, _, _, rate_wel, concentration = well_high_lvl_test_data_transient
         layer = [1, 1, 1, 1, 2, 2, 2, 2]
         obj = imod.mf6.LayeredWell(x, y, layer, rate_wel, concentration)
-        dims_expected = {
+        sizes_expected = {
             "ncellid": 8,
             "time": 5,
-            "nmax_cellid": 3,
+            "dim_cellid": 3,
             "species": 2,
         }
         cellid_expected = np.array(
@@ -188,28 +188,28 @@ class GridAgnosticWellCases:
             dtype=np.int64,
         )
         rate_expected = np.outer(np.ones((8,), dtype=np.float32), np.arange(5) + 1)
-        return obj, dims_expected, cellid_expected, rate_expected
+        return obj, sizes_expected, cellid_expected, rate_expected
 
 
 @parametrize_with_cases(
-    ["wel", "dims_expected", "cellid_expected", "rate_expected"],
+    ["wel", "sizes_expected", "cellid_expected", "rate_expected"],
     cases=GridAgnosticWellCases,
 )
-def test_to_mf6_pkg(basic_dis, wel, dims_expected, cellid_expected, rate_expected):
+def test_to_mf6_pkg(basic_dis, wel, sizes_expected, cellid_expected, rate_expected):
     # Arrange
     idomain, top, bottom = basic_dis
     active = idomain == 1
     k = xr.ones_like(idomain)
 
-    nmax_cellid_expected = np.array(["layer", "row", "column"])
+    dim_cellid_expected = np.array(["layer", "row", "column"])
 
     # Act
     mf6_wel = wel.to_mf6_pkg(active, top, bottom, k)
     mf6_ds = mf6_wel.dataset
 
     # Assert
-    assert dict(mf6_ds.dims) == dims_expected
-    np.testing.assert_equal(mf6_ds.coords["nmax_cellid"].values, nmax_cellid_expected)
+    assert dict(mf6_ds.sizes) == sizes_expected
+    np.testing.assert_equal(mf6_ds.coords["dim_cellid"].values, dim_cellid_expected)
     np.testing.assert_equal(mf6_ds["cellid"].values, cellid_expected)
     np.testing.assert_equal(mf6_ds["rate"].values, rate_expected)
 
@@ -692,7 +692,7 @@ def test_derive_cellid_from_points(basic_dis, well_high_lvl_test_data_stationary
     x, y, _, _, _, _ = well_high_lvl_test_data_stationary
     layer = [1, 1, 1, 1, 2, 2, 2, 2]
 
-    nmax_cellid_expected = np.array(["layer", "row", "column"])
+    dim_cellid_expected = np.array(["layer", "row", "column"])
     cellid_expected = np.array(
         [
             [1, 1, 9],
@@ -712,7 +712,7 @@ def test_derive_cellid_from_points(basic_dis, well_high_lvl_test_data_stationary
 
     # Assert
     np.testing.assert_array_equal(cellid, cellid_expected)
-    np.testing.assert_equal(cellid.coords["nmax_cellid"].values, nmax_cellid_expected)
+    np.testing.assert_equal(cellid.coords["dim_cellid"].values, dim_cellid_expected)
 
 
 def test_render__stationary(well_test_data_stationary):

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -19,7 +19,7 @@ from imod.logging.loglevel import LogLevel
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.npf import NodePropertyFlow
 from imod.mf6.utilities.grid import broadcast_to_full_domain
-from imod.mf6.wel import LayeredWell, Well
+from imod.mf6.wel import LayeredWell, Well, derive_cellid_from_points
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.tests.fixtures.flow_basic_fixture import BasicDisSettings
@@ -708,7 +708,7 @@ def test_derive_cellid_from_points(basic_dis, well_high_lvl_test_data_stationary
     )
 
     # Act
-    cellid = imod.mf6.wel.Well._derive_cellid_from_points(idomain, x, y, layer)
+    cellid = derive_cellid_from_points(idomain, x, y, layer)
 
     # Assert
     np.testing.assert_array_equal(cellid, cellid_expected)

--- a/imod/tests/test_mf6/test_mf6_wel_lowlvl.py
+++ b/imod/tests/test_mf6/test_mf6_wel_lowlvl.py
@@ -185,7 +185,7 @@ def test_remove_inactive__stationary(basic_dis, mf6wel_test_data_stationary):
     ds_removed = imod.mf6.utilities.dataset.remove_inactive(ds, active)
 
     # Assert
-    assert dict(ds_removed.dims) == {"ncellid": 6, "nmax_cellid": 3}
+    assert dict(ds_removed.dims) == {"ncellid": 6, "dim_cellid": 3}
 
 
 def test_remove_inactive__transient(basic_dis, mf6wel_test_data_transient):
@@ -203,4 +203,4 @@ def test_remove_inactive__transient(basic_dis, mf6wel_test_data_transient):
     ds_removed = imod.mf6.utilities.dataset.remove_inactive(ds, active)
 
     # Assert
-    assert dict(ds_removed.dims) == {"ncellid": 6, "time": 5, "nmax_cellid": 3}
+    assert dict(ds_removed.dims) == {"ncellid": 6, "time": 5, "dim_cellid": 3}

--- a/imod/tests/test_msw/test_coupler_mapping.py
+++ b/imod/tests/test_msw/test_coupler_mapping.py
@@ -6,6 +6,8 @@ import xarray as xr
 from numpy.testing import assert_equal
 
 from imod import mf6, msw
+from imod.mf6.mf6_wel_adapter import Mf6Wel
+from imod.mf6.wel import derive_cellid_from_points
 
 
 def test_simple_model_with_sprinkling(fixed_format_parser):
@@ -35,15 +37,11 @@ def test_simple_model_with_sprinkling(fixed_format_parser):
 
     # Well
     well_layer = [3, 2, 1]
-    well_row = [1, 2, 3]
-    well_column = [2, 2, 2]
+    well_y = y
+    well_x = [2.0, 2.0, 2.0]
     well_rate = [-5.0] * 3
-    well = mf6.WellDisStructured(
-        layer=well_layer,
-        row=well_row,
-        column=well_column,
-        rate=well_rate,
-    )
+    cellids = derive_cellid_from_points(svat, well_x, well_y, well_layer)
+    well = Mf6Wel(cellids, well_rate)
 
     like = xr.full_like(svat.sel(subunit=1, drop=True), 1.0, dtype=float).expand_dims(
         layer=[1, 2, 3]
@@ -94,15 +92,11 @@ def test_simple_model_with_sprinkling_1_subunit(fixed_format_parser):
 
     # Well
     well_layer = [3, 2]
-    well_row = [1, 3]
-    well_column = [2, 2]
+    well_y = [3.0, 1.0]
+    well_x = [2.0, 2.0]
     well_rate = [-5.0] * 2
-    well = mf6.WellDisStructured(
-        layer=well_layer,
-        row=well_row,
-        column=well_column,
-        rate=well_rate,
-    )
+    cellids = derive_cellid_from_points(svat, well_x, well_y, well_layer)
+    well = Mf6Wel(cellids, well_rate)
 
     like = xr.full_like(svat.sel(subunit=0, drop=True), 1.0, dtype=float).expand_dims(
         layer=[1, 2, 3]

--- a/imod/tests/test_msw/test_sprinkling.py
+++ b/imod/tests/test_msw/test_sprinkling.py
@@ -6,7 +6,9 @@ import xarray as xr
 from numpy import nan
 from numpy.testing import assert_almost_equal, assert_equal
 
-from imod import mf6, msw
+from imod import msw
+from imod.mf6.mf6_wel_adapter import Mf6Wel
+from imod.mf6.wel import derive_cellid_from_points
 
 
 def test_simple_model(fixed_format_parser):
@@ -54,15 +56,11 @@ def test_simple_model(fixed_format_parser):
 
     # Well
     well_layer = [3, 2, 1]
-    well_row = [1, 2, 3]
-    well_column = [2, 2, 2]
+    well_y = y
+    well_x = [2.0, 2.0, 2.0]
     well_rate = [-5.0] * 3
-    well = mf6.WellDisStructured(
-        layer=well_layer,
-        row=well_row,
-        column=well_column,
-        rate=well_rate,
-    )
+    cellids = derive_cellid_from_points(svat, well_x, well_y, well_layer)
+    well = Mf6Wel(cellids, well_rate)
 
     coupler_mapping = msw.Sprinkling(
         max_abstraction_groundwater,
@@ -132,15 +130,11 @@ def test_simple_model_1_subunit(fixed_format_parser):
 
     # Well
     well_layer = [3, 2]
-    well_row = [1, 3]
-    well_column = [2, 2]
+    well_y = [1.0, 3.0]
+    well_x = [2.0, 2.0]
     well_rate = [-5.0] * 2
-    well = mf6.WellDisStructured(
-        layer=well_layer,
-        row=well_row,
-        column=well_column,
-        rate=well_rate,
-    )
+    cellids = derive_cellid_from_points(svat, well_x, well_y, well_layer)
+    well = Mf6Wel(cellids, well_rate)
 
     coupler_mapping = msw.Sprinkling(
         max_abstraction_groundwater,

--- a/imod/typing/__init__.py
+++ b/imod/typing/__init__.py
@@ -7,14 +7,15 @@ from typing import TYPE_CHECKING, TypeAlias, TypeVar, Union
 import numpy as np
 import xarray as xr
 import xugrid as xu
+from numpy.typing import NDArray
 
 GridDataArray: TypeAlias = Union[xr.DataArray, xu.UgridDataArray]
 GridDataset: TypeAlias = Union[xr.Dataset, xu.UgridDataset]
 ScalarAsDataArray: TypeAlias = Union[xr.DataArray, xu.UgridDataArray]
 ScalarAsDataset: TypeAlias = Union[xr.Dataset, xu.UgridDataset]
 UnstructuredData: TypeAlias = Union[xu.UgridDataset, xu.UgridDataArray]
-FloatArray: TypeAlias = np.ndarray
-IntArray: TypeAlias = np.ndarray
+FloatArray: TypeAlias = NDArray[np.floating]
+IntArray: TypeAlias = NDArray[np.int_]
 
 
 # Types for optional dependencies.


### PR DESCRIPTION
Fixes #728

# Description
This PR updates two MetaSWAP packages that depend on wells to use of the deprecated ``WellDisStructured`` object to the ``Mf6Wel`` object.

It fixes the first small step of the big metaswap refactor. I chose a feature branch as base branch to merge into, to still have the option to create some hotfixes for a new release of iMOD Python while primod is being updated.

I also renamed some variable names and dimension names with clearer names. Furthermore, I type annotated some method.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
