### PR TITLE
Issue #1255 msw refactor mf6 obj at write

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -13,9 +13,20 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 Changed
 ~~~~~~~
 
+- :class:`imod.msw.CouplingMapping`, :class:`imod.msw.Sprinkling`,
+  `imod.msw.Sprinkling.MetaSwapModel`, now take the
+  :class:`imod.mf6.mf6_wel_adapter.Mf6Wel` and the
+  :class:`imod.mf6.StructuredDiscretization` packages as arguments at their
+  respective ``write`` method, instead of upon initializing these MetaSWAP
+  objects.
 - :class:`imod.msw.CouplingMapping` and :class:`imod.msw.Sprinkling` now take
   the :class:`imod.mf6.mf6_wel_adapter.Mf6Wel` as well argument instead of the
   deprecated :class:`imod.mf6.WellDisStructured`.
+
+Added
+~~~~~
+
+- :meth:`imod.msw.MetaSwapModel.regrid_like` to regrid MetaSWAP models.
 
 
 [Unreleased]
@@ -97,9 +108,7 @@ Added
   :meth:`imod.mf6.GeneralHeadboundary.cleanup`, :meth:`imod.mf6.River.cleanup`,
   :meth:`imod.mf6.Well.cleanup` convenience methods to call the corresponding
   cleanup utility functions with the appropriate arguments.
-- :meth:`imod.msw.MetaSwapModel.regrid_like` to regrid MetaSWAP models. This is
-  still experimental functionality, regridding the :class:`imod.msw.Sprinkling`
-  is not yet supported.
+
 
 Removed
 ~~~~~~~

--- a/examples/metaswap/read_metaswap_file.py
+++ b/examples/metaswap/read_metaswap_file.py
@@ -75,7 +75,7 @@ landuse_options = imod.msw.LanduseOptions(
 directory = imod.util.temporary_directory()
 os.makedirs(directory)
 
-landuse_options.write(directory, None, None)
+landuse_options.write(directory, None, None, None, None)
 
 # %%
 # Reading the .inp file

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -283,7 +283,7 @@ def derive_cellid_from_points(
     }
     cellid = cellid.assign_coords(coords=xy_coords)
 
-    return cellid
+    return cellid.astype(int)
 
 
 class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -7,7 +7,7 @@ import xarray as xr
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.mf6_wel_adapter import Mf6Wel
 from imod.msw.fixed_format import VariableMetaData
-from imod.msw.pkgbase import MetaSwapPackage
+from imod.msw.pkgbase import DataDictType, MetaSwapPackage
 from imod.typing import IntArray
 
 
@@ -70,12 +70,12 @@ class CouplerMapping(MetaSwapPackage):
 
         self.dataset["mod_id"].values[:, idomain_top_active.values] = mod_id_1d
 
-    def _render(self, file: TextIO, index: np.ndarray, svat: xr.DataArray):
+    def _render(self, file: TextIO, index: IntArray, svat: xr.DataArray):
         self._create_mod_id_rch(svat)
         # package check only possible after calling _create_mod_id_rch
         self._pkgcheck()
 
-        data_dict = {"svat": svat.values.ravel()[index]}
+        data_dict: DataDictType = {"svat": svat.values.ravel()[index]}
 
         data_dict["layer"] = np.full_like(data_dict["svat"], 1)
 

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -73,7 +73,6 @@ class CouplerMapping(MetaSwapPackage):
         idomain_top_active = idomain_active.sel(layer=1, drop=True)
         mod_id = self._create_mod_id_rch(svat, idomain_top_active)
 
-        # package check only possible after calling _create_mod_id_rch
         self._pkgcheck()
 
         data_dict: DataDictType = {"svat": svat.values.ravel()[index]}

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import Optional, TextIO, cast
 
 import numpy as np
 import pandas as pd
@@ -70,7 +70,7 @@ class CouplerMapping(MetaSwapPackage):
 
         self.dataset["mod_id"].values[:, idomain_top_active.values] = mod_id_1d
 
-    def _render(self, file, index, svat: xr.DataArray):
+    def _render(self, file: TextIO, index: np.ndarray, svat: xr.DataArray):
         self._create_mod_id_rch(svat)
         # package check only possible after calling _create_mod_id_rch
         self._pkgcheck()

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -28,7 +28,7 @@ class CouplerMapping(MetaSwapPackage):
         "layer": VariableMetaData(5, 0, 9999, int),
     }
 
-    _with_subunit = ("mod_id",)
+    _with_subunit = ()
     _without_subunit = ()
     _to_fill = ("free",)
 

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -1,4 +1,4 @@
-from typing import Optional, TextIO, cast
+from typing import Any, TextIO
 
 import numpy as np
 import pandas as pd
@@ -18,13 +18,6 @@ class CouplerMapping(MetaSwapPackage):
     This class is responsible for the file `mod2svat.inp`. It also includes
     connection to wells.
 
-    Parameters
-    ----------
-    modflow_dis: StructuredDiscretization
-        Modflow 6 structured discretization
-    well: Mf6Wel (optional)
-        If given, this parameter describes sprinkling of SVAT units from MODFLOW
-        cells.
     """
 
     _file_name = "mod2svat.inp"
@@ -41,53 +34,57 @@ class CouplerMapping(MetaSwapPackage):
 
     def __init__(
         self,
-        modflow_dis: StructuredDiscretization,
-        well: Optional[Mf6Wel] = None,
     ):
         super().__init__()
 
-        if well and (not isinstance(well, Mf6Wel)):
-            raise TypeError(rf"well not of type 'Mf6Wel', got '{type(well)}'")
-        self.well = well
-        # Test if equal or larger than 1, to ignore idomain == -1 as well. Don't
-        # assign to self.dataset, as grid extent might differ from svat when
-        # MetaSWAP only covers part of the Modflow grid domain.
-        self.idomain_active = modflow_dis["idomain"] >= 1
-
-    def _create_mod_id_rch(self, svat):
+    def _create_mod_id_rch(
+        self, svat: xr.DataArray, idomain_top_active: xr.DataArray
+    ) -> xr.DataArray:
         """
         Create modflow indices for the recharge layer, which is where
         infiltration will take place.
         """
-        self.dataset["mod_id"] = xr.full_like(svat, fill_value=0, dtype=np.int64)
+        mod_id = xr.full_like(svat, fill_value=0, dtype=np.int64)
         n_subunit = svat["subunit"].size
-        idomain_top_active = self.idomain_active.sel(layer=1, drop=True)
 
         n_mod_top = idomain_top_active.sum()
 
         # idomain does not have a subunit dimension, so tile for n_subunits
-        mod_id_1d = np.tile(np.arange(1, n_mod_top + 1), (n_subunit, 1))
+        mod_id_1d: IntArray = np.tile(np.arange(1, n_mod_top + 1), (n_subunit, 1))
 
-        self.dataset["mod_id"].values[:, idomain_top_active.values] = mod_id_1d
+        mod_id.data[:, idomain_top_active.data] = mod_id_1d
+        return mod_id
 
-    def _render(self, file: TextIO, index: IntArray, svat: xr.DataArray):
-        self._create_mod_id_rch(svat)
+    def _render(
+        self,
+        file: TextIO,
+        index: IntArray,
+        svat: xr.DataArray,
+        mf6_dis: StructuredDiscretization,
+        mf6_well: Mf6Wel,
+        *args: Any,
+    ):
+        if mf6_well and (not isinstance(mf6_well, Mf6Wel)):
+            raise TypeError(rf"mf6_well not of type 'Mf6Wel', got '{type(mf6_well)}'")
+        # Test if equal or larger than 1, to ignore idomain == -1 as well. Don't
+        # assign to self.dataset, as grid extent might differ from svat when
+        # MetaSWAP only covers part of the Modflow grid domain.
+        idomain_active = mf6_dis["idomain"] >= 1
+        idomain_top_active = idomain_active.sel(layer=1, drop=True)
+        mod_id = self._create_mod_id_rch(svat, idomain_top_active)
+
         # package check only possible after calling _create_mod_id_rch
         self._pkgcheck()
 
         data_dict: DataDictType = {"svat": svat.values.ravel()[index]}
-
         data_dict["layer"] = np.full_like(data_dict["svat"], 1)
-
-        for var in self._with_subunit:
-            data_dict[var] = self._index_da(self.dataset[var], index)
+        data_dict["mod_id"] = self._index_da(mod_id, index)
 
         # Get well values
-        if self.well:
-            mod_id_well, svat_well, layer_well = self._create_well_id(svat)
-            data_dict["mod_id"] = np.append(mod_id_well, data_dict["mod_id"])
-            data_dict["svat"] = np.append(svat_well, data_dict["svat"])
-            data_dict["layer"] = np.append(layer_well, data_dict["layer"])
+        if mf6_well:
+            well_data_dict = self._create_well_id(svat, idomain_active, mf6_well)
+            for key in data_dict.keys():
+                data_dict[key] = np.append(well_data_dict[key], data_dict[key])
 
         for var in self._to_fill:
             data_dict[var] = ""
@@ -101,15 +98,17 @@ class CouplerMapping(MetaSwapPackage):
         return self.write_dataframe_fixed_width(file, dataframe)
 
     def _create_well_id(
-        self, svat: xr.DataArray
-    ) -> tuple[IntArray, IntArray, IntArray]:
+        self,
+        svat: xr.DataArray,
+        idomain_active: xr.DataArray,
+        mf6_well: Mf6Wel,
+    ) -> DataDictType:
         """
         Get modflow indices, svats, and layer number for the wells
         """
         n_subunit = svat["subunit"].size
 
-        well = cast(Mf6Wel, self.well)
-        well_cellid = well.dataset["cellid"]
+        well_cellid = mf6_well.dataset["cellid"]
         if len(well_cellid.coords["dim_cellid"]) != 3:
             raise TypeError("Coupling to unstructured grids is not supported.")
 
@@ -117,9 +116,9 @@ class CouplerMapping(MetaSwapPackage):
         well_row = well_cellid.sel(dim_cellid="row").data - 1
         well_column = well_cellid.sel(dim_cellid="column").data - 1
 
-        n_mod = self.idomain_active.sum()
-        mod_id = xr.full_like(self.idomain_active, 0, dtype=np.int64)
-        mod_id.data[self.idomain_active.data] = np.arange(1, n_mod + 1)
+        n_mod = idomain_active.sum()
+        mod_id = xr.full_like(idomain_active, 0, dtype=np.int64)
+        mod_id.data[idomain_active.data] = np.arange(1, n_mod + 1)
 
         well_mod_id = mod_id.data[well_layer - 1, well_row, well_column]
         well_mod_id = np.tile(well_mod_id, (n_subunit, 1))
@@ -135,7 +134,7 @@ class CouplerMapping(MetaSwapPackage):
         layer = np.tile(well_layer, (n_subunit, 1))
         layer_1d = layer[well_active]
 
-        return (well_mod_id_1d, well_svat_1d, layer_1d)
+        return {"mod_id": well_mod_id_1d, "svat": well_svat_1d, "layer": layer_1d}
 
     def is_regridding_supported(self) -> bool:
         return False

--- a/imod/msw/initial_conditions.py
+++ b/imod/msw/initial_conditions.py
@@ -1,6 +1,6 @@
 import pathlib
 import shutil
-from typing import TextIO
+from typing import Any, TextIO
 
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.msw.fixed_format import VariableMetaData
@@ -24,7 +24,7 @@ class InitialConditionsEquilibrium(MetaSwapPackage, IRegridPackage):
     def __init__(self):
         super().__init__()
 
-    def _render(self, file: TextIO, *args):
+    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
         file.write(self._option + "\n")
 
 
@@ -51,7 +51,7 @@ class InitialConditionsRootzonePressureHead(MetaSwapPackage, IRegridPackage):
         super().__init__()
         self.dataset["initial_pF"] = initial_pF
 
-    def _render(self, file: TextIO, *args):
+    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
         file.write(self._option + "\n")
 
         dataframe = self.dataset.assign_coords(index=[0]).to_dataframe()
@@ -79,7 +79,7 @@ class InitialConditionsPercolation(MetaSwapPackage, IRegridPackage):
     def __init__(self):
         super().__init__()
 
-    def _render(self, file: TextIO, *args):
+    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
         file.write(self._option + "\n")
 
 

--- a/imod/msw/initial_conditions.py
+++ b/imod/msw/initial_conditions.py
@@ -24,7 +24,7 @@ class InitialConditionsEquilibrium(MetaSwapPackage, IRegridPackage):
     def __init__(self):
         super().__init__()
 
-    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
+    def _render(self, file: TextIO, *args: Any):
         file.write(self._option + "\n")
 
 
@@ -51,7 +51,7 @@ class InitialConditionsRootzonePressureHead(MetaSwapPackage, IRegridPackage):
         super().__init__()
         self.dataset["initial_pF"] = initial_pF
 
-    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
+    def _render(self, file: TextIO, *args: Any):
         file.write(self._option + "\n")
 
         dataframe = self.dataset.assign_coords(index=[0]).to_dataframe()
@@ -79,7 +79,7 @@ class InitialConditionsPercolation(MetaSwapPackage, IRegridPackage):
     def __init__(self):
         super().__init__()
 
-    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
+    def _render(self, file: TextIO, *args: Any):
         file.write(self._option + "\n")
 
 

--- a/imod/msw/initial_conditions.py
+++ b/imod/msw/initial_conditions.py
@@ -1,5 +1,6 @@
 import pathlib
 import shutil
+from typing import TextIO
 
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.msw.fixed_format import VariableMetaData
@@ -23,7 +24,7 @@ class InitialConditionsEquilibrium(MetaSwapPackage, IRegridPackage):
     def __init__(self):
         super().__init__()
 
-    def _render(self, file, *args):
+    def _render(self, file: TextIO, *args):
         file.write(self._option + "\n")
 
 
@@ -50,7 +51,7 @@ class InitialConditionsRootzonePressureHead(MetaSwapPackage, IRegridPackage):
         super().__init__()
         self.dataset["initial_pF"] = initial_pF
 
-    def _render(self, file, *args):
+    def _render(self, file: TextIO, *args):
         file.write(self._option + "\n")
 
         dataframe = self.dataset.assign_coords(index=[0]).to_dataframe()
@@ -78,7 +79,7 @@ class InitialConditionsPercolation(MetaSwapPackage, IRegridPackage):
     def __init__(self):
         super().__init__()
 
-    def _render(self, file, *args):
+    def _render(self, file: TextIO, *args):
         file.write(self._option + "\n")
 
 

--- a/imod/msw/landuse.py
+++ b/imod/msw/landuse.py
@@ -1,4 +1,4 @@
-from typing import TextIO
+from typing import Any, TextIO
 
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.msw.fixed_format import VariableMetaData
@@ -195,7 +195,7 @@ class LanduseOptions(MetaSwapPackage, IRegridPackage):
 
         self._pkgcheck()
 
-    def _render(self, file: TextIO, *args):
+    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
         dataframe = self.dataset.to_dataframe(
             dim_order=("landuse_index",)
         ).reset_index()

--- a/imod/msw/landuse.py
+++ b/imod/msw/landuse.py
@@ -1,3 +1,5 @@
+from typing import TextIO
+
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.msw.fixed_format import VariableMetaData
 from imod.msw.pkgbase import MetaSwapPackage
@@ -193,7 +195,7 @@ class LanduseOptions(MetaSwapPackage, IRegridPackage):
 
         self._pkgcheck()
 
-    def _render(self, file, *args):
+    def _render(self, file: TextIO, *args):
         dataframe = self.dataset.to_dataframe(
             dim_order=("landuse_index",)
         ).reset_index()

--- a/imod/msw/landuse.py
+++ b/imod/msw/landuse.py
@@ -195,7 +195,7 @@ class LanduseOptions(MetaSwapPackage, IRegridPackage):
 
         self._pkgcheck()
 
-    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
+    def _render(self, file: TextIO, *args: Any):
         dataframe = self.dataset.to_dataframe(
             dim_order=("landuse_index",)
         ).reset_index()

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Optional
+from typing import Optional, TextIO
 
 import numpy as np
 import pandas as pd
@@ -21,10 +21,12 @@ class MeteoMapping(MetaSwapPackage):
     new packages.
     """
 
+    meteo: GridDataArray
+
     def __init__(self):
         super().__init__()
 
-    def _render(self, file, index, svat):
+    def _render(self, file: TextIO, index: np.ndarray, svat: xr.DataArray):
         data_dict = {"svat": svat.values.ravel()[index]}
 
         row, column = self.grid_mapping(svat, self.meteo)

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -32,7 +32,6 @@ class MeteoMapping(MetaSwapPackage):
         index: IntArray,
         svat: xr.DataArray,
         *args: Any,
-        **kwargs: Any,
     ):
         data_dict = {"svat": svat.values.ravel()[index]}
 

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -9,7 +9,7 @@ from imod.mf6.utilities.regrid import RegridderWeightsCache
 from imod.msw.fixed_format import VariableMetaData
 from imod.msw.pkgbase import MetaSwapPackage
 from imod.prepare import common
-from imod.typing import GridDataArray
+from imod.typing import GridDataArray, IntArray
 from imod.util.regrid_method_type import RegridMethodType
 
 
@@ -26,7 +26,7 @@ class MeteoMapping(MetaSwapPackage):
     def __init__(self):
         super().__init__()
 
-    def _render(self, file: TextIO, index: np.ndarray, svat: xr.DataArray):
+    def _render(self, file: TextIO, index: IntArray, svat: xr.DataArray):
         data_dict = {"svat": svat.values.ravel()[index]}
 
         row, column = self.grid_mapping(svat, self.meteo)

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Optional, TextIO
+from typing import Any, Optional, TextIO
 
 import numpy as np
 import pandas as pd
@@ -26,7 +26,14 @@ class MeteoMapping(MetaSwapPackage):
     def __init__(self):
         super().__init__()
 
-    def _render(self, file: TextIO, index: IntArray, svat: xr.DataArray):
+    def _render(
+        self,
+        file: TextIO,
+        index: IntArray,
+        svat: xr.DataArray,
+        *args: Any,
+        **kwargs: Any,
+    ):
         data_dict = {"svat": svat.values.ravel()[index]}
 
         row, column = self.grid_mapping(svat, self.meteo)

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -251,7 +251,7 @@ class MetaSwapModel(Model):
         # write package contents
         for pkgname in self:
             self[pkgname].write(
-                directory, index, svat, mf6_dis=mf6_dis, mf6_wel=mf6_wel
+                directory, index, svat, mf6_dis, mf6_wel
             )
 
     def regrid_like(

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -106,7 +106,7 @@ class MetaSwapModel(Model):
             self._render_unsaturated_database_path(unsaturated_database)
         )
 
-    def _render_unsaturated_database_path(self, unsaturated_database):
+    def _render_unsaturated_database_path(self, unsaturated_database: Union[str, Path]):
         # Force to Path object
         unsaturated_database = Path(unsaturated_database)
 

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -6,7 +6,8 @@ from typing import Optional, Tuple, Union
 import jinja2
 import numpy as np
 
-from imod import mf6
+from imod.mf6.dis import StructuredDiscretization
+from imod.mf6.mf6_wel_adapter import Mf6Wel
 from imod.mf6.utilities.regrid import RegridderWeightsCache
 from imod.msw.coupler_mapping import CouplerMapping
 from imod.msw.grid_data import GridData
@@ -204,7 +205,12 @@ class MetaSwapModel(Model):
         if not optional_package:
             raise KeyError(f"Could not find package of type: {pkg_type}")
 
-    def write(self, directory: Union[str, Path]):
+    def write(
+        self,
+        directory: Union[str, Path],
+        mf6_dis: StructuredDiscretization,
+        mf6_wel: Mf6Wel,
+    ):
         """
         Write packages and simulation settings (para_sim.inp).
 
@@ -244,11 +250,13 @@ class MetaSwapModel(Model):
 
         # write package contents
         for pkgname in self:
-            self[pkgname].write(directory, index, svat)
+            self[pkgname].write(
+                directory, index, svat, mf6_dis=mf6_dis, mf6_wel=mf6_wel
+            )
 
     def regrid_like(
         self,
-        mf6_regridded_dis: mf6.StructuredDiscretization,
+        mf6_regridded_dis: StructuredDiscretization,
         regrid_context: Optional[RegridderWeightsCache] = None,
         regridder_types: Optional[dict[str, Tuple[RegridderType, str]]] = None,
     ) -> "MetaSwapModel":
@@ -273,6 +281,6 @@ class MetaSwapModel(Model):
                 raise ValueError(f"package {pkgname} cannot be  regridded")
             regridded_model[pkgname] = regridded_package
         if mod2svat_name is not None:
-            regridded_model[mod2svat_name] = CouplerMapping(mf6_regridded_dis)
+            regridded_model[mod2svat_name] = CouplerMapping()
 
         return regridded_model

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -250,9 +250,7 @@ class MetaSwapModel(Model):
 
         # write package contents
         for pkgname in self:
-            self[pkgname].write(
-                directory, index, svat, mf6_dis, mf6_wel
-            )
+            self[pkgname].write(directory, index, svat, mf6_dis, mf6_wel)
 
     def regrid_like(
         self,

--- a/imod/msw/output_control.py
+++ b/imod/msw/output_control.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Optional, TextIO
+from typing import Any, Optional, TextIO
 
 import pandas as pd
 
@@ -87,7 +87,7 @@ class VariableOutputControl(MetaSwapPackage, IRegridPackage):
         for key, value in kwargs.items():
             self.dataset[key] = int(value)
 
-    def _render(self, file: TextIO, *args):
+    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
         variable, option = zip(
             *[(var, self.dataset[var].values) for var in self.dataset.data_vars]
         )
@@ -125,7 +125,7 @@ class TimeOutputControl(MetaSwapPackage, IRegridPackage):
 
         self.dataset["times"] = time
 
-    def _render(self, file: TextIO, *args):
+    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
         year, time_since_start_year = to_metaswap_timeformat(self.dataset["times"])
 
         dataframe = pd.DataFrame(

--- a/imod/msw/output_control.py
+++ b/imod/msw/output_control.py
@@ -87,7 +87,7 @@ class VariableOutputControl(MetaSwapPackage, IRegridPackage):
         for key, value in kwargs.items():
             self.dataset[key] = int(value)
 
-    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
+    def _render(self, file: TextIO, *args: Any):
         variable, option = zip(
             *[(var, self.dataset[var].values) for var in self.dataset.data_vars]
         )

--- a/imod/msw/output_control.py
+++ b/imod/msw/output_control.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Optional
+from typing import Optional, TextIO
 
 import pandas as pd
 
@@ -87,7 +87,7 @@ class VariableOutputControl(MetaSwapPackage, IRegridPackage):
         for key, value in kwargs.items():
             self.dataset[key] = int(value)
 
-    def _render(self, file, *args):
+    def _render(self, file: TextIO, *args):
         variable, option = zip(
             *[(var, self.dataset[var].values) for var in self.dataset.data_vars]
         )
@@ -125,7 +125,7 @@ class TimeOutputControl(MetaSwapPackage, IRegridPackage):
 
         self.dataset["times"] = time
 
-    def _render(self, file, *args):
+    def _render(self, file: TextIO, *args):
         year, time_since_start_year = to_metaswap_timeformat(self.dataset["times"])
 
         dataframe = pd.DataFrame(

--- a/imod/msw/output_control.py
+++ b/imod/msw/output_control.py
@@ -125,7 +125,7 @@ class TimeOutputControl(MetaSwapPackage, IRegridPackage):
 
         self.dataset["times"] = time
 
-    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
+    def _render(self, file: TextIO, *args: Any):
         year, time_since_start_year = to_metaswap_timeformat(self.dataset["times"])
 
         dataframe = pd.DataFrame(

--- a/imod/msw/pkgbase.py
+++ b/imod/msw/pkgbase.py
@@ -1,7 +1,7 @@
 import abc
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Optional, TextIO, Union
+from typing import Any, Optional, TextIO, TypeAlias, Union
 
 import numpy as np
 import pandas as pd
@@ -12,8 +12,11 @@ from imod.mf6.utilities.regrid import (
     _regrid_like,
 )
 from imod.msw.fixed_format import format_fixed_width
+from imod.typing import IntArray
 from imod.typing.grid import GridDataArray, GridDataset
 from imod.util.regrid_method_type import EmptyRegridMethod, RegridMethodType
+
+DataDictType: TypeAlias = dict[str, IntArray | int | str]
 
 
 class MetaSwapPackage(abc.ABC):
@@ -76,7 +79,7 @@ class MetaSwapPackage(abc.ABC):
             f"{__class__.__name__}(**{self._pkg_id}.dataset.sel(**selection))"
         )
 
-    def write(self, directory: Union[str, Path], index: np.ndarray, svat: xr.DataArray):
+    def write(self, directory: Union[str, Path], index: IntArray, svat: xr.DataArray):
         """
         Write MetaSWAP package to its corresponding fixed format file. This has
         the `.inp` extension.
@@ -110,19 +113,19 @@ class MetaSwapPackage(abc.ABC):
                 file.write(content)
             file.write("\n")
 
-    def _index_da(self, da, index):
+    def _index_da(self, da: xr.DataArray, index: IntArray) -> np.ndarray:
         """
         Helper method that converts a DataArray to a 1d numpy array, and
         consequently applies boolean indexing.
         """
         return da.values.ravel()[index]
 
-    def _render(self, file: TextIO, index: np.ndarray, svat: xr.DataArray):
+    def _render(self, file: TextIO, index: IntArray, svat: xr.DataArray):
         """
         Collect to be written data in a DataFrame and call
         ``self.write_dataframe_fixed_width``
         """
-        data_dict = {"svat": svat.values.ravel()[index]}
+        data_dict: DataDictType = {"svat": svat.values.ravel()[index]}
 
         subunit = svat.coords["subunit"]
 

--- a/imod/msw/pkgbase.py
+++ b/imod/msw/pkgbase.py
@@ -1,7 +1,7 @@
 import abc
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, TextIO, Union
 
 import numpy as np
 import pandas as pd
@@ -27,6 +27,10 @@ class MetaSwapPackage(abc.ABC):
     __slots__ = "_pkg_id"
     _file_name = "filename_not_set"
     _regrid_method: RegridMethodType = EmptyRegridMethod()
+    _with_subunit: tuple = ()
+    _without_subunit: tuple = ()
+    _to_fill: tuple = ()
+    _metadata_dict: dict = {}
 
     def __init__(self):
         self.dataset = xr.Dataset()
@@ -113,7 +117,7 @@ class MetaSwapPackage(abc.ABC):
         """
         return da.values.ravel()[index]
 
-    def _render(self, file, index, svat):
+    def _render(self, file: TextIO, index: np.ndarray, svat: xr.DataArray):
         """
         Collect to be written data in a DataFrame and call
         ``self.write_dataframe_fixed_width``

--- a/imod/msw/pkgbase.py
+++ b/imod/msw/pkgbase.py
@@ -150,7 +150,7 @@ class MetaSwapPackage(abc.ABC):
         svat: xr.DataArray,
         mf6_dis: StructuredDiscretization,
         mf6_well: Mf6Wel,
-    ):  # mf6_dis: StructuredDiscretization, mf6_well: Mf6Wel):
+    ) -> None:
         """
         Collect to be written data in a DataFrame and call
         ``self.write_dataframe_fixed_width``

--- a/imod/msw/ponding.py
+++ b/imod/msw/ponding.py
@@ -1,4 +1,8 @@
+from typing import TextIO
+
+import numpy as np
 import pandas as pd
+import xarray as xr
 
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.msw.fixed_format import VariableMetaData
@@ -51,7 +55,7 @@ class Ponding(MetaSwapPackage, IRegridPackage):
 
         self._pkgcheck()
 
-    def _render(self, file, index, svat):
+    def _render(self, file: TextIO, index: np.ndarray, svat: xr.DataArray):
         data_dict = {"svat": svat.values.ravel()[index]}
 
         for var in self._with_subunit:

--- a/imod/msw/ponding.py
+++ b/imod/msw/ponding.py
@@ -1,4 +1,4 @@
-from typing import TextIO
+from typing import Any, TextIO
 
 import pandas as pd
 import xarray as xr
@@ -55,7 +55,7 @@ class Ponding(MetaSwapPackage, IRegridPackage):
 
         self._pkgcheck()
 
-    def _render(self, file: TextIO, index: IntArray, svat: xr.DataArray):
+    def _render(self, file: TextIO, index: IntArray, svat: xr.DataArray, *args: Any):
         data_dict: DataDictType = {"svat": svat.values.ravel()[index]}
 
         for var in self._with_subunit:

--- a/imod/msw/ponding.py
+++ b/imod/msw/ponding.py
@@ -1,13 +1,13 @@
 from typing import TextIO
 
-import numpy as np
 import pandas as pd
 import xarray as xr
 
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.msw.fixed_format import VariableMetaData
-from imod.msw.pkgbase import MetaSwapPackage
+from imod.msw.pkgbase import DataDictType, MetaSwapPackage
 from imod.msw.regrid.regrid_schemes import PondingRegridMethod
+from imod.typing import IntArray
 
 
 class Ponding(MetaSwapPackage, IRegridPackage):
@@ -55,8 +55,8 @@ class Ponding(MetaSwapPackage, IRegridPackage):
 
         self._pkgcheck()
 
-    def _render(self, file: TextIO, index: np.ndarray, svat: xr.DataArray):
-        data_dict = {"svat": svat.values.ravel()[index]}
+    def _render(self, file: TextIO, index: IntArray, svat: xr.DataArray):
+        data_dict: DataDictType = {"svat": svat.values.ravel()[index]}
 
         for var in self._with_subunit:
             data_dict[var] = self._index_da(self.dataset[var], index)

--- a/imod/msw/regrid/regrid_schemes.py
+++ b/imod/msw/regrid/regrid_schemes.py
@@ -9,6 +9,35 @@ from imod.util.regrid_method_type import (
 
 
 @dataclass(config=_CONFIG)
+class SprinklingRegridMethod(RegridMethodType):
+    """
+    Object containing regridder methods for the
+    :class:`imod.msw.Sprinkling` package. This can be provided to the
+    ``regrid_like`` method to regrid with custom settings.
+
+    Parameters
+    ----------
+    max_abstraction_groundwater: tuple, default (RegridderType.OVERLAP, "mean")
+    max_abstraction_surfacewater: tuple, default (RegridderType.OVERLAP, "mean")
+
+    Examples
+    --------
+    Regrid with custom settings:
+
+    >>> regrid_method = SprinklingRegridMethod(max_abstraction_groundwater=(RegridderType.BARYCENTRIC,))
+    >>> sprinking.regrid_like(target_grid, RegridderWeightsCache(), regrid_method)
+
+    The RegridderType.OVERLAP and RegridderType.RELATIVEOVERLAP require an extra
+    method as string.
+
+    >>> regrid_method = SprinklingRegridMethod(max_abstraction_groundwater=(RegridderType.OVERLAP, "max",))
+    """
+
+    max_abstraction_groundwater: _RegridVarType = (RegridderType.OVERLAP, "mean")
+    max_abstraction_surfacewater: _RegridVarType = (RegridderType.OVERLAP, "mean")
+
+
+@dataclass(config=_CONFIG)
 class MeteoGridRegridMethod(RegridMethodType):
     """
     Object containing regridder methods for the

--- a/imod/msw/sprinkling.py
+++ b/imod/msw/sprinkling.py
@@ -7,6 +7,7 @@ import xarray as xr
 from imod.mf6.mf6_wel_adapter import Mf6Wel
 from imod.msw.fixed_format import VariableMetaData
 from imod.msw.pkgbase import MetaSwapPackage
+from imod.typing import IntArray
 
 
 class Sprinkling(MetaSwapPackage):
@@ -68,7 +69,7 @@ class Sprinkling(MetaSwapPackage):
 
         self._pkgcheck()
 
-    def _render(self, file: TextIO, index: np.ndarray, svat: xr.DataArray):
+    def _render(self, file: TextIO, index: IntArray, svat: xr.DataArray):
         well_cellid = self.well["cellid"]
         if len(well_cellid.coords["dim_cellid"]) != 3:
             raise TypeError("Coupling to unstructured grids is not supported.")

--- a/imod/msw/sprinkling.py
+++ b/imod/msw/sprinkling.py
@@ -1,3 +1,5 @@
+from typing import TextIO
+
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -66,7 +68,7 @@ class Sprinkling(MetaSwapPackage):
 
         self._pkgcheck()
 
-    def _render(self, file, index, svat):
+    def _render(self, file: TextIO, index: np.ndarray, svat: xr.DataArray):
         well_cellid = self.well["cellid"]
         if len(well_cellid.coords["dim_cellid"]) != 3:
             raise TypeError("Coupling to unstructured grids is not supported.")

--- a/imod/msw/vegetation.py
+++ b/imod/msw/vegetation.py
@@ -1,3 +1,5 @@
+from typing import TextIO
+
 import numpy as np
 import xarray as xr
 
@@ -77,7 +79,7 @@ class AnnualCropFactors(MetaSwapPackage, IRegridPackage):
 
         self._pkgcheck()
 
-    def _render(self, file, *args):
+    def _render(self, file: TextIO, *args):
         dataframe = self.dataset.to_dataframe(
             dim_order=("vegetation_index", "day_of_year")
         ).reset_index()

--- a/imod/msw/vegetation.py
+++ b/imod/msw/vegetation.py
@@ -1,4 +1,4 @@
-from typing import TextIO
+from typing import Any, TextIO
 
 import numpy as np
 import xarray as xr
@@ -79,7 +79,7 @@ class AnnualCropFactors(MetaSwapPackage, IRegridPackage):
 
         self._pkgcheck()
 
-    def _render(self, file: TextIO, *args):
+    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
         dataframe = self.dataset.to_dataframe(
             dim_order=("vegetation_index", "day_of_year")
         ).reset_index()

--- a/imod/msw/vegetation.py
+++ b/imod/msw/vegetation.py
@@ -79,7 +79,7 @@ class AnnualCropFactors(MetaSwapPackage, IRegridPackage):
 
         self._pkgcheck()
 
-    def _render(self, file: TextIO, *args: Any, **kwargs: Any):
+    def _render(self, file: TextIO, *args: Any):
         dataframe = self.dataset.to_dataframe(
             dim_order=("vegetation_index", "day_of_year")
         ).reset_index()

--- a/imod/tests/conftest.py
+++ b/imod/tests/conftest.py
@@ -88,4 +88,4 @@ from .fixtures.mf6_welltest_fixture import (
     well_test_data_transient,
 )
 from .fixtures.msw_fixture import fixed_format_parser, simple_2d_grid_with_subunits
-from .fixtures.msw_model_fixture import coupled_mf6_model, msw_model
+from .fixtures.msw_model_fixture import coupled_mf6_model, coupled_mf6wel, msw_model

--- a/imod/tests/fixtures/msw_model_fixture.py
+++ b/imod/tests/fixtures/msw_model_fixture.py
@@ -118,9 +118,6 @@ def make_msw_model():
     dx = 1.0
     dy = -1.0
 
-    nrow = len(y)
-    ncol = len(x)
-
     freq = "D"
     times = pd.date_range(start="1/1/1971", end="1/3/1971", freq=freq)
 
@@ -189,30 +186,6 @@ def make_msw_model():
     )
     lu = xr.ones_like(vegetation_index_da, dtype=float)
 
-    # %% Well
-
-    wel_layer = 3
-
-    well_x = np.tile(x, nrow)
-    well_y = np.repeat(y, ncol)
-    well_rate = np.zeros(well_x.shape)
-    well_layer = np.full_like(well_x, wel_layer)
-
-    cellids = derive_cellid_from_points(active, well_x, well_y, well_layer).astype(int)
-    well = Mf6Wel(cellids, well_rate)
-
-    # %% Modflow 6
-    dz = np.array([1, 10, 100])
-    layer = [1, 2, 3]
-
-    top = 0.0
-    bottom = top - xr.DataArray(
-        np.cumsum(layer * dz), coords={"layer": layer}, dims="layer"
-    )
-
-    idomain = xr.full_like(msw_grid, 1, dtype=int).expand_dims(layer=layer)
-    dis = mf6.StructuredDiscretization(top=top, bottom=bottom, idomain=idomain)
-
     # %% Initiate model
     msw_model = msw.MetaSwapModel(unsaturated_database=unsaturated_database)
     msw_model["grid"] = msw.GridData(
@@ -235,7 +208,6 @@ def make_msw_model():
     msw_model["sprinkling"] = msw.Sprinkling(
         max_abstraction_groundwater=xr.full_like(msw_grid, 100.0),
         max_abstraction_surfacewater=xr.full_like(msw_grid, 100.0),
-        well=well,
     )
 
     # %% Ponding
@@ -299,7 +271,7 @@ def make_msw_model():
     )
 
     # %% Metaswap Mappings
-    msw_model["mod2svat"] = msw.CouplerMapping(modflow_dis=dis, well=well)
+    msw_model["mod2svat"] = msw.CouplerMapping()
 
     # %% Output Control
     msw_model["oc_idf"] = msw.IdfMapping(area, -9999.0)

--- a/imod/tests/test_msw/test_coupler_mapping.py
+++ b/imod/tests/test_msw/test_coupler_mapping.py
@@ -53,11 +53,11 @@ def test_simple_model_with_sprinkling(fixed_format_parser):
         idomain=xr.full_like(like, 1, dtype=np.int32),
     )
 
-    coupler_mapping = msw.CouplerMapping(dis, well)
+    coupler_mapping = msw.CouplerMapping()
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        coupler_mapping.write(output_dir, index, svat)
+        coupler_mapping.write(output_dir, index, svat, dis, well)
 
         results = fixed_format_parser(
             output_dir / msw.CouplerMapping._file_name,
@@ -108,11 +108,11 @@ def test_simple_model_with_sprinkling_1_subunit(fixed_format_parser):
         idomain=xr.full_like(like, 1, dtype=np.int32),
     )
 
-    coupler_mapping = msw.CouplerMapping(dis, well)
+    coupler_mapping = msw.CouplerMapping()
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        coupler_mapping.write(output_dir, index, svat)
+        coupler_mapping.write(output_dir, index, svat, dis, well)
 
         results = fixed_format_parser(
             output_dir / msw.CouplerMapping._file_name,
@@ -159,11 +159,11 @@ def test_simple_model_without_sprinkling(fixed_format_parser):
         idomain=xr.full_like(like, 1, dtype=np.int32),
     )
 
-    coupler_mapping = msw.CouplerMapping(dis)
+    coupler_mapping = msw.CouplerMapping()
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        coupler_mapping.write(output_dir, index, svat)
+        coupler_mapping.write(output_dir, index, svat, dis, None)
 
         results = fixed_format_parser(
             output_dir / msw.CouplerMapping._file_name,

--- a/imod/tests/test_msw/test_evapotranspiration_mapping.py
+++ b/imod/tests/test_msw/test_evapotranspiration_mapping.py
@@ -61,7 +61,7 @@ def test_evapotranspiration_mapping_simple(fixed_format_parser):
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        evapotranspiration_mapping.write(output_dir, index, svat)
+        evapotranspiration_mapping.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / msw.EvapotranspirationMapping._file_name,
@@ -125,7 +125,7 @@ def test_evapotranspiration_mapping_negative_dx(fixed_format_parser):
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        evapotranspiration_mapping.write(output_dir, index, svat)
+        evapotranspiration_mapping.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / msw.EvapotranspirationMapping._file_name,
@@ -192,4 +192,4 @@ def test_evapotranspiration_mapping_out_of_bound():
         output_dir = Path(output_dir)
         # The grid is out of bounds, which is why we expect a ValueError to be raisen
         with pytest.raises(ValueError):
-            evapotranspiration_mapping.write(output_dir, index, svat)
+            evapotranspiration_mapping.write(output_dir, index, svat, None, None)

--- a/imod/tests/test_msw/test_grid_data.py
+++ b/imod/tests/test_msw/test_grid_data.py
@@ -65,7 +65,7 @@ def test_write(
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        grid_data.write(output_dir, index, svat)
+        grid_data.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / GridData._file_name, GridData._metadata_dict
@@ -336,7 +336,7 @@ def test_simple_model(fixed_format_parser):
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        grid_data.write(output_dir, index, svat)
+        grid_data.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / GridData._file_name, GridData._metadata_dict
@@ -446,7 +446,7 @@ def test_simple_model_1_subunit(fixed_format_parser):
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        grid_data.write(output_dir, index, svat)
+        grid_data.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / GridData._file_name, GridData._metadata_dict

--- a/imod/tests/test_msw/test_idf_mapping.py
+++ b/imod/tests/test_msw/test_idf_mapping.py
@@ -4,8 +4,6 @@ from imod.mf6.utilities.regrid import RegridderWeightsCache
 from imod.msw.idf_mapping import IdfMapping
 from imod.tests.fixtures.msw_regrid_fixture import get_3x3_area, get_5x5_new_grid
 
-nan = np.nan
-
 
 def test_idf_mapping_regrid():
     area = get_3x3_area()

--- a/imod/tests/test_msw/test_infiltration.py
+++ b/imod/tests/test_msw/test_infiltration.py
@@ -119,7 +119,7 @@ def test_write(
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        infiltration.write(output_dir, index, svat)
+        infiltration.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / Infiltration._file_name, Infiltration._metadata_dict
@@ -186,7 +186,7 @@ def test_simple_model(fixed_format_parser):
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        infiltration.write(output_dir, index, svat)
+        infiltration.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / Infiltration._file_name, Infiltration._metadata_dict

--- a/imod/tests/test_msw/test_initial_conditions.py
+++ b/imod/tests/test_msw/test_initial_conditions.py
@@ -15,14 +15,15 @@ from imod.msw import (
 )
 from imod.typing.grid import is_empty
 
+DUMMY_ARGS = None, None, None, None
+
 
 def test_initial_conditions_equilibrium():
     ic = InitialConditionsEquilibrium()
-    dummy = None, None
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        ic.write(output_dir, *dummy)
+        ic.write(output_dir, *DUMMY_ARGS)
 
         with open(output_dir / ic._file_name) as f:
             lines = f.readlines()
@@ -43,11 +44,10 @@ def test_initial_conditions_equilibrium_regrid(simple_2d_grid_with_subunits):
 
 def test_initial_conditions_percolation():
     ic = InitialConditionsPercolation()
-    dummy = None, None
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        ic.write(output_dir, *dummy)
+        ic.write(output_dir, *DUMMY_ARGS)
 
         with open(output_dir / ic._file_name) as f:
             lines = f.readlines()
@@ -67,11 +67,10 @@ def test_initial_conditions_percolation_regrid(simple_2d_grid_with_subunits):
 
 def test_initial_conditions_rootzone_pressure_head():
     ic = InitialConditionsRootzonePressureHead(2.2)
-    dummy = None, None
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        ic.write(output_dir, *dummy)
+        ic.write(output_dir, *DUMMY_ARGS)
 
         with open(output_dir / ic._file_name) as f:
             lines = f.readlines()
@@ -90,7 +89,6 @@ def test_initial_conditions_rootzone_regrid(simple_2d_grid_with_subunits):
 
 
 def test_initial_conditions_saved_state():
-    dummy = None, None
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
         with open(output_dir / "foo.out", "w") as f:
@@ -98,19 +96,18 @@ def test_initial_conditions_saved_state():
 
         ic = InitialConditionsSavedState(output_dir / "foo.out")
 
-        ic.write(output_dir, *dummy)
+        ic.write(output_dir, *DUMMY_ARGS)
 
         assert Path(output_dir / "init_svat.inp").exists()
 
 
 def test_initial_conditions_saved_state_no_file():
-    dummy = None, None
     ic = InitialConditionsSavedState(r"doesntexist.txt")
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
         with pytest.raises(FileNotFoundError):
-            ic.write(output_dir, *dummy)
+            ic.write(output_dir, *DUMMY_ARGS)
 
 
 def test_initial_conditions_saved_state_regrid():

--- a/imod/tests/test_msw/test_landuse_options.py
+++ b/imod/tests/test_msw/test_landuse_options.py
@@ -55,7 +55,7 @@ def test_landuse_options(fixed_format_parser):
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        lu_options.write(output_dir, None, None)
+        lu_options.write(output_dir, None, None, None, None)
 
         results = fixed_format_parser(
             output_dir / LanduseOptions._file_name, LanduseOptions._metadata_dict

--- a/imod/tests/test_msw/test_model.py
+++ b/imod/tests/test_msw/test_model.py
@@ -8,9 +8,12 @@ from imod import mf6, msw
 from imod.mf6.utilities.regrid import RegridderWeightsCache
 
 
-def test_msw_model_write(msw_model, tmp_path):
+def test_msw_model_write(msw_model, coupled_mf6_model, tmp_path):
+    mf6_dis = coupled_mf6_model["GWF_1"]["dis"]
+    mf6_wel = coupled_mf6_model["GWF_1"]["well_msw"]
+
     output_dir = tmp_path / "metaswap"
-    msw_model.write(output_dir)
+    msw_model.write(output_dir, mf6_dis, mf6_wel)
 
     assert len(list(output_dir.rglob(r"*.inp"))) == 16
     assert len(list(output_dir.rglob(r"*.asc"))) == 4
@@ -102,7 +105,8 @@ def get_target_mf6_discretization():
     return dis
 
 
-def test_model_regrid(msw_model, tmp_path):
+def test_model_regrid(msw_model, coupled_mf6_model, tmp_path):
+    mf6_wel = coupled_mf6_model["GWF_1"]["well_msw"]
     # sprinkling not supported yet for regridding
     msw_model.pop("sprinkling")
 
@@ -110,4 +114,6 @@ def test_model_regrid(msw_model, tmp_path):
 
     regrid_context = RegridderWeightsCache()
     regridded_model = msw_model.regrid_like(mf6_discretization, regrid_context)
-    regridded_model.write(tmp_path)
+    # TODO: Assign grid agnostic well to coupled_m f6_model, regrid coupled
+    #   model, and convert well package to mf6 package
+    regridded_model.write(tmp_path, mf6_discretization, mf6_wel)

--- a/imod/tests/test_msw/test_model.py
+++ b/imod/tests/test_msw/test_model.py
@@ -107,9 +107,6 @@ def get_target_mf6_discretization():
 
 def test_model_regrid(msw_model, coupled_mf6_model, tmp_path):
     mf6_wel = coupled_mf6_model["GWF_1"]["well_msw"]
-    # sprinkling not supported yet for regridding
-    msw_model.pop("sprinkling")
-
     mf6_discretization = get_target_mf6_discretization()
 
     regrid_context = RegridderWeightsCache()

--- a/imod/tests/test_msw/test_output_control.py
+++ b/imod/tests/test_msw/test_output_control.py
@@ -9,6 +9,8 @@ from numpy.testing import assert_almost_equal, assert_equal
 
 from imod.msw import IdfMapping, TimeOutputControl, VariableOutputControl
 
+DUMMY_ARGS = None, None, None, None
+
 
 def grid():
     x = [1.0, 2.0, 3.0, 4.0]
@@ -54,12 +56,11 @@ def grid():
 
 
 def test_var_oc(fixed_format_parser):
-    dummy = None, None
     var_output_control = VariableOutputControl()
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        var_output_control.write(output_dir, *dummy)
+        var_output_control.write(output_dir, *DUMMY_ARGS)
 
         results = fixed_format_parser(
             output_dir / VariableOutputControl._file_name,
@@ -74,7 +75,6 @@ def test_var_oc(fixed_format_parser):
 
 
 def test_time_oc(fixed_format_parser):
-    dummy = None, None
     freq = "D"
     times = pd.date_range(start="1/1/1971", end="1/3/1971", freq=freq)
 
@@ -82,7 +82,7 @@ def test_time_oc(fixed_format_parser):
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        time_output_control.write(output_dir, *dummy)
+        time_output_control.write(output_dir, *DUMMY_ARGS)
 
         results = fixed_format_parser(
             output_dir / TimeOutputControl._file_name, TimeOutputControl._metadata_dict
@@ -101,7 +101,7 @@ def test_idf_oc_write_simple_model(fixed_format_parser):
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        idf_output_control.write(output_dir, index, svat)
+        idf_output_control.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / IdfMapping._file_name, IdfMapping._metadata_dict

--- a/imod/tests/test_msw/test_ponding.py
+++ b/imod/tests/test_msw/test_ponding.py
@@ -81,7 +81,7 @@ def test_simple_model(fixed_format_parser):
     ponding, index, svat = setup_ponding()
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        ponding.write(output_dir, index, svat)
+        ponding.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / Ponding._file_name, Ponding._metadata_dict

--- a/imod/tests/test_msw/test_precipitation_mapping.py
+++ b/imod/tests/test_msw/test_precipitation_mapping.py
@@ -62,7 +62,7 @@ def test_precipitation_mapping_simple(fixed_format_parser):
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        precipitation_mapping.write(output_dir, index, svat)
+        precipitation_mapping.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / msw.PrecipitationMapping._file_name,
@@ -127,7 +127,7 @@ def test_precipitation_mapping_negative_dy_meteo(fixed_format_parser):
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        precipitation_mapping.write(output_dir, index, svat)
+        precipitation_mapping.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / msw.PrecipitationMapping._file_name,
@@ -189,7 +189,7 @@ def test_precipitation_mapping_negative_dy_meteo_svat(fixed_format_parser):
     precipitation_mapping = msw.PrecipitationMapping(precipitation)
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        precipitation_mapping.write(output_dir, index, svat)
+        precipitation_mapping.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / msw.PrecipitationMapping._file_name,
@@ -257,4 +257,4 @@ def test_precipitation_mapping_out_of_bound():
         output_dir = Path(output_dir)
         # The grid is out of bounds, which is why we expect a ValueError to be raisen
         with pytest.raises(ValueError):
-            precipitation_mapping.write(output_dir, index, svat)
+            precipitation_mapping.write(output_dir, index, svat, None, None)

--- a/imod/tests/test_msw/test_scaling_factors.py
+++ b/imod/tests/test_msw/test_scaling_factors.py
@@ -78,7 +78,7 @@ def test_simple_model(fixed_format_parser):
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        scaling_factors.write(output_dir, index, svat)
+        scaling_factors.write(output_dir, index, svat, None, None)
 
         results = fixed_format_parser(
             output_dir / ScalingFactors._file_name, ScalingFactors._metadata_dict

--- a/imod/tests/test_msw/test_sprinkling.py
+++ b/imod/tests/test_msw/test_sprinkling.py
@@ -78,11 +78,11 @@ def test_simple_model(fixed_format_parser):
 
     assert_equal(results["svat"], np.array([1, 2, 3, 4]))
     assert_almost_equal(
-        results["max_abstraction_groundwater_m3_d"],
+        results["max_abstraction_groundwater"],
         np.array([100.0, 300.0, 100.0, 200.0]),
     )
     assert_almost_equal(
-        results["max_abstraction_surfacewater_m3_d"],
+        results["max_abstraction_surfacewater"],
         np.array([100.0, 300.0, 100.0, 200.0]),
     )
     assert_equal(results["layer"], np.array([3, 1, 3, 2]))
@@ -151,11 +151,11 @@ def test_simple_model_1_subunit(fixed_format_parser):
 
     assert_equal(results["svat"], np.array([1, 2]))
     assert_almost_equal(
-        results["max_abstraction_groundwater_m3_d"],
+        results["max_abstraction_groundwater"],
         np.array([100.0, 300.0]),
     )
     assert_almost_equal(
-        results["max_abstraction_surfacewater_m3_d"],
+        results["max_abstraction_surfacewater"],
         np.array([100.0, 300.0]),
     )
     assert_equal(results["layer"], np.array([3, 2]))

--- a/imod/tests/test_msw/test_sprinkling.py
+++ b/imod/tests/test_msw/test_sprinkling.py
@@ -62,15 +62,14 @@ def test_simple_model(fixed_format_parser):
     cellids = derive_cellid_from_points(svat, well_x, well_y, well_layer)
     well = Mf6Wel(cellids, well_rate)
 
-    coupler_mapping = msw.Sprinkling(
+    sprinkling = msw.Sprinkling(
         max_abstraction_groundwater,
         max_abstraction_surfacewater,
-        well,
     )
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        coupler_mapping.write(output_dir, index, svat)
+        sprinkling.write(output_dir, index, svat, None, well)
 
         results = fixed_format_parser(
             output_dir / msw.Sprinkling._file_name,
@@ -136,15 +135,14 @@ def test_simple_model_1_subunit(fixed_format_parser):
     cellids = derive_cellid_from_points(svat, well_x, well_y, well_layer)
     well = Mf6Wel(cellids, well_rate)
 
-    coupler_mapping = msw.Sprinkling(
+    sprinkling = msw.Sprinkling(
         max_abstraction_groundwater,
         max_abstraction_surfacewater,
-        well,
     )
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
-        coupler_mapping.write(output_dir, index, svat)
+        sprinkling.write(output_dir, index, svat, None, well)
 
         results = fixed_format_parser(
             output_dir / msw.Sprinkling._file_name,


### PR DESCRIPTION
Fixes #1255 and #1056

# Description
This is part 2 of the metaswap refactoring on the iMOD Python side. The goal of this step was to require a Mf6Wel object at ``write`` instead of at init. For this I was struggling quite a lot with Linkov's principle and the resulting mypy errors. In the end, I resorted to requiring all arguments for the write method for each package. This results in a bit of a weird situation, where a ``None`` has to be provided for the ``mf6_dis`` and ``mf6_wel`` arguments to the ``write`` of an individual no even using these args. I don't think this is a major hickup for users, as they are nearly always writing with ``model.write`` directly, and not writing individual packages manually.

Though not perfect, I think this is certainly a big improvement to the current situation.

In total, this PR:

- Removes the mf6 packages as attributes from ``Sprinkling`` and ``CouplerMapping``. This makes dumping the metaswap packages easier. This affects the files ``imod.msw.sprinkling.py`` and ``imod.msw.coupler_mapping.py``.
- Updates the  ``Sprinkling`` and ``CouplerMapping`` class to ask MODFLOW6 packages at ``write`` instead of at ``__init__``. This affects ``imod.msw.sprinkling.py``, ``imod.msw.coupler_mapping.py``, and ``imod.msw.model.py``
- Updates the signatures
- Implements a ``regrid_like`` for the Sprinkling package. Affects ``imod.msw.sprinkling.py``.
- Adds a test to regrid a MetaSWAP model and its coupled MODFLOW6 model. The ``Mf6Wel`` package has to be created manually now after regridding.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
