### PR TITLE
Issue #1263 Fix failing pixi pipeline

### DIFF
--- a/.teamcity/Pixi/PixiProject.kt
+++ b/.teamcity/Pixi/PixiProject.kt
@@ -46,7 +46,11 @@ object UpdateDependencies : BuildType({
                     
                     if (git status -suno pixi.lock) 
                     {
-                      echo "Commit changes" 
+                      echo "Setup username and email"
+                      git config --global user.name "Teamcity"
+                      git config --global user.email "teamcity@deltares.nl"
+                      
+                      echo "Commit changes"
                       git commit -m "Update pixi.lock"
 
                       echo "Push changes" 


### PR DESCRIPTION
Fixes #1263

# Description
Something has changed on TeamCity. The pixi pipeline is now unable to determine the users emailadres.
This resulted the pipeline script being unable to create/push a commit.

This PR sets the username and email explicitly which should fix the issue

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
