### PR TITLE
Issue #1261 Support imod5 ipf data in cap for open_projectfile_data

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -28,6 +28,8 @@ Fixed
   addressed.
 - Added :func:`imod.mf6.open_dvs` to read dependent variable output files like
   the water content file of :class:`imod.mf6.UnsaturatedZoneFlow`.
+- `imod.prj.open_projectfile_data` is now able to also read IPF data for
+  sprinkling wells in the CAP package.
 
 Changed
 ~~~~~~~

--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -84,7 +84,7 @@ METASWAP_VARS = (
     "meteo_station_number",
     "surface_elevation",
     "artificial_recharge",
-    "artifical_recharge_layer",
+    "artificial_recharge_layer",
     "artificial_recharge_capacity",
     "wetted_area",
     "urban_area",
@@ -1047,7 +1047,10 @@ def open_projectfile_data(path: FilePath) -> Dict[str, Any]:
                 data, repeats = _read_package_ipf(block_content, periods)
             elif key == "(cap)":
                 variables = set(METASWAP_VARS).intersection(block_content.keys())
+                ipf_var = "artificial_recharge_layer"
+                block_content_ipf = {"ipf": block_content.pop(ipf_var)}
                 data = _open_package_idf(block_content, variables)
+                data_ipf, _ = _read_package_ipf(block_content_ipf, periods)
             elif key in ("extra", "(pcg)"):
                 data = [block_content]
             elif key in KEYS:

--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -1068,11 +1068,18 @@ def open_projectfile_data(path: FilePath) -> Dict[str, Any]:
             elif key == "(wel)":
                 data, repeats = _read_package_ipf(block_content, periods)
             elif key == "(cap)":
+                maybe_ipf_var = "artificial_recharge_layer"
+                maybe_ipf_content = block_content.pop(maybe_ipf_var)
+                maybe_ipf_path = maybe_ipf_content[0]["path"]
+                is_ipf = maybe_ipf_path.suffix.lower() == ".ipf"
+                if not is_ipf:
+                    # Not ipf, potential ipf content is in fact idf content, so
+                    # needs to be reattached.
+                    block_content[maybe_ipf_var] = maybe_ipf_content
                 variables = set(METASWAP_VARS).intersection(block_content.keys())
-                ipf_var = "artificial_recharge_layer"
-                data_ipf = imod.ipf.read(block_content.pop(ipf_var))
                 data = _open_package_idf(block_content, variables)
-                data[0][ipf_var] = data_ipf
+                if is_ipf:
+                    data[0][maybe_ipf_var] = imod.ipf.read(maybe_ipf_path)
             elif key in ("extra", "(pcg)"):
                 data = [block_content]
             elif key in KEYS:

--- a/imod/tests/test_mf6/test_import_prj.py
+++ b/imod/tests/test_mf6/test_import_prj.py
@@ -266,9 +266,9 @@ def test_import_ipf_unique_id_and_logging(tmp_path):
 
     with open(logfile_path, "r") as log_file:
         log = log_file.read()
-        assert "This happened at x  = 197910, y = 362860, id = extractions" in log
-        assert "appended with the suffix  _1" in log
-        assert "appended with the suffix  _2" in log
+        assert "This happened at x =\n197910, y = 362860, id = extractions" in log
+        assert "appended with the suffix _1" in log
+        assert "appended with the suffix _2" in log
 
 
 def snippet_boundary_condition(factor: float, addition: float):


### PR DESCRIPTION
Fixes #1261

# Description
This PR changes the following things:
- expands ``imod.prj.open_projectfile_data`` so that it doesn't  break upon reading a CAP (with data for MetaSWAP) where an IPF is specified for sprinkling wells, instead of a IDF. 
- slightly refactors the projectfile tests, to work with two test cases, and to move the projectfile template outside the setup. This allows expanding the prj template and adding more test cases for the projectfile.
- some boyscouting: move some of the logic in ``_read_package_ipf`` to separate functions, to reducte the function's length. This is not really that relevant to this PR, but I started working on this thinking I needed the _read_package_ipf. It turned out this wasn't necessary.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
