### PR TITLE
Fix Issue #1267 and #1268 prepare mf6 well model

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -27,6 +27,15 @@ Added
 ~~~~~
 
 - :meth:`imod.msw.MetaSwapModel.regrid_like` to regrid MetaSWAP models.
+- :meth:`imod.mf6.GroundwaterFlowModel.prepare_wel_for_mf6` to prepare wells for
+  MODFLOW6, for debugging purposes.
+
+Fixed
+~~~~~
+
+- Bug where error was thrown when :class:`imod.mf6.NodePropertyFlow` was
+  assigned to :class:`imod.mf6.GroundwaterFlowModel` with key different from
+  ``"npf"`` upon writing, as well as well or horizontal flow barrier packages.
 
 
 [Unreleased]

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -35,7 +35,7 @@ Fixed
 
 - Bug where error was thrown when :class:`imod.mf6.NodePropertyFlow` was
   assigned to :class:`imod.mf6.GroundwaterFlowModel` with key different from
-  ``"npf"`` upon writing, as well as well or horizontal flow barrier packages.
+  ``"npf"`` upon writing, along with well or horizontal flow barrier packages.
 
 
 [Unreleased]

--- a/docs/api/mf6.rst
+++ b/docs/api/mf6.rst
@@ -33,6 +33,7 @@ Model objects & methods
     Modflow6Simulation.regrid_like
     GroundwaterFlowModel
     GroundwaterFlowModel.mask_all_packages
+    GroundwaterFlowModel.prepare_wel_for_mf6
     GroundwaterFlowModel.dump
     GroundwaterTransportModel
     GroundwaterTransportModel.mask_all_packages

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -243,9 +243,6 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
     def prepare_wel_for_mf6(
         self, pkgname: str, validate: bool = True, strict_well_validation: bool = True
     ) -> Mf6Wel:
-        validate_context = ValidationContext(
-            validate=validate, strict_well_validation=strict_well_validation
-        )
         """
         Prepare grid-agnostic well for MODFLOW6, using the models grid
         information and hydraulic conductivities. Allocates LayeredWell & Well
@@ -272,6 +269,9 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
             Direct representation of MODFLOW6 WEL package, with 'cellid'
             indicating layer, row columns.
         """
+        validate_context = ValidationContext(
+            validate=validate, strict_well_validation=strict_well_validation
+        )
         return self._prepare_wel_for_mf6(pkgname, validate_context)
 
     @standard_log_decorator()

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -194,7 +194,9 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
     def _get_k(self):
         npf_key = self._get_pkgkey(imod.mf6.NodePropertyFlow._pkg_id)
         if not npf_key:
-            raise KeyError("No NodePropertyFlow package was assigned to Modflow6Model, make sure this is included.")
+            raise KeyError(
+                "No NodePropertyFlow package was assigned to Modflow6Model, make sure this is included."
+            )
         npf = self[npf_key]
         return npf["k"]
 

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -554,7 +554,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         clipped : Modflow6Model
         """
 
-        top, bottom, idomain = self._get_domain_geometry()
+        top, bottom, _ = self._get_domain_geometry()
 
         clipped = type(self)(**self._options)
         for key, pkg in self.items():

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -21,6 +21,7 @@ import imod
 from imod.logging import standard_log_decorator
 from imod.mf6.hfb import HorizontalFlowBarrierBase
 from imod.mf6.interfaces.imodel import IModel
+from imod.mf6.mf6_wel_adapter import Mf6Wel
 from imod.mf6.package import Package
 from imod.mf6.statusinfo import NestedStatusInfo, StatusInfo, StatusInfoBase
 from imod.mf6.utilities.mask import _mask_all_packages
@@ -175,7 +176,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
 
         self._check_for_required_packages(modelkey)
 
-    def __get_domain_geometry(
+    def _get_domain_geometry(
         self,
     ) -> tuple[
         Union[xr.DataArray, xu.UgridDataArray],
@@ -190,14 +191,12 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         idomain = discretization["idomain"]
         return top, bottom, idomain
 
-    def __get_k(self):
-        try:
-            npf = self[imod.mf6.NodePropertyFlow._pkg_id]
-        except RuntimeError:
-            raise ValidationError("expected one package of type ModePropertyFlow")
-
-        k = npf["k"]
-        return k
+    def _get_k(self):
+        npf_key = self._get_pkgkey(imod.mf6.NodePropertyFlow._pkg_id)
+        if not npf_key:
+            raise KeyError("No NodePropertyFlow package was assigned to Modflow6Model, make sure this is included.")
+        npf = self[npf_key]
+        return npf["k"]
 
     @standard_log_decorator()
     def validate(self, model_name: str = "") -> StatusInfoBase:
@@ -239,6 +238,60 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
 
         return model_status_info
 
+    def prepare_wel_for_mf6(
+        self, pkgname: str, validate: bool = True, strict_well_validation: bool = True
+    ) -> Mf6Wel:
+        validate_context = ValidationContext(
+            validate=validate, strict_well_validation=strict_well_validation
+        )
+        """
+        Prepare grid-agnostic well for MODFLOW6, using the models grid
+        information and hydraulic conductivities. Allocates LayeredWell & Well
+        objects, which have x,y locations, to row & columns. Furthermore, Well
+        objects are allocated to model layers, depending on screen depth.
+
+        This function is called upon writing the model, it is included in the
+        public API for the user's debugging purposes.
+
+        Parameters
+        ----------
+        pkgname: string
+            Name of well package that is to be prepared for MODFLOW6
+        validate: bool, default True
+            Run validation before converting
+        strict_well_validation: bool, default True
+            Set well validation strict:
+            Throw error if well is removed entirely during its assignment to
+            layers.
+
+        Returns
+        -------
+        Mf6Wel
+            Direct representation of MODFLOW6 WEL package, with 'cellid'
+            indicating layer, row columns.
+        """
+        return self._prepare_wel_for_mf6(pkgname, validate_context)
+
+    @standard_log_decorator()
+    def _prepare_wel_for_mf6(
+        self, pkgname: str, validate_context: ValidationContext
+    ) -> Mf6Wel:
+        pkg = self[pkgname]
+        if not isinstance(pkg, GridAgnosticWell):
+            raise TypeError(
+                f"""Package '{pkgname}' not of appropriate type, should be of type:
+                 'Well', 'LayeredWell', got {type(pkg)}"""
+            )
+        top, bottom, idomain = self._get_domain_geometry()
+        k = self._get_k()
+        return pkg._to_mf6_pkg(
+            idomain,
+            top,
+            bottom,
+            k,
+            validate_context,
+        )
+
     @standard_log_decorator()
     def write(
         self,
@@ -274,15 +327,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         for pkg_name, pkg in self.items():
             try:
                 if issubclass(type(pkg), GridAgnosticWell):
-                    top, bottom, idomain = self.__get_domain_geometry()
-                    k = self.__get_k()
-                    mf6_well_pkg = pkg._to_mf6_pkg(
-                        idomain,
-                        top,
-                        bottom,
-                        k,
-                        validate_context,
-                    )
+                    mf6_well_pkg = self._prepare_wel_for_mf6(pkg_name, validate_context)
                     mf6_well_pkg.write(
                         pkgname=pkg_name,
                         globaltimes=globaltimes,
@@ -302,8 +347,8 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         if len(mf6_hfb_ls) > 0:
             try:
                 pkg_name = HFB_PKGNAME
-                top, bottom, idomain = self.__get_domain_geometry()
-                k = self.__get_k()
+                top, bottom, idomain = self._get_domain_geometry()
+                k = self._get_k()
                 mf6_hfb_pkg = merge_hfb_packages(mf6_hfb_ls, idomain, top, bottom, k)
                 mf6_hfb_pkg.write(
                     pkgname=pkg_name,
@@ -506,7 +551,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         clipped : Modflow6Model
         """
 
-        top, bottom, idomain = self.__get_domain_geometry()
+        top, bottom, idomain = self._get_domain_geometry()
 
         clipped = type(self)(**self._options)
         for key, pkg in self.items():

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -195,7 +195,8 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         npf_key = self._get_pkgkey(imod.mf6.NodePropertyFlow._pkg_id)
         if not npf_key:
             raise KeyError(
-                "No NodePropertyFlow package was assigned to Modflow6Model, make sure this is included."
+                """Unable to obtain the hydraulic conductivity. Make sure a
+                NodePropertyFlow package is assigned to the Modflow6Model."""
             )
         npf = self[npf_key]
         return npf["k"]

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -393,12 +393,14 @@ def test_prepare_wel_to_mf6(
     # Assert
     assert isinstance(mf6_well, Mf6Wel)
 
+
 def test_prepare_wel_to_mf6__error(
     structured_flow_model: GroundwaterFlowModel,
 ):
     # Act
     with pytest.raises(TypeError):
         structured_flow_model.prepare_wel_for_mf6("dis", True, True)
+
 
 def test_get_k(structured_flow_model: GroundwaterFlowModel):
     # Act
@@ -412,6 +414,7 @@ def test_get_k(structured_flow_model: GroundwaterFlowModel):
     k = structured_flow_model._get_k()
     # Assert
     assert isinstance(k, xr.DataArray)
+
 
 def test_get_domain_geometry(structured_flow_model: GroundwaterFlowModel):
     # Act

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -407,13 +407,15 @@ def test_get_k(structured_flow_model: GroundwaterFlowModel):
     k = structured_flow_model._get_k()
     # Assert
     assert isinstance(k, xr.DataArray)
+    assert np.all(k == 1.23)
     # Arrange
     npf = structured_flow_model.pop("npf")
-    structured_flow_model["npf_with_other_name"] = npf
+    structured_flow_model["npf_other_name"] = npf
     # Act
     k = structured_flow_model._get_k()
     # Assert
     assert isinstance(k, xr.DataArray)
+    assert np.all(k == 1.23)
 
 
 def test_get_domain_geometry(structured_flow_model: GroundwaterFlowModel):
@@ -423,3 +425,11 @@ def test_get_domain_geometry(structured_flow_model: GroundwaterFlowModel):
     assert isinstance(top, xr.DataArray)
     assert isinstance(bottom, xr.DataArray)
     assert isinstance(idomain, xr.DataArray)
+
+    assert top.dtype == np.float64
+    assert bottom.dtype == np.float64
+    assert idomain.dtype == np.int32
+
+    assert np.all(np.isin(top.values, [10.0]))
+    assert np.all(np.isin(bottom.values, [-1.0, -2.0, -3.0]))
+    assert np.all(np.isin(idomain.values, [1]))

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -407,7 +407,7 @@ def test_get_k(structured_flow_model: GroundwaterFlowModel):
     k = structured_flow_model._get_k()
     # Assert
     assert isinstance(k, xr.DataArray)
-    assert np.all(k == 1.23)
+    np.testing.assert_allclose(k.values, 1.23)
     # Arrange
     npf = structured_flow_model.pop("npf")
     structured_flow_model["npf_other_name"] = npf
@@ -415,7 +415,7 @@ def test_get_k(structured_flow_model: GroundwaterFlowModel):
     k = structured_flow_model._get_k()
     # Assert
     assert isinstance(k, xr.DataArray)
-    assert np.all(k == 1.23)
+    np.testing.assert_allclose(k.values, 1.23)
 
 
 def test_get_domain_geometry(structured_flow_model: GroundwaterFlowModel):

--- a/imod/tests/test_select/test_select_points.py
+++ b/imod/tests/test_select/test_select_points.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 import xugrid as xu
+from filelock import FileLock
 
 import imod
 
@@ -43,9 +44,11 @@ def test_uda(test_da):
     return xu.UgridDataArray(da, grid)
 
 
-@pytest.fixture(scope="module")
-def test_uda_elevation():
-    elevation = xu.data.elevation_nl()
+@pytest.fixture(scope="function")
+def uda_elevation():
+    from xugrid.data.sample_data import REGISTRY
+    with FileLock(REGISTRY.path / "xugrid_elevation_nl.nc.lock"):
+        elevation = xu.data.elevation_nl()
     return xu.concat(
         [elevation, elevation - 10.0, elevation - 20.0], dim="z"
     ).assign_coords(z=[0.0, -10.0, -20.0])
@@ -169,7 +172,7 @@ def test_get_values__unstructured(test_uda):
     assert expected == actual
 
 
-def test_get_indices__uda_elevation(test_uda_elevation):
+def test_get_indices__uda_elevation(uda_elevation):
     """
     Test for layered unstructured grid, x and y need to be looked up on
     Ugrid2d, whereas z should be looked in the regular coordinates.
@@ -181,7 +184,7 @@ def test_get_indices__uda_elevation(test_uda_elevation):
     z = np.array([-1.0, -2.0, -15.0, 1.0, -23.0])
 
     points_indices = imod.select.points_indices(
-        test_uda_elevation, x=x, y=y, z=z, out_of_bounds="ignore"
+        uda_elevation, x=x, y=y, z=z, out_of_bounds="ignore"
     )
 
     data_expected = {}
@@ -195,13 +198,13 @@ def test_get_indices__uda_elevation(test_uda_elevation):
         np.testing.assert_equal(points_indices[key], data_expected[key])
 
 
-def test_get_values__uda_elevation(test_uda_elevation):
+def test_get_values__uda_elevation(uda_elevation):
     x = np.array([30_000.0, 31_000.0, 30_000.0, 1.0, 31_000.0])
     y = np.array([400_000.0, 390_000.0, 400_000.0, 1.0, 390_000.0])
     z = np.array([-1.0, -2.0, -15.0, 1.0, -23.0])
 
     points_values = imod.select.points_values(
-        test_uda_elevation, x=x, y=y, z=z, out_of_bounds="ignore"
+        uda_elevation, x=x, y=y, z=z, out_of_bounds="ignore"
     )
     data_expected = np.array([3.04, -0.74, -6.96, -20.74])
 

--- a/imod/tests/test_select/test_select_points.py
+++ b/imod/tests/test_select/test_select_points.py
@@ -47,6 +47,7 @@ def test_uda(test_da):
 @pytest.fixture(scope="function")
 def uda_elevation():
     from xugrid.data.sample_data import REGISTRY
+
     with FileLock(REGISTRY.path / "xugrid_elevation_nl.nc.lock"):
         elevation = xu.data.elevation_nl()
     return xu.concat(


### PR DESCRIPTION
Fixes #1267 and #1268

# Description
This does the following:
- fixes a bug with ``self.__get_k`` and different keys for the ``NodePropertyFlow``. Now the method ``__get_k`` is implicitly hardcoded with the "npf" key, as this is the ``NodePropertyFlow._pkg_id``
- Adds a method ``Groundwater.prepare_wel_for_mf6`` to allocate wells to the public API. Users can call this for debugging purposes and ``primod`` can call it to fetch Mf6Wel objects to for its coupling schemes
- Make ``_get_k`` and ``_get_domain_geometry`` methods semi-private and add tests for these functions.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
