### PR TITLE
Fix Issue #1262 Purge np.bool, convert to np.bool_

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -30,6 +30,8 @@ Fixed
   the water content file of :class:`imod.mf6.UnsaturatedZoneFlow`.
 - `imod.prj.open_projectfile_data` is now able to also read IPF data for
   sprinkling wells in the CAP package.
+- Fix that caused iMOD Python to break upon import with numpy >=1.23, <2.0 .
+
 
 Changed
 ~~~~~~~

--- a/imod/select/points.py
+++ b/imod/select/points.py
@@ -64,7 +64,7 @@ def __arr_like_points(points: dict, fill_value: Any) -> npt.NDArray:
     return np.full(shape, fill_value)
 
 
-def points_in_bounds(da: GridDataArray, **points) -> npt.NDArray[np.bool]:
+def points_in_bounds(da: GridDataArray, **points) -> npt.NDArray[np.bool_]:
     """
     Returns whether points specified by keyword arguments fall within the bounds
     of ``da``.


### PR DESCRIPTION
Fixes #1262

# Description
``np.bool`` was an alias for the builtin bool. It was removed in numpy >1.23, but then reintroduced in numpy 2.0 for some reason.

It was used in a type hint ``points_in_bounds``. If you try to install iMOD Python with 1.26, it breaks upon import.

I think adding extra test jobs to for all kinds of versions for dependencies, defeats the purpose of the test bench, so I didn't add any extra tests. This issue is very specific, as iMOD Python now breaks for very specific versions of numpy: >=1.23, <2.0. 

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
