### PR TITLE
Issue #1273 cleanup example

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -91,6 +91,10 @@ Added
 - :meth:`imod.msw.MetaSwapModel.regrid_like` to regrid MetaSWAP models. This is
   still experimental functionality, regridding the :class:`imod.msw.Sprinkling`
   is not yet supported.
+- The context :func:`imod.util.context.print_if_error` to print an error instead
+  of raising it in a ``with`` statement. This is useful for code snippets which
+  definitely will fail.
+
 
 Removed
 ~~~~~~~

--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -15,6 +15,7 @@ Utilities
     
     cd
     ignore_warnings
+    print_if_error
     to_datetime
 
     coord_reference

--- a/examples/user-guide/10-cleanup.py
+++ b/examples/user-guide/10-cleanup.py
@@ -19,21 +19,33 @@ gwf_simulation = imod.data.hondsrug_simulation(tmpdir / "hondsrug_saved")
 # %%
 
 def get_colleagues_data(gwf_model):
-    from copy import deepcopy
-    riv_ds = deepcopy(gwf_model["riv"].dataset)
+    import xarray as xr
+    dis_ds = gwf_model["dis"].dataset
+    riv_ds_old = gwf_model["riv"].dataset
+    # Existing RIV package has only layer coord with [1, 3, 5, 6]. This causes
+    # problems with some methods, at least with cleanup. Therefore align data
+    # here for this example. Not sure if we want to support river packages with
+    # limited layer coords.
+    riv_ds, _ = xr.align(riv_ds_old, dis_ds, join="outer")
     x = riv_ds.coords["x"]
+    y = riv_ds.coords["y"]
     riv_bot_da = riv_ds["bottom_elevation"]
     riv_ds["stage"] += 0.05
     riv_ds["stage"] = riv_ds["stage"].where(x > 239500)
     riv_ds["conductance"] = riv_ds["conductance"].fillna(0.0)
+    x_preserve = (x < 244200) | (x > 246000)
+    y_preserve = (y < 560000) | (y > 561000)
     riv_ds["bottom_elevation"] = riv_bot_da.where(
-        (x > 244000) & (x < 246000), 
+        x_preserve | y_preserve, 
     riv_bot_da + 0.15)
     return riv_ds
 
 
 
 # %%
+#
+# Update existing model with new data
+# -----------------------------------
 #
 # Your dear colleague has brought you some new data for tile drainage, which
 # should be much better than the previous dataset "riv" included in the
@@ -66,7 +78,7 @@ gwf_model["new_riv"] = imod.mf6.River(**new_riv_ds)
 
 tmp_dir = imod.util.temporary_directory()
 
-gwf_simulation.write(tmp_dir)
+#gwf_simulation.write(tmp_dir)
 
 # %%
 #
@@ -76,15 +88,159 @@ gwf_simulation.write(tmp_dir)
 # * The bottom elevation exceeds stage in some cells
 # * NoData cells are not aligned between stage and conductance
 # * NoData cells are not aligned between stage and bottom_elevation
-# * There are conductance values with value < 0.0
-# 
-# *Exercise*: Use the function ``imod.visualize.plot_map`` to visually inspect
-# the errors in your colleagues dataset.
-# 
+# * There are conductance values with value <= 0.0
 
 # %%
+# 
+# *Exercise*: Use the function ``imod.visualize.plot_map`` to visually inspect
+# the errors in your colleagues dataset. You can alter the variable name to
+# inspect different variables.
+# 
 
+imod.visualize.plot_map(
+    new_riv_ds["stage"].max(dim="layer"), "viridis", np.linspace(-1, 19, 9)
+)
 
+# %% 
+# 
+# We can also check where stage exceeds river bottom elevation using basic
+# xarray functionality.
 
+stage_above_riv_bot = new_riv_ds["stage"] < new_riv_ds["bottom_elevation"]
 
+imod.visualize.plot_map(
+    stage_above_riv_bot.max(dim="layer"), "viridis", [0, 1]
+)
 
+# %%
+# 
+# So luckily the area affected by this error is only small. Let's investigate
+# the size of the error here.
+# 
+
+diff = new_riv_ds["bottom_elevation"] - new_riv_ds["stage"]
+
+max_diff = diff.max()
+
+max_diff
+
+# %%
+#
+# That is a relatively subtle error, which is probably why it slipped your
+# colleague's attention. Let's plot the troublesome area:
+
+imod.visualize.plot_map(
+    diff.where(stage_above_riv_bot).max(dim="layer"), "viridis", np.linspace(0, max_diff.values, 9)
+)
+
+# %%
+# 
+# That is only a small area. Plotting these errors can help you analyze the size
+# of problems and communicate with your colleague where there are problems.
+#
+# Data cleanup
+# ------------
+# 
+# The data quality seems acceptable for now to carry on modelling, so we can
+# already set up a model for the project. We need to communicate with colleagues
+# later that there are mistakes, so that the errors can be corrected.
+# 
+# iMOD Python has a set of utilities to help you with cleaning erronous data.
+# Note that these cleanup utilities can only fix a limited set of common
+# mistakes, in ways you might not need/like. It therefore is always wise to
+# verify if you think the fixes are correct in this case.
+#
+# Let's clean up the problematic river data using the
+# :meth:`imod.mf6.River.cleanup` method. Note that this method changes the data
+# inplace. This means that the package's will be updated, without returning a
+# new copy of the package. This means that do comparisons of the
+# dataset before and after the fix, we can copy the dirty dataset first.
+
+dirty_ds = gwf_model["new_riv"].dataset.copy()
+
+# %% 
+# 
+# We can now clean up the package. To clean up the River package, the method
+# requires the model discretization, contained in the
+# :class:`imod.mf6.StructuredDiscretization` package. In this model, we named
+# this package "dis".
+
+dis_pkg = gwf_model["dis"]
+gwf_model["new_riv"].cleanup(dis=dis_pkg)
+
+cleaned_ds = gwf_model["new_riv"].dataset
+
+# %%
+#
+# According to the method's explanation (the method calls
+# :func:`imod.prepare.cleanup_riv`), the bottom elevation should be altered by
+# the cleanup function.
+#
+# Let's first see if the stages were altered, we'll calculate the difference
+# between the original stage and cleaned version.
+
+diff_stage = dirty_ds["stage"] - cleaned_ds["stage"]
+
+imod.visualize.plot_map(
+    diff_stage.max(dim="layer"), "viridis", np.linspace(0, max_diff.values, 9)
+)
+
+# %%
+#
+# The stages are indeed not altered.
+#
+# Let's see if the bottom elevations are lowered, we'll calculate the difference
+# between the original bottom elevation and cleaned version.
+
+diff_riv_bot = dirty_ds["bottom_elevation"] - cleaned_ds["bottom_elevation"]
+
+imod.visualize.plot_map(
+    diff_riv_bot.max(dim="layer"), "viridis", np.linspace(0, max_diff.values, 9)
+)
+# %%
+#
+# You can see the bottom elevation was lowered by the cleanup method.
+# Furthermore the area in the west where no active stages were defined are also
+# deactivated.
+#
+# Writing the cleaned model
+# -------------------------
+#
+# The river package has been Let's see if we can write the model.
+
+gwf_simulation.write(tmp_dir)
+
+# %%
+#
+# Great! The model was succesfully written!
+#
+# Cleaning data without a MODFLOW6 simulation
+# -------------------------------------------
+#
+# There might be situations where you do not have a MODFLOW6 simulation at hand,
+# and you still want to clean up your river grids. For this you can use the
+# :func:`imod.prepare.cleanup_riv` function. For this you need to separately
+# provide your grids.
+#
+
+idomain = dis_pkg["idomain"]
+bottom = dis_pkg["bottom"]
+stage = dirty_ds["stage"]
+conductance = dirty_ds["conductance"]
+bottom_elevation = dirty_ds["bottom_elevation"]
+
+riv_cleaned_dict = imod.prepare.cleanup_riv(
+    idomain, bottom, stage, conductance, bottom_elevation
+)
+
+riv_cleaned_dict
+
+# %%
+#
+# This returns a dictionary which you can feed to the River package.
+
+riv_pkg = imod.mf6.River(**riv_cleaned_dict)
+
+riv_pkg
+
+# %%

--- a/examples/user-guide/10-cleanup.py
+++ b/examples/user-guide/10-cleanup.py
@@ -85,6 +85,8 @@ gwf_model["new_riv"] = imod.mf6.River(**new_riv_ds)
 
 tmp_dir = imod.util.temporary_directory()
 
+# Ignore the "with" statement, it is to succesfully render the Jupyter notebook
+# online.
 with PrintErrorInsteadOfRaise():
     gwf_simulation.write(tmp_dir)
 

--- a/examples/user-guide/10-cleanup.py
+++ b/examples/user-guide/10-cleanup.py
@@ -4,7 +4,7 @@ Data cleanup
 
 More often than not, data contained in databases is not entirely consistent,
 causing errors. It therefore is useful to have some utilities at hand to clean
-up data. We included some convenience methods to help cleaning up inconsistent
+up data. We included some convenience methods to help clean up inconsistent
 datasets.
 """
 
@@ -140,9 +140,9 @@ imod.visualize.plot_map(
 #
 # Let's clean up the problematic river data using the
 # :meth:`imod.mf6.River.cleanup` method. Note that this method changes the data
-# inplace. This means that the package's will be updated, without returning a
-# new copy of the package. This means that do comparisons of the
-# dataset before and after the fix, we can copy the dirty dataset first.
+# inplace. This means that the package will be updated, without returning a new
+# copy of the package. This means that we need to copy the dirty dataset first,
+# before we can do comparisons of the dataset before and after the fix.
 
 dirty_ds = gwf_model["new_riv"].dataset.copy()
 

--- a/examples/user-guide/10-cleanup.py
+++ b/examples/user-guide/10-cleanup.py
@@ -1,4 +1,7 @@
 """
+Data cleanup
+============
+
 More often than not, data contained in databases is not entirely consistent,
 causing errors. It therefore is useful to have some utilities at hand to clean
 up data. We included some convenience methods to help cleaning up inconsistent
@@ -23,8 +26,6 @@ from imod.util.context import print_if_error
 tmpdir = imod.util.temporary_directory()
 
 gwf_simulation = imod.data.hondsrug_simulation(tmpdir / "hondsrug_saved")
-
-# %%
 
 
 # %%
@@ -105,7 +106,7 @@ imod.visualize.plot_map(stage_above_riv_bot.max(dim="layer"), "viridis", [0, 1])
 
 diff = new_riv_ds["bottom_elevation"] - new_riv_ds["stage"]
 
-max_diff = diff.max()
+max_diff = diff.max().values
 
 max_diff
 
@@ -117,7 +118,7 @@ max_diff
 imod.visualize.plot_map(
     diff.where(stage_above_riv_bot).max(dim="layer"),
     "viridis",
-    np.linspace(0, max_diff.values, 9),
+    np.linspace(0, max_diff, 9),
 )
 
 # %%
@@ -125,8 +126,8 @@ imod.visualize.plot_map(
 # That is only a small area. Plotting these errors can help you analyze the size
 # of problems and communicate with your colleague where there are problems.
 #
-# Data cleanup
-# ------------
+# The ``cleanup`` method
+# ----------------------
 #
 # The data quality seems acceptable for now to carry on modelling, so we can
 # already set up a model for the project. We need to communicate with colleagues
@@ -169,7 +170,7 @@ cleaned_ds = gwf_model["new_riv"].dataset
 diff_stage = dirty_ds["stage"] - cleaned_ds["stage"]
 
 imod.visualize.plot_map(
-    diff_stage.max(dim="layer"), "viridis", np.linspace(0, max_diff.values, 9)
+    diff_stage.max(dim="layer"), "viridis", np.linspace(0, max_diff, 9)
 )
 
 # %%
@@ -182,7 +183,7 @@ imod.visualize.plot_map(
 diff_riv_bot = dirty_ds["bottom_elevation"] - cleaned_ds["bottom_elevation"]
 
 imod.visualize.plot_map(
-    diff_riv_bot.max(dim="layer"), "viridis", np.linspace(0, max_diff.values, 9)
+    diff_riv_bot.max(dim="layer"), "viridis", np.linspace(0, max_diff, 9)
 )
 # %%
 #
@@ -190,10 +191,19 @@ imod.visualize.plot_map(
 # Furthermore the area in the west where no active stages were defined are also
 # deactivated.
 #
+# We advice to always verify if the data is cleaned in a manner that fits your
+# use-case. For example, you might need to raise the stages to the river bottom
+# elevation, instead of lowering the latter to the former like the ``cleanup``
+# method just did. In such case, you need to manually fix the data.
+#
+# The ``cleanup`` method helps getting your data through the model validation,
+# but is not guaranteed to be the "best" way to clean up your data!
+#
 # Writing the cleaned model
 # -------------------------
 #
-# The river package has been Let's see if we can write the model.
+# Now that the river package has been cleaned, let's see if we can write the
+# model.
 
 gwf_simulation.write(tmp_dir)
 

--- a/examples/user-guide/10-cleanup.py
+++ b/examples/user-guide/10-cleanup.py
@@ -1,0 +1,90 @@
+"""
+More often than not, data contained in databases is not entirely consistent,
+causing errors. It therefore is useful to have some utilities at hand to clean
+up data. We included some convenience methods to help cleaning up inconsistent
+datasets.
+"""
+import numpy as np
+
+import imod
+
+# %%
+# There is a separate example contained in
+# :doc:`hondsrug </examples/mf6/hondsrug>`
+# that you should look at if you are interested in the model building
+tmpdir = imod.util.temporary_directory()
+
+gwf_simulation = imod.data.hondsrug_simulation(tmpdir / "hondsrug_saved")
+
+# %%
+
+def get_colleagues_data(gwf_model):
+    from copy import deepcopy
+    riv_ds = deepcopy(gwf_model["riv"].dataset)
+    x = riv_ds.coords["x"]
+    riv_bot_da = riv_ds["bottom_elevation"]
+    riv_ds["stage"] += 0.05
+    riv_ds["stage"] = riv_ds["stage"].where(x > 239500)
+    riv_ds["conductance"] = riv_ds["conductance"].fillna(0.0)
+    riv_ds["bottom_elevation"] = riv_bot_da.where(
+        (x > 244000) & (x < 246000), 
+    riv_bot_da + 0.15)
+    return riv_ds
+
+
+
+# %%
+#
+# Your dear colleague has brought you some new data for tile drainage, which
+# should be much better than the previous dataset "riv" included in the
+# database.
+
+gwf_model = gwf_simulation["GWF"]
+new_riv_ds = get_colleagues_data(gwf_model)
+
+# %%
+# Let's do a brief visual check if the colleague's data seems alright:
+
+# Plot
+imod.visualize.plot_map(
+    new_riv_ds["stage"].max(dim="layer"), "viridis", np.linspace(-1, 19, 9)
+)
+
+# %% 
+# 
+# Hmmmm, the western side of the river stage grid seems suspiciously inactive...
+# We have to contact our colleague later. For now, let's work with what we have
+# and update the model.
+
+old_riv = gwf_model.pop("riv")
+
+gwf_model["new_riv"] = imod.mf6.River(**new_riv_ds)
+
+# %%
+# 
+# Lets's write the simulation with our updated model!
+
+tmp_dir = imod.util.temporary_directory()
+
+gwf_simulation.write(tmp_dir)
+
+# %%
+#
+# Oh no! Our river package has a completely inconsistent dataset.
+# The model validation raises the following issues:
+# 
+# * The bottom elevation exceeds stage in some cells
+# * NoData cells are not aligned between stage and conductance
+# * NoData cells are not aligned between stage and bottom_elevation
+# * There are conductance values with value < 0.0
+# 
+# *Exercise*: Use the function ``imod.visualize.plot_map`` to visually inspect
+# the errors in your colleagues dataset.
+# 
+
+# %%
+
+
+
+
+

--- a/examples/user-guide/10-cleanup.py
+++ b/examples/user-guide/10-cleanup.py
@@ -41,6 +41,14 @@ def get_colleagues_data(gwf_model):
     return riv_ds
 
 
+class PrintErrorInsteadOfRaise:
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, tb):
+        if exc_type:
+            print(f"{exc_val}")
+            return True  # swallow the exception
 
 # %%
 #
@@ -57,7 +65,6 @@ new_riv_ds = get_colleagues_data(gwf_model)
 # %%
 # Let's do a brief visual check if the colleague's data seems alright:
 
-# Plot
 imod.visualize.plot_map(
     new_riv_ds["stage"].max(dim="layer"), "viridis", np.linspace(-1, 19, 9)
 )
@@ -78,7 +85,8 @@ gwf_model["new_riv"] = imod.mf6.River(**new_riv_ds)
 
 tmp_dir = imod.util.temporary_directory()
 
-#gwf_simulation.write(tmp_dir)
+with PrintErrorInsteadOfRaise():
+    gwf_simulation.write(tmp_dir)
 
 # %%
 #

--- a/examples/user-guide/10-cleanup.py
+++ b/examples/user-guide/10-cleanup.py
@@ -4,9 +4,17 @@ causing errors. It therefore is useful to have some utilities at hand to clean
 up data. We included some convenience methods to help cleaning up inconsistent
 datasets.
 """
+
+# %%
+# We'll start with the usual imports
 import numpy as np
 
 import imod
+
+# %%
+# These imports can be ignored
+from imod.schemata import ValidationError
+from imod.util.context import print_if_error
 
 # %%
 # There is a separate example contained in
@@ -18,49 +26,18 @@ gwf_simulation = imod.data.hondsrug_simulation(tmpdir / "hondsrug_saved")
 
 # %%
 
-def get_colleagues_data(gwf_model):
-    import xarray as xr
-    dis_ds = gwf_model["dis"].dataset
-    riv_ds_old = gwf_model["riv"].dataset
-    # Existing RIV package has only layer coord with [1, 3, 5, 6]. This causes
-    # problems with some methods, at least with cleanup. Therefore align data
-    # here for this example. Not sure if we want to support river packages with
-    # limited layer coords.
-    riv_ds, _ = xr.align(riv_ds_old, dis_ds, join="outer")
-    x = riv_ds.coords["x"]
-    y = riv_ds.coords["y"]
-    riv_bot_da = riv_ds["bottom_elevation"]
-    riv_ds["stage"] += 0.05
-    riv_ds["stage"] = riv_ds["stage"].where(x > 239500)
-    riv_ds["conductance"] = riv_ds["conductance"].fillna(0.0)
-    x_preserve = (x < 244200) | (x > 246000)
-    y_preserve = (y < 560000) | (y > 561000)
-    riv_ds["bottom_elevation"] = riv_bot_da.where(
-        x_preserve | y_preserve, 
-    riv_bot_da + 0.15)
-    return riv_ds
-
-
-class PrintErrorInsteadOfRaise:
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_val, tb):
-        if exc_type:
-            print(f"{exc_val}")
-            return True  # swallow the exception
 
 # %%
 #
 # Update existing model with new data
 # -----------------------------------
 #
-# Your dear colleague has brought you some new data for tile drainage, which
+# Your dear colleague has brought you some new data for the river package, which
 # should be much better than the previous dataset "riv" included in the
 # database.
 
 gwf_model = gwf_simulation["GWF"]
-new_riv_ds = get_colleagues_data(gwf_model)
+new_riv_ds = imod.data.colleagues_river_data(tmpdir / "hondsrug_saved")
 
 # %%
 # Let's do a brief visual check if the colleague's data seems alright:
@@ -69,8 +46,8 @@ imod.visualize.plot_map(
     new_riv_ds["stage"].max(dim="layer"), "viridis", np.linspace(-1, 19, 9)
 )
 
-# %% 
-# 
+# %%
+#
 # Hmmmm, the western side of the river stage grid seems suspiciously inactive...
 # We have to contact our colleague later. For now, let's work with what we have
 # and update the model.
@@ -80,53 +57,51 @@ old_riv = gwf_model.pop("riv")
 gwf_model["new_riv"] = imod.mf6.River(**new_riv_ds)
 
 # %%
-# 
+#
 # Lets's write the simulation with our updated model!
 
 tmp_dir = imod.util.temporary_directory()
 
 # Ignore the "with" statement, it is to succesfully render the Jupyter notebook
 # online.
-with PrintErrorInsteadOfRaise():
+with print_if_error(ValidationError):
     gwf_simulation.write(tmp_dir)
 
 # %%
 #
 # Oh no! Our river package has a completely inconsistent dataset.
 # The model validation raises the following issues:
-# 
+#
 # * The bottom elevation exceeds stage in some cells
 # * NoData cells are not aligned between stage and conductance
 # * NoData cells are not aligned between stage and bottom_elevation
 # * There are conductance values with value <= 0.0
 
 # %%
-# 
+#
 # *Exercise*: Use the function ``imod.visualize.plot_map`` to visually inspect
 # the errors in your colleagues dataset. You can alter the variable name to
 # inspect different variables.
-# 
+#
 
 imod.visualize.plot_map(
     new_riv_ds["stage"].max(dim="layer"), "viridis", np.linspace(-1, 19, 9)
 )
 
-# %% 
-# 
+# %%
+#
 # We can also check where stage exceeds river bottom elevation using basic
 # xarray functionality.
 
 stage_above_riv_bot = new_riv_ds["stage"] < new_riv_ds["bottom_elevation"]
 
-imod.visualize.plot_map(
-    stage_above_riv_bot.max(dim="layer"), "viridis", [0, 1]
-)
+imod.visualize.plot_map(stage_above_riv_bot.max(dim="layer"), "viridis", [0, 1])
 
 # %%
-# 
+#
 # So luckily the area affected by this error is only small. Let's investigate
 # the size of the error here.
-# 
+#
 
 diff = new_riv_ds["bottom_elevation"] - new_riv_ds["stage"]
 
@@ -140,21 +115,23 @@ max_diff
 # colleague's attention. Let's plot the troublesome area:
 
 imod.visualize.plot_map(
-    diff.where(stage_above_riv_bot).max(dim="layer"), "viridis", np.linspace(0, max_diff.values, 9)
+    diff.where(stage_above_riv_bot).max(dim="layer"),
+    "viridis",
+    np.linspace(0, max_diff.values, 9),
 )
 
 # %%
-# 
+#
 # That is only a small area. Plotting these errors can help you analyze the size
 # of problems and communicate with your colleague where there are problems.
 #
 # Data cleanup
 # ------------
-# 
+#
 # The data quality seems acceptable for now to carry on modelling, so we can
 # already set up a model for the project. We need to communicate with colleagues
 # later that there are mistakes, so that the errors can be corrected.
-# 
+#
 # iMOD Python has a set of utilities to help you with cleaning erronous data.
 # Note that these cleanup utilities can only fix a limited set of common
 # mistakes, in ways you might not need/like. It therefore is always wise to
@@ -168,8 +145,8 @@ imod.visualize.plot_map(
 
 dirty_ds = gwf_model["new_riv"].dataset.copy()
 
-# %% 
-# 
+# %%
+#
 # We can now clean up the package. To clean up the River package, the method
 # requires the model discretization, contained in the
 # :class:`imod.mf6.StructuredDiscretization` package. In this model, we named
@@ -228,9 +205,10 @@ gwf_simulation.write(tmp_dir)
 # -------------------------------------------
 #
 # There might be situations where you do not have a MODFLOW6 simulation or River
-# package at hand, and you still want to clean up your river grids. For this you
-# can use the :func:`imod.prepare.cleanup_riv` function. For this you need to
-# separately provide your grids.
+# package at hand, and you still want to clean up your river grids. In this
+# case, you can use the :func:`imod.prepare.cleanup_riv` function. This function
+# requires you to to separately provide your grids and returns a dictionary of
+# grids.
 #
 
 idomain = dis_pkg["idomain"]

--- a/examples/user-guide/10-cleanup.py
+++ b/examples/user-guide/10-cleanup.py
@@ -217,10 +217,10 @@ gwf_simulation.write(tmp_dir)
 # Cleaning data without a MODFLOW6 simulation
 # -------------------------------------------
 #
-# There might be situations where you do not have a MODFLOW6 simulation at hand,
-# and you still want to clean up your river grids. For this you can use the
-# :func:`imod.prepare.cleanup_riv` function. For this you need to separately
-# provide your grids.
+# There might be situations where you do not have a MODFLOW6 simulation or River
+# package at hand, and you still want to clean up your river grids. For this you
+# can use the :func:`imod.prepare.cleanup_riv` function. For this you need to
+# separately provide your grids.
 #
 
 idomain = dis_pkg["idomain"]
@@ -237,7 +237,8 @@ riv_cleaned_dict
 
 # %%
 #
-# This returns a dictionary which you can feed to the River package.
+# This returns a dictionary which you can use however you want, and furthermore
+# feed to the River package.
 
 riv_pkg = imod.mf6.River(**riv_cleaned_dict)
 

--- a/examples/user-guide/10-cleanup.py
+++ b/examples/user-guide/10-cleanup.py
@@ -17,7 +17,7 @@ import imod
 # %%
 # These imports can be ignored
 from imod.schemata import ValidationError
-from imod.util.context import print_if_error
+from imod.util import print_if_error
 
 # %%
 # There is a separate example contained in

--- a/imod/data/__init__.py
+++ b/imod/data/__init__.py
@@ -2,6 +2,7 @@
 from .sample_data import (
     ahn,
     circle,
+    colleagues_river_data,
     fluxes,
     head_observations,
     hondsrug_crosssection,

--- a/imod/data/sample_data.py
+++ b/imod/data/sample_data.py
@@ -248,3 +248,30 @@ def hondsrug_planar_river() -> xr.Dataset:
     planar_river["stage"] = (top - planar_river["stage"]) / 2 + planar_river["stage"]
 
     return planar_river
+
+
+def colleagues_river_data(path: Union[str, Path]):
+    """
+    River data with some mistakes introduced to showcase cleanup
+    utilities.
+    """
+    gwf_model = hondsrug_simulation(path)["GWF"]
+    dis_ds = gwf_model["dis"].dataset
+    riv_ds_old = gwf_model["riv"].dataset
+    # Existing RIV package has only layer coord with [1, 3, 5, 6]. This causes
+    # problems with some methods, at least with cleanup. Therefore align data
+    # here for the cleanup example. Not sure if we want to support river
+    # packages with limited layer coords.
+    riv_ds, _ = xr.align(riv_ds_old, dis_ds, join="outer")
+    x = riv_ds.coords["x"]
+    y = riv_ds.coords["y"]
+    riv_bot_da = riv_ds["bottom_elevation"]
+    riv_ds["stage"] += 0.05
+    riv_ds["stage"] = riv_ds["stage"].where(x > 239500)
+    riv_ds["conductance"] = riv_ds["conductance"].fillna(0.0)
+    x_preserve = (x < 244200) | (x > 246000)
+    y_preserve = (y < 560000) | (y > 561000)
+    riv_ds["bottom_elevation"] = riv_bot_da.where(
+        x_preserve | y_preserve, riv_bot_da + 0.15
+    )
+    return riv_ds

--- a/imod/data/sample_data.py
+++ b/imod/data/sample_data.py
@@ -260,8 +260,8 @@ def colleagues_river_data(path: Union[str, Path]):
     riv_ds_old = gwf_model["riv"].dataset
     # Existing RIV package has only layer coord with [1, 3, 5, 6]. This causes
     # problems with some methods, at least with cleanup. Therefore align data
-    # here for the cleanup example. Not sure if we want to support river
-    # packages with limited layer coords.
+    # here for the cleanup example. River packages with limited layer coords are
+    # currently not fully supported.
     riv_ds, _ = xr.align(riv_ds_old, dis_ds, join="outer")
     x = riv_ds.coords["x"]
     y = riv_ds.coords["y"]

--- a/imod/tests/test_util/test_util_context.py
+++ b/imod/tests/test_util/test_util_context.py
@@ -1,0 +1,12 @@
+import pytest
+
+from imod.util.context import print_if_error
+
+
+def test_print_if_error():
+    with print_if_error(TypeError):
+        1 + "a"
+    
+    with pytest.raises(TypeError):
+        with print_if_error(ValueError):
+            1 + "a"

--- a/imod/tests/test_util/test_util_context.py
+++ b/imod/tests/test_util/test_util_context.py
@@ -6,7 +6,7 @@ from imod.util.context import print_if_error
 def test_print_if_error():
     with print_if_error(TypeError):
         1 + "a"
-    
+
     with pytest.raises(TypeError):
         with print_if_error(ValueError):
             1 + "a"

--- a/imod/util/__init__.py
+++ b/imod/util/__init__.py
@@ -7,7 +7,7 @@ imod/util.py. Therefore these should be available under the imod.util namespace.
 
 import warnings
 
-from imod.util.context import cd, ignore_warnings
+from imod.util.context import cd, ignore_warnings, print_if_error
 from imod.util.path import temporary_directory
 from imod.util.spatial import (
     coord_reference,

--- a/imod/util/context.py
+++ b/imod/util/context.py
@@ -52,7 +52,7 @@ def print_if_error(exception_type: BaseException):
     ----------
     exception_type: Exception
         Exception to accept
-    
+
     Examples
     --------
     >>> with print_if_error(TypeError):

--- a/imod/util/context.py
+++ b/imod/util/context.py
@@ -43,17 +43,22 @@ def cd(path: Union[str, pathlib.Path]):
 
 @contextlib.contextmanager
 def print_if_error(exception_type: BaseException):
+    """
+    Prints error instead of raising it. Useful for cases when pieces of code are
+    expected to fail, but the script needs to continue. This is a common
+    use-case for examples in the documentation.
+
+    Parameters
+    ----------
+    exception_type: Exception
+        Exception to accept
+    
+    Examples
+    --------
+    >>> with print_if_error(TypeError):
+            1 + "a"
+    """
     try:
         yield
     except exception_type as e:
         print(e)
-
-
-class PrintErrorInsteadOfRaise:
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_val, _):
-        if exc_type:
-            print(f"{exc_val}")
-            return True  # swallow the exception

--- a/imod/util/context.py
+++ b/imod/util/context.py
@@ -42,7 +42,7 @@ def cd(path: Union[str, pathlib.Path]):
 
 
 @contextlib.contextmanager
-def print_if_error(exception_type: BaseException):
+def print_if_error(exception_type: type[BaseException]):
     """
     Prints error instead of raising it. Useful for cases when pieces of code are
     expected to fail, but the script needs to continue. This is a common

--- a/imod/util/context.py
+++ b/imod/util/context.py
@@ -39,3 +39,21 @@ def cd(path: Union[str, pathlib.Path]):
         yield
     finally:
         os.chdir(curdir)
+
+
+@contextlib.contextmanager
+def print_if_error(exception_type: BaseException):
+    try:
+        yield
+    except exception_type as e:
+        print(e)
+
+
+class PrintErrorInsteadOfRaise:
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, _):
+        if exc_type:
+            print(f"{exc_val}")
+            return True  # swallow the exception


### PR DESCRIPTION
Fixes #1273

# Description
Add example of cleanup utilities to the user guide. I think it shows a common use-case for cleaning up data.

Technically the most challenging issue was to work around the fact that sphinx_gallery doesn't have an option to select expected errors in specific code blocks. There is [this PR](https://github.com/sphinx-gallery/sphinx-gallery/pull/930) to introduce this, but unfortunately for us this has not been finished yet. 

I resorted to trapping the error and printing it with a context manager, that seemed like the cleanest solution to me. I added this small context to the public API, so that users can also read in the online documentation what the context manager does.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [x] **If feature added**: Added/extended example
