### PR TITLE
Issue #1183 Update documentation on package managers

### DIFF
--- a/docs/faq/general.rst
+++ b/docs/faq/general.rst
@@ -117,7 +117,7 @@ imod has significantly more:
 Many of these packages have binary dependencies, but both FloPy and imod can be
 installed via ``pip``. However, full functionality -- such as exporting to
 netCDF, reading and writing GIS formats, or 3D visualization -- involves more
-complex dependencies, which require the ``mamba`` or ``conda`` package managers
+complex dependencies, which require the ``pixi`` or ``conda`` package managers
 to install correctly (especially on Windows).
  
 Large data

--- a/docs/faq/python.rst
+++ b/docs/faq/python.rst
@@ -78,7 +78,7 @@ Installing Python packages -- `without the agonizing pain`_
 
 We highly recommend installing packages using ``pixi`` or alternatively ``conda``
 
-Pixi and conda are package- and environment managers that installs packages from
+Pixi and conda are package- and environment-managers that install packages from
 a remote repository (which is a remote storage location of software packages).
 Pip (acronym for "Pip install packages") can also be used for installing Python
 packages, but was designed mainly to install pure Python packages, without
@@ -86,21 +86,30 @@ binary dependencies; trying to ``pip install`` packages with complex depencies
 is therefore a recipe for frustration and disaster.
 
 Pixi and conda, do several things. First and foremost, they solve the dependency
-problem when installing a package. Secondly, they also installs binary
+problem when installing a package. Secondly, they also install binary
 dependencies. Thirdly, they provides isolated Python installations (termed
 environments). You might create a new environment if you have unsatisfiable
 version requirements, like two versions of Python (e.g. 2.7 and 3.9).
 
 Additionally, pixi allows you to store an environment in a specific state in a
-textfile, allowing you to share envrionments with colleagues. conda and pip have
-similar functionality, but this is far from as robust as pixi implemented this.
+textfile, allowing you to share envrionments with colleagues. Conda and pip have
+similar functionality, but this is by far not as robust as pixi implemented
+this.
 
 Some packages cannot be installed by conda/pixi because they are not available
-on the conda channels. In that case, you can fall back on ``pip`` to install
-the package (``pip install {package name}``).
+on the conda channels. In that case, with pixi you can install these from PyPI
+(Python Package Index) as follows::
 
-Find the articles: `Understanding conda and pip`_ and Conda:`Myths and
-Misconceptions`_ for additional information. See also the `pixi docs`_.
+  pixi add <package_name> --pypi
+
+With conda you can fall back on ``pip`` to install the package:: 
+
+  pip install <package_name>
+
+
+Find the articles: `Let's stop dependency hell`_, `Understanding conda and pip`_
+and Conda:`Myths and Misconceptions`_ for additional information. See also the
+`pixi docs`_.
 
 
 Setting up an environment
@@ -189,6 +198,7 @@ You can find installers for Miniconda here:
 * https://conda.io/miniconda.html
 
 .. _"dependency hell": https://en.wikipedia.org/wiki/Dependency_hell
+.. _let's stop dependency hell: https://prefix.dev/blog/launching_pixi
 .. _without the agonizing pain: https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.110.418>
 .. _Understanding conda and pip: https://www.anaconda.com/understanding-conda-and-pip
 .. _Myths and Misconceptions: https://jakevdp.github.io/blog/2016/08/25/conda-myths-and-misconceptions/

--- a/docs/faq/python.rst
+++ b/docs/faq/python.rst
@@ -73,69 +73,34 @@ use the same version of ``A``, but you'll find that suddenly package ``D``
 affairs is colloquially called `"dependency hell"`_.
 
 
-Installing Python packages with mamba -- `without the agonizing pain`_
-----------------------------------------------------------------------
+Installing Python packages -- `without the agonizing pain`_
+-----------------------------------------------------------
 
-We highly recommend installing packages using ``mamba`` or ``conda``. Conda is
-a package and environment manager that installs packages from a remote
-repository (which is a remote storage location of software packages); Mamba is
-a (much) faster version of conda. Pip (acronym for "Pip install packages") can
-also be used for installing Python packages, but was designed mainly to install
-pure Python packages, without binary dependencies; trying to ``pip install``
-packages with complex depencies is therefore a recipe for frustration and
-disaster.
+We highly recommend installing packages using ``pixi`` or alternatively ``conda``
 
-Conda does several things. First and foremost, it solves the dependency problem
-when installing a package. Secondly, it also installs binary dependencies.
-Thirdly, it provides isolated Python installations (termed environments). You
-might create a new environment if you have unsatisfiable version requirements,
-like two versions of Python (e.g. 2.7 and 3.9).
+Pixi and conda are package- and environment managers that installs packages from
+a remote repository (which is a remote storage location of software packages).
+Pip (acronym for "Pip install packages") can also be used for installing Python
+packages, but was designed mainly to install pure Python packages, without
+binary dependencies; trying to ``pip install`` packages with complex depencies
+is therefore a recipe for frustration and disaster.
 
-Mamba is a reimplementation of the conda package manager in C++. As the imod
-package has a large number of dependencies, using ``mamba`` instead of
-``conda`` can strongly reduce installation times (from e.g. 30 minutes to 3
-minutes!). As ``mamba`` has become sufficiently stable, we now strongly
-recommend it over ``conda`` for installing packages and creating environments.
+Pixi and conda, do several things. First and foremost, they solve the dependency
+problem when installing a package. Secondly, they also installs binary
+dependencies. Thirdly, they provides isolated Python installations (termed
+environments). You might create a new environment if you have unsatisfiable
+version requirements, like two versions of Python (e.g. 2.7 and 3.9).
 
-Some packages cannot be installed by conda/mamba because they are not available
+Additionally, pixi allows you to store an environment in a specific state in a
+textfile, allowing you to share envrionments with colleagues. conda and pip have
+similar functionality, but this is far from as robust as pixi implemented this.
+
+Some packages cannot be installed by conda/pixi because they are not available
 on the conda channels. In that case, you can fall back on ``pip`` to install
 the package (``pip install {package name}``).
 
 Find the articles: `Understanding conda and pip`_ and Conda:`Myths and
-Misconceptions`_ for additional information. See also the `Mamba homepage`_.
-
-
-Anaconda, Miniconda, Miniforge, Mambaforge
-------------------------------------------
-
-Ananaconda and Miniconda both provide a Python installation and conda as the
-package manager. The difference between them is that Anaconda comes with a
-large number of packages pre-installed in the base environment (which is why
-the installation is over a gigabyte). Miniconda, on the other hand, comes
-bare bones. Since we recommend working from environments to install packages
-into (see below), we do not consider the full Anaconda installer attractive.
-
-.. note::
-
-  Since April 2020, Anaconda has `changed`_ their `Terms of Service`_, limiting
-  use of the anaconda repository to commercial users. If you worry you fall in
-  the category of commercial users, we recommend installing Miniforge or
-  Mambaforge instead. The change has negligible consequences for imod users, as
-  we've long fully relied on the community led `conda-forge`_ channel.
-
-You can find the Miniforge homepage and the Miniforge and Mambaforge installers
-here:
-
-* https://github.com/conda-forge/miniforge
-* https://github.com/conda-forge/miniforge#mambaforge
-
-You can find installers for Miniconda or Anaconda here:
-
-* https://conda.io/miniconda.html
-* https://www.anaconda.com/distribution/
-
-During installation, tick the box "Add Anaconda/Miniforge to PATH", even though it
-colors a suggestive red.
+Misconceptions`_ for additional information. See also the `pixi docs`_.
 
 
 Setting up an environment
@@ -176,8 +141,8 @@ Then start the interactive environment::
     pixi shell --environment interactive
 
 
-Installing a newer or old version
----------------------------------
+Installing a development version of iMOD Python
+-----------------------------------------------
 
 Since we're currently in the process of adding a lot of features, the version
 on PyPI or conda-forge doesn't always install the carry the latest updates.
@@ -194,18 +159,39 @@ To get the latest developments at a later point in time, execute within the
 
     git pull
     
-Installing specific (older) versions is possible by specifying a version
-number::
-
-    pip install imod==0.11.0
-    
 Past versions can also be found on the iMOD Python `releases page`_.
+
+
+Anaconda, Miniconda, Miniforge
+------------------------------
+
+Ananaconda and Miniconda both provide a Python installation and conda as the
+package manager. The difference between them is that Anaconda comes with a
+large number of packages pre-installed in the base environment (which is why
+the installation is over a gigabyte). Miniconda, on the other hand, comes
+bare bones. Since we recommend working from environments to install packages
+into (see below), we do not consider the full Anaconda installer attractive.
+
+.. note::
+
+  Since April 2020, Anaconda has `changed`_ their `Terms of Service`_, limiting
+  use of the anaconda repository to commercial users. If you worry you fall in
+  the category of commercial users, we recommend installing Miniforge instead.
+  The change has negligible consequences for imod users, as we've long fully
+  relied on the community led `conda-forge`_ channel.
+
+You can find the Miniforge homepage and the Miniforge installers here:
+
+* https://github.com/conda-forge/miniforge
+
+You can find installers for Miniconda here:
+
+* https://conda.io/miniconda.html
 
 .. _"dependency hell": https://en.wikipedia.org/wiki/Dependency_hell
 .. _without the agonizing pain: https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.110.418>
 .. _Understanding conda and pip: https://www.anaconda.com/understanding-conda-and-pip
 .. _Myths and Misconceptions: https://jakevdp.github.io/blog/2016/08/25/conda-myths-and-misconceptions/
-.. _Mamba homepage: https://github.com/mamba-org/mamba
 .. _changed: https://www.anaconda.com/blog/sustaining-our-stewardship-of-the-open-source-data-science-community
 .. _Terms of Service: https://www.anaconda.com/terms-of-service
 .. _conda-forge: https://conda-forge.org/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -114,12 +114,14 @@ You can activate your environment using::
 
   pixi shell
 
-These commands created a ``pixi.toml`` and a ``pixi.lock``. The ``pixi.toml``
-captures the instructions you gave pixi to look for dependencies. The
-``pixi.lock`` is textfile that captures the environment in a specific state, so
-with exact version numbers. This is very useful, as it allows you to transfer
-environments to other machines, by just copying two textfiles. The lockfile will
-be updated if you run ``pixi update`` or change the ``pixi.toml`` file. Both the
+These commands create a ``pixi.toml`` and a ``pixi.lock``. The ``pixi.toml``
+contains the dependencies of your project. If you followed the commands above,
+the only dependency present in the toml should be ``imod``. The ``pixi.lock`` is
+a textfile that captures the environment in a specific state, so all
+dependencies, with their dependencies and so on, with exact version numbers.
+This is very useful, as it allows you to get the exact same environment on a
+different machine, by just copying two textfiles. The lockfile will be updated
+if you run ``pixi update`` or change the ``pixi.toml`` file. Both the
 ``pixi.toml`` as well as the ``pixi.lock`` are required to fully reproduce an
 environment. 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python 3.7 or greater**. 
+You'll need **Python 3.10 or greater**. 
 
 The recommended way to install Python depends on your experience: Are you new to
 the Python packaging ecosystem or already got experience with it? If you already
@@ -22,19 +22,23 @@ Experienced
 ^^^^^^^^^^^
 
 For experienced users, who want to be in control of packages installed, we
-recommend using the `Mambaforge`_ Python distribution. This installs Python and
-the ``mamba`` package manager. `Miniforge`_ and `Miniconda`_ will only install Python
-and the ``conda`` package manager. Differences to note, in a nutshell:
+recommend installing using `pixi`_. Pixi supports creating reproducible
+projects, where all dependencies' versions in an environment are stored in a
+textfile, the "lockfile". On top of that, it is faster than other package
+managers.
 
-* ``mamba`` is much faster than ``conda``, but has identical commands. 
-* Mambaforge and miniforge are community driven installers, installing by
-  default from the ``conda-forge`` channel.
-* Miniconda is a company driven (Anaconda) installer, installing by default
+Alternatively, you can use the `Miniforge`_ Python distribution. This installs
+the ``conda`` package manager. This installer differs from the also
+commonly-used `Miniconda`_ installer, in a nutshell:
+
+* Miniforge is a community driven installers, installing by
+  default from the ``conda-forge`` channel (Pixi also does this).
+* Miniconda is a company driven installer, installing by default
   from the ``anaconda`` channel.
 * Installing from the ``anaconda`` channel has certain (legal) `limitations`_
-  for "commercial use".
+  for "commercial use", especially if you work in a large organization.
 
-Installing Mambaforge/Miniforge/Miniconda does not require administrative
+Installing Pixi/Mambaforge/Miniforge/Miniconda does not require administrative
 rights to your computer and doesn't interfere with any other Python
 installations in your system.
 
@@ -95,38 +99,47 @@ are listed `here. <https://deltares.github.io/deltaforge/index.html#where>`__
 Users new to the python package ecosystem are recommended to install iMOD Python
 using Deltaforge.
 
-Installing with mamba
-^^^^^^^^^^^^^^^^^^^^^
+Installing with pixi
+^^^^^^^^^^^^^^^^^^^^
 
-You can install ``imod`` using the `mamba package manager`_ that comes with the
-Mambaforge distribution. We advice to install ``imod`` in a seperate ``conda``
-environment, as you can simply delete these in case they break. Not doing so
-will install imod and its dependencies in your base environment, which requires
-a reinstall of Mambaforge in case this environment breaks::
+Pixi supports creating reproducible projects, where all dependencies' versions
+in an environment are stored in a textfile, the "lockfile". On top of that, it
+is faster than other package managers. Installing with pixi is fast and easy::
 
-  mamba create -n imodenv
-  mamba install -n imodenv imod --channel conda-forge
-  
-``mamba`` will automatically find the appropriate versions of the dependencies
-and in this case install them in the ``imodenv`` environment. Installing with
-mamba or conda will automatically download *all* optional dependencies, and
-enable all functionality.
+  pixi init my_project
+  cd my_project
+  pixi add imod
 
-To run scripts using ``imod``, you first have to activate the ``imodenv``
-environment::
+You can activate your environment using::
 
-  conda activate imodenv
+  pixi shell
+
+These commands created a ``pixi.toml`` and a ``pixi.lock``. The ``pixi.toml``
+captures the instructions you gave pixi to look for dependencies. The
+``pixi.lock`` is textfile that captures the environment in a specific state, so
+with exact version numbers. This is very useful, as it allows you to transfer
+environments to other machines, by just copying two textfiles. The lockfile will
+be updated if you run ``pixi update`` or change the ``pixi.toml`` file. Both the
+``pixi.toml`` as well as the ``pixi.lock`` are required to fully reproduce an
+environment. 
+
 
 Installing with conda
 ^^^^^^^^^^^^^^^^^^^^^
 
-Alternatively, you can also use the `conda package manager`_. Like mamba, conda
-will also infer the appropriate versions of the dependencies and install them.
-However, it generally takes around a factor 5 longer to do so, but may be
-worthwhile if mamba is unstable or buggy::
+Alternatively, you can also use the `conda package manager`_. We advice to
+install ``imod`` in a seperate ``conda`` environment, as you can simply delete
+these in case they break. Not doing so will install imod and its dependencies in
+your base environment, which requires a reinstall of Miniforge in case this
+environment breaks::
 
   conda create -n imodenv
   conda install -n imodenv imod --channel conda-forge
+
+``conda`` will automatically find the appropriate versions of the dependencies
+and in this case install them in the ``imodenv`` environment. Installing with
+conda will automatically download *all* optional dependencies, and
+enable all functionality.
 
 To run scripts using ``imod``, you first have to activate the ``imodenv``
 environment::
@@ -140,12 +153,12 @@ Finally, you can also use the `pip package manager`_::
 
   pip install imod
   
-Unlike installing with conda or mamba, installing with pip will not install
+Unlike installing with conda, installing with pip will not install
 all optional dependencies. This results in a far smaller installation, but
 it means that not all functionality is directly available.
 
 Refer to :doc:`../faq/python` in the FAQ section for background
-information on ``mamba``, ``conda``, and ``pip``.
+information on ``conda``, and ``pip``.
 
 Installing the latest development version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -163,9 +176,8 @@ Alternatively, you can clone the git repository locally and install from there::
 .. _Verde's: https://www.fatiando.org/verde/latest/install.html
 .. _Deltaforge: https://deltares.github.io/deltaforge/
 .. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
-.. _Mambaforge: https://github.com/conda-forge/miniforge#mambaforge
 .. _Miniforge: https://github.com/conda-forge/miniforge
 .. _limitations: https://www.anaconda.com/blog/anaconda-commercial-edition-faq
-.. _mamba package manager: https://github.com/mamba-org/mamba
 .. _conda package manager: https://docs.conda.io/en/latest/
 .. _pip package manager: https://pypi.org/project/pip/
+.. _pixi: https://pixi.sh/latest/


### PR DESCRIPTION
Fixes #1183 and #1185

# Description
* I did not want to remove references to Anaconda entirely: Anaconda is still well known, so we need our docs to briefly explain what it is and why you could use an alternative. I reduced the mentions of it.
* I added pixi as the recommended way of installing imod, since it seems to be stable enough now. The recently added functionality for a global installation also makes pixi behave more like users are used to from conda.
* I removed mentions of ``mamba``, as its faster dependency solver is now the default in ``conda``, and the lead developer moved on to develop ``pixi``. Mamba is a success in my opinion, but it has served its purpose: Its killer feature has been moved to conda, and mamba will be less maintained. At least I think, I haven't seen any mentions of sunsetting it though and it has an active userbase. Regardless, three options for package installers (pixi, conda, pip) is already overwhelming for most of our users, so removing this formerly-critical-now-less-useful option is necessary.

# Checklist

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
