### PR TITLE
Issue #1192 Add the dockerfile for the docker build image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ examples/data
 
 /imod/tests/mydask.png
 /imod/tests/*_report.xml
+docs/sg_execution_times.rst

--- a/.teamcity/Dockerfile/Dockerfile
+++ b/.teamcity/Dockerfile/Dockerfile
@@ -1,0 +1,29 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/server:ltsc2022
+LABEL maintainer="sunny.titus@deltares.nl"
+
+ARG PIXI_VERSION=v0.34.0
+
+## Setup user
+USER "NT Authority\System"
+
+# Install .NET 4.8
+ADD https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe /ndp48-x86-x64-allos-enu.exe
+RUN C:\ndp48-x86-x64-allos-enu.exe /quiet /install && del C:\ndp48-x86-x64-allos-enu.exe
+
+## Install chocolatey
+ENV ChocolateyUseWindowsCompression false 
+RUN powershell Set-ExecutionPolicy Bypass -Scope Process -Force;`
+     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;`
+     iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+## Install useful packages
+RUN choco install -y --no-progress `
+    git.install `
+    powershell-core
+
+## Install Pixi
+RUN ["powershell", "iwr -useb https://pixi.sh/install.ps1 | iex"]
+
+CMD [ "cmd" ]

--- a/docs/developing/ci.rst
+++ b/docs/developing/ci.rst
@@ -48,6 +48,9 @@ To pull the latest image use the command below:
 
 Sometimes you want to use an older version of the docker builder. To get an older version you can run the same command but use a different tag.
 To find out which tags are available and which is the latest you can have a look at the `artifacts page`_.
+The tag name corresponds with the pixi version inside the docker image e.g. :34.0 means that the image contains pixi v34.0.
+
+
 To pull a specific version run:
 
 .. code-block:: console

--- a/docs/developing/ci.rst
+++ b/docs/developing/ci.rst
@@ -38,9 +38,17 @@ The docker build container is also used on the build server and therefore settin
 
 Obtain the image
 ~~~~~~~~~~~~~~~~
-To obtain the container you can either pull it from the Deltares registry or build it yourself.
+To obtain the container you can either pull it from the `docker registry`_ registry or build it yourself.
 
-To pull it use the following command:
+To pull the latest image use the command below:
+
+.. code-block:: console
+
+   docker pull containers.deltares.nl/hydrology_product_line_imod/windows-pixi:latest
+
+Sometimes you want to use an older version of the docker builder. To get an older version you can run the same command but use a different tag.
+To find out which tags are available and which is the latest you can have a look at the `artifacts page`_.
+To pull a specific version run:
 
 .. code-block:: console
 
@@ -54,7 +62,10 @@ To spin up the container run the following command:
 
 .. code-block:: console
 
-   docker run --rm -it windows-pixi:34.0
+   docker run --rm -it windows-pixi:latest
 
 This commands spins up an interactive session which will be automatically removed whenever you exit it.
 Your next steps should be to clone the imod-python repository, checkout the branch you want to debug and run the pixi tasks corresponding to the failing build step.
+
+.. _docker registry: https://containers.deltares.nl
+.. _artifacts page: https://containers.deltares.nl/harbor/projects/32/repositories/windows-pixi/artifacts-tab

--- a/docs/developing/ci.rst
+++ b/docs/developing/ci.rst
@@ -1,8 +1,17 @@
 Debugging Continuous Integration
 --------------------------------
 
+When the CI pipeline fails you want to be able to reproduce it locally. There are 2 general approaches to doing this.
+- Running the pipeline steps locally
+- Running the pipeline steps inside the docker build container
+
+Running the pipeline steps locally
+----------------------------------
+
 The commands run during the Continuous Integration are they same as the tasks defined
-in the pixi tasks list. For example if the MyPy step fails you can locally run the command:
+in the pixi tasks list. Therefor you can directly call these tasks on your local repository.
+
+For example if the MyPy step fails you can locally run the command:
 
 .. code-block:: console
 
@@ -19,3 +28,33 @@ To full lists of tasks  can be found in the pixi.toml file or can be found by ru
 .. code-block:: console
 
    pixi task list
+
+Running the pipeline steps inside the docker build container
+------------------------------------------------------------
+
+If you're unable to reproduce a failing build using the method above you can try running it inside the docker build container.
+The docker build container is also used on the build server and therefore settings one up locally should provide you with the exact same environment.
+
+
+Obtain the image
+~~~~~~~~~~~~~~~~
+To obtain the container you can either pull it from the Deltares registry or build it yourself.
+
+To pull it use the following command:
+
+.. code-block:: console
+
+   docker pull containers.deltares.nl/hydrology_product_line_imod/windows-pixi:34.0
+
+To build it yourself see :ref:`How to build`.
+
+Create the container
+~~~~~~~~~~~~~~~~~~~~
+To spin up the container run the following command:
+
+.. code-block:: console
+
+   docker run --rm -it windows-pixi:34.0
+
+This commands spins up an interactive session which will be automatically removed whenever you exit it.
+Your next steps should be to clone the imod-python repository, checkout the branch you want to debug and run the pixi tasks corresponding to the failing build step.

--- a/docs/developing/docker.rst
+++ b/docs/developing/docker.rst
@@ -7,7 +7,7 @@ Furthermore we can also easily debug a failing build by running the container lo
 
 
 Dockerfile
-----------
+~~~~~~~~~~
 The dockerfile can be found at `.teamcity\\Dockerfile\\Dockerfile` and is displayed below as well.
 
 .. literalinclude:: ../../.teamcity/Dockerfile/Dockerfile

--- a/docs/developing/docker.rst
+++ b/docs/developing/docker.rst
@@ -6,11 +6,19 @@ This is done by defining the the docker image and tag to be used by the pipeline
 Furthermore we can also easily debug a failing build by running the container locally on our machine.
 
 
+Dockerfile
+----------
+The dockerfile can be found at `.teamcity\\Dockerfile\\Dockerfile` and is displayed below as well.
+
+.. literalinclude:: ../../.teamcity/Dockerfile/Dockerfile
+    :language: docker
+
+
 .. _How to build:
 
 How to build
 ------------
-The dockerfile to build the image can be found at `.teamcity\\Dockerfile\\Dockerfile`. A prerequisite of building the image is that you have `Docker Desktop`_ installed on your machine.
+A prerequisite of building the image is that you have `Docker Desktop`_ installed on your machine.
 Once installed open a console and navigate to the folder where the dockerfile resides.
 
 To build the image:
@@ -21,7 +29,6 @@ To build the image:
   docker build -t windows-pixi:34.0 . -m 2GB  
 
 The image tag is not randomly chosen. It matches the Pixi version shipped with the image. So make sure the tag equals the version inside the dockerfile.
-
 
 Updating the Pixi version
 -------------------------
@@ -51,6 +58,7 @@ After you connected to the registry you can tag and push your image:
     docker push containers.deltares.nl/hydrology_product_line_imod/windows-pixi:34.0
 
 Again, make sure the tags match the ``PIXI_VERSION`` inside the dockerfile.
+
 
 .. _Docker Desktop: https://www.docker.com/products/docker-desktop/
 .. _here: https://containers.deltares.nl

--- a/docs/developing/docker.rst
+++ b/docs/developing/docker.rst
@@ -1,0 +1,56 @@
+Docker build image
+------------------
+
+The CI build steps are run in a docker container. Running the build steps inside a container has several advantages. One of them is the ability to create reproducible builds.
+This is done by defining the the docker image and tag to be used by the pipeline inside the pipeline files. If in the future we want to build an old commit then we exactly know which docker image and tag we should use.
+Furthermore we can also easily debug a failing build by running the container locally on our machine.
+
+
+.. _How to build:
+
+How to build
+------------
+The dockerfile to build the image can be found at `.teamcity\\Dockerfile\\Dockerfile`. A prerequisite of building the image is that you have `Docker Desktop`_ installed on your machine.
+Once installed open a console and navigate to the folder where the dockerfile resides.
+
+To build the image:
+
+.. code-block:: console
+
+  docker context use desktop-windows  
+  docker build -t windows-pixi:34.0 . -m 2GB  
+
+The image tag is not randomly chosen. It matches the Pixi version shipped with the image. So make sure the tag equals the version inside the dockerfile.
+
+
+Updating the Pixi version
+-------------------------
+Updating the Pixi version is easy. In the dockerfile there is an argument called ``PIXI_VERSION``. Change this and follow the steps at `How to build`_ to rebuild the image. Don't forget to add the correct tag
+
+
+Pushing the image
+-----------------
+Once build you can upload it to the Deltares repository. To do this you do need to have the required credentials.
+
+
+The first step is to connect to the docker registry. You only have to do this once. The settings thereafter will be stored on your machine.
+To connect you need your email address and your cli secret. The secret can be found `here`_  by clicking on your username in the top right, and then selecting your user profile.
+
+
+To connect:
+
+.. code-block:: console
+
+  docker login -u <<deltares_email>> -p <<cli_secret>> https://containers.deltares.nl
+
+After you connected to the registry you can tag and push your image:
+
+.. code-block:: console
+
+    docker tag windows-pixi:34.0 containers.deltares.nl/hydrology_product_line_imod/windows-pixi:34.0
+    docker push containers.deltares.nl/hydrology_product_line_imod/windows-pixi:34.0
+
+Again, make sure the tags match the ``PIXI_VERSION`` inside the dockerfile.
+
+.. _Docker Desktop: https://www.docker.com/products/docker-desktop/
+.. _here: https://containers.deltares.nl

--- a/docs/developing/index.rst
+++ b/docs/developing/index.rst
@@ -34,6 +34,7 @@ in-depth description.
    documentation
    ci
    releasing
+   docker
 
 .. _Contributing to xarray guide: https://xarray.pydata.org/en/latest/contributing.html
 .. _pages: https://github.com/Deltares/imod-python/issues


### PR DESCRIPTION
Fixes #1192 

# Description
This PR add the dockerfile used to create the docker image which is being used in the build pipeline.
Documentation has been added how to build and update it. Furthermore the section about debugging a failing CI build has been extended to explain how to run the container locally  to debug it.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [x] **If feature added**: Added/extended example
