### PR TITLE
Issue #1285 grid data from imod5

### DIFF
--- a/imod/msw/grid_data.py
+++ b/imod/msw/grid_data.py
@@ -199,9 +199,7 @@ class GridData(MetaSwapPackage, IRegridPackage):
 
         mf6_top_active = target_dis["idomain"].isel(layer=0, drop=True)
         subunit_active = (
-            (imod5_cap["boundary"] == 1)
-            & (data["area"] > 0)
-            & (mf6_top_active >= 1)
+            (imod5_cap["boundary"] == 1) & (data["area"] > 0) & (mf6_top_active >= 1)
         )
         active = subunit_active.all(dim="subunit")
         data_active = {

--- a/imod/msw/grid_data.py
+++ b/imod/msw/grid_data.py
@@ -3,6 +3,7 @@ from typing import Optional
 import numpy as np
 import xarray as xr
 
+from imod.logging import LogLevel, logger
 from imod.mf6 import StructuredDiscretization
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.regrid.regrid_schemes import (
@@ -30,11 +31,17 @@ def get_cell_area_from_imod5_data(
     urban_area = imod5_data["cap"]["urban_area"]
     rural_area = mf6_area - (wetted_area + urban_area)
     if (wetted_area > mf6_area).any():
-        print(f"wetted area was set to the max cell area of {mf6_area}")
+        logger.log(
+            loglevel=LogLevel.WARNING,
+            message=f"wetted area was set to the max cell area of {mf6_area}",
+            additional_depth=0,
+        )
         wetted_area = wetted_area.where(wetted_area <= mf6_area, other=mf6_area)
     if (rural_area < 0.0).any():
-        print(
-            "found urban area > than (cel-area - wetted area). Urban area was set to 0"
+        logger.log(
+            loglevel=LogLevel.WARNING,
+            message="found urban area > than (cel-area - wetted area). Urban area was set to 0",
+            additional_depth=0,
         )
         urban_area = urban_area.where(rural_area > 0.0, other=0.0)
     rural_area = mf6_area - (wetted_area + urban_area)

--- a/imod/msw/grid_data.py
+++ b/imod/msw/grid_data.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Optional
 
 import numpy as np
@@ -165,7 +164,6 @@ class GridData(MetaSwapPackage, IRegridPackage):
     def from_imod5_data(
         cls,
         imod5_data: dict[str, dict[str, GridDataArray]],
-        period_data: dict[str, list[datetime]],
         target_dis: StructuredDiscretization,
         regridder_types: Optional[RegridMethodType] = None,
         regrid_cache: RegridderWeightsCache = RegridderWeightsCache(),

--- a/imod/msw/grid_data.py
+++ b/imod/msw/grid_data.py
@@ -18,9 +18,8 @@ from imod.util.spatial import get_cell_area, spatial_reference
 
 
 def _concat_subunits(arg1: GridDataArray, arg2: GridDataArray):
-    return concat(
-        [arg1, arg2], dim="subunit"
-    ).assign_coords(subunit = [0, 1])
+    return concat([arg1, arg2], dim="subunit").assign_coords(subunit=[0, 1])
+
 
 def get_cell_area_from_imod5_data(
     imod5_data: dict[str, dict[str, GridDataArray]],

--- a/imod/msw/pkgbase.py
+++ b/imod/msw/pkgbase.py
@@ -240,3 +240,6 @@ class MetaSwapPackage(abc.ABC):
 
     def get_regrid_methods(self) -> RegridMethodType:
         return deepcopy(self._regrid_method)
+
+    def from_imod5_data(self, *args, **kwargs):
+        raise NotImplementedError("Method not implemented for this package.")

--- a/imod/tests/test_msw/test_grid_data.py
+++ b/imod/tests/test_msw/test_grid_data.py
@@ -455,13 +455,15 @@ def test_from_imod5_data(grid_data_dict: dict[str, xr.DataArray]):
 
     imod5_data = {"cap": cap_data}
 
-    layer = xr.DataArray([1, 1], coords={"layer": [1, 2]}, dims=("layer", ))
+    layer = xr.DataArray([1, 1], coords={"layer": [1, 2]}, dims=("layer",))
     idomain = layer * xr.ones_like(like, dtype=int)
 
     # Dis only needed for idomain
-    dis = StructuredDiscretization(top, top-0.1, idomain, validate=False)
+    dis = StructuredDiscretization(top, top - 0.1, idomain, validate=False)
 
     griddata = GridData.from_imod5_data(imod5_data, target_dis=dis)
     expected_rootzone_depth = cap_data["rootzone_thickness"] * 0.01
-    xr.testing.assert_allclose(expected_rootzone_depth, griddata["rootzone_depth"].sel(subunit=0, drop=True))
-    assert (griddata["landuse"].sel(subunit = 1, drop=True) == 18).all()
+    xr.testing.assert_allclose(
+        expected_rootzone_depth, griddata["rootzone_depth"].sel(subunit=0, drop=True)
+    )
+    assert (griddata["landuse"].sel(subunit=1, drop=True) == 18).all()

--- a/imod/typing/__init__.py
+++ b/imod/typing/__init__.py
@@ -11,6 +11,7 @@ from numpy.typing import NDArray
 
 GridDataArray: TypeAlias = Union[xr.DataArray, xu.UgridDataArray]
 GridDataset: TypeAlias = Union[xr.Dataset, xu.UgridDataset]
+GridDataDict: TypeAlias = dict[str, GridDataArray]
 ScalarAsDataArray: TypeAlias = Union[xr.DataArray, xu.UgridDataArray]
 ScalarAsDataset: TypeAlias = Union[xr.Dataset, xu.UgridDataset]
 UnstructuredData: TypeAlias = Union[xu.UgridDataset, xu.UgridDataArray]


### PR DESCRIPTION
Fixes #1285 

# Description

- This PR implements ``GridData.from_imod5_data``, which has the following requirements:
  - Area: Split area in rural & urban area
  - Active: Split where active/inactive
  - Landuse: Set urban_landuse to 18
  - Rootzone thickness: convert from centimeter to meter
- Refactors the ``test_grid_data.py`` to separate cases, reduces code duplication
- Add unittest for ``GridData.from_imod5_data``

It has a arguments for regridding, but these don't do anything yet. I wasn't sure if I should keep this to already have a future-proof signature, or not add these, as the regridder arguments only confuse people. I don't think regridding the MetaSWAP iMOD5 grids (like we do with MODFLOW6 data) is a part of iMOD Python now, as we are first focusing on the LHM, for which this is not a hard requirement.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
