### PR TITLE
Issue #1290 infiltration from imod5

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -7,6 +7,16 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
 
+[Unreleased]
+------------
+
+Changed
+~~~~~~~
+
+- :class:`imod.msw.Infiltration`'s variables ``upward_resistance`` and
+  ``downward_resistance`` now require a ``subunit`` coordinate.
+
+
 [0.18.0]
 --------
 

--- a/imod/msw/infiltration.py
+++ b/imod/msw/infiltration.py
@@ -34,9 +34,6 @@ class Infiltration(MetaSwapPackage, IRegridPackage):
     extra_storage_coefficient: array of floats (xr.DataArray)
         Extra storage coefficient of phreatic layer. This array must not have a
         subunit coordinate.
-    active: array of bools (xr.DataArray)
-        Describes whether SVAT units are active or not. This array must not have
-        a subunit coordinate.
     """
 
     _file_name = "infi_svat.inp"

--- a/imod/msw/infiltration.py
+++ b/imod/msw/infiltration.py
@@ -4,12 +4,8 @@ from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.msw.fixed_format import VariableMetaData
 from imod.msw.pkgbase import MetaSwapPackage
 from imod.msw.regrid.regrid_schemes import InfiltrationRegridMethod
-from imod.typing import GridDataArray
-from imod.typing.grid import concat, ones_like
-
-
-def _concat_subunits(arg1: GridDataArray, arg2: GridDataArray):
-    return concat([arg1, arg2], dim="subunit").assign_coords(subunit=[0, 1])
+from imod.msw.utilities.common import concat_imod5
+from imod.typing.grid import ones_like
 
 
 class Infiltration(MetaSwapPackage, IRegridPackage):
@@ -98,7 +94,7 @@ class Infiltration(MetaSwapPackage, IRegridPackage):
             data_ls = [
                 cap_data[f"{landuse}_{var_key}"] for landuse in ["rural", "urban"]
             ]
-            data[var_rename] = _concat_subunits(*data_ls)
+            data[var_rename] = concat_imod5(*data_ls)
 
         data["bottom_resistance"] = ones_like(data["downward_resistance"])
         data["extra_storage_coefficient"] = ones_like(data["downward_resistance"])

--- a/imod/msw/infiltration.py
+++ b/imod/msw/infiltration.py
@@ -5,6 +5,7 @@ from imod.msw.fixed_format import VariableMetaData
 from imod.msw.pkgbase import MetaSwapPackage
 from imod.msw.regrid.regrid_schemes import InfiltrationRegridMethod
 from imod.msw.utilities.common import concat_imod5
+from imod.typing import GridDataDict
 from imod.typing.grid import ones_like
 
 
@@ -77,7 +78,7 @@ class Infiltration(MetaSwapPackage, IRegridPackage):
         self._pkgcheck()
 
     @classmethod
-    def from_imod5_data(cls, imod5_data) -> "Infiltration":
+    def from_imod5_data(cls, imod5_data: dict[str, GridDataDict]) -> "Infiltration":
         cap_data = imod5_data["cap"]
         data = {}
         # Use runon resistance as downward resistance, and runoff for downward
@@ -93,7 +94,8 @@ class Infiltration(MetaSwapPackage, IRegridPackage):
             ]
             data[var_rename] = concat_imod5(*data_ls)
 
-        data["bottom_resistance"] = ones_like(data["downward_resistance"])
-        data["extra_storage_coefficient"] = ones_like(data["downward_resistance"])
+        like = data["downward_resistance"].isel(subunit=0, drop=True)
+        data["bottom_resistance"] = ones_like(like)
+        data["extra_storage_coefficient"] = ones_like(like)
 
         return cls(**data)

--- a/imod/tests/fixtures/msw_model_fixture.py
+++ b/imod/tests/fixtures/msw_model_fixture.py
@@ -226,8 +226,8 @@ def make_msw_model():
     # %% Infiltration
     msw_model["infiltration"] = msw.Infiltration(
         infiltration_capacity=xr.full_like(area, 1.0),
-        downward_resistance=xr.full_like(msw_grid, -9999.0),
-        upward_resistance=xr.full_like(msw_grid, -9999.0),
+        downward_resistance=xr.full_like(area, -9999.0),
+        upward_resistance=xr.full_like(area, -9999.0),
         bottom_resistance=xr.full_like(msw_grid, -9999.0),
         extra_storage_coefficient=xr.full_like(msw_grid, 0.1),
     )

--- a/imod/tests/test_msw/test_infiltration.py
+++ b/imod/tests/test_msw/test_infiltration.py
@@ -28,15 +28,25 @@ def setup_infiltration_package(subunit, y, x, dy, dx):
     )
 
     downward_resistance = xr.DataArray(
-        np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
-        dims=("y", "x"),
-        coords={"y": y, "x": x, "dx": dx, "dy": dy},
+        np.array(
+            [
+                [[1.0, 2.0, 3.0], [nan, nan, nan], [7.0, 8.0, 9.0]],
+                [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [nan, nan, nan]],
+            ]
+        ),
+        dims=("subunit", "y", "x"),
+        coords={"subunit": subunit, "y": y, "x": x, "dx": dx, "dy": dy},
     )
 
     upward_resistance = xr.DataArray(
-        np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
-        dims=("y", "x"),
-        coords={"y": y, "x": x, "dx": dx, "dy": dy},
+        np.array(
+            [
+                [[1.0, 2.0, 3.0], [nan, nan, nan], [7.0, 8.0, 9.0]],
+                [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [nan, nan, nan]],
+            ]
+        ),
+        dims=("subunit", "y", "x"),
+        coords={"subunit": subunit, "y": y, "x": x, "dx": dx, "dy": dy},
     )
 
     bottom_resistance = xr.DataArray(

--- a/imod/tests/test_msw/test_ponding.py
+++ b/imod/tests/test_msw/test_ponding.py
@@ -117,7 +117,6 @@ def test_from_imod5_data():
     cap_data = {}
     mapping_ls = [
         ("rural_runoff_resistance", "runoff_resistance", 0),
-        ("rural_runoff_resistance", "runoff_resistance", 0),
         ("urban_runoff_resistance", "runoff_resistance", 1),
         ("rural_runon_resistance", "runon_resistance", 0),
         ("urban_runon_resistance", "runon_resistance", 1),


### PR DESCRIPTION
Fixes #1290

# Description
Adds from_imod5_data classmethod.

Requirements:

* Set runon/runoff resistance to downward/upward resistance respectively
* Set extra storage coefficient and bottom resistance to 1
* If resistance smaller than 5.0, deactivate resistance by setting it to MetaSWAP nodata value.

I also added the ``upward_resistance`` and ``downward_resistance`` to the list with grids which have a subunit coordinate, as a comment in @HendrikKok's script mentioned this was missing, and a required feature.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
