### PR TITLE
Issue #1292 mete grids from imod5

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -9,6 +9,12 @@ The format is based on `Keep a Changelog`_, and this project adheres to
 [Unreleased]
 ------------
 
+Added
+~~~~~
+
+- :class:`imod.msw.MeteoGridCopy` to copy existing `mete_grid.inp` files, so
+  ASCII grids in large existing meteo databases do not have to be read.
+
 Changed
 ~~~~~~~
 

--- a/imod/msw/__init__.py
+++ b/imod/msw/__init__.py
@@ -9,7 +9,7 @@ from imod.msw.initial_conditions import (
     InitialConditionsSavedState,
 )
 from imod.msw.landuse import LanduseOptions
-from imod.msw.meteo_grid import MeteoGrid
+from imod.msw.meteo_grid import MeteoGrid, MeteoGridCopy
 from imod.msw.meteo_mapping import EvapotranspirationMapping, PrecipitationMapping
 from imod.msw.model import MetaSwapModel
 from imod.msw.output_control import TimeOutputControl, VariableOutputControl

--- a/imod/msw/meteo_grid.py
+++ b/imod/msw/meteo_grid.py
@@ -1,7 +1,7 @@
 import csv
 from pathlib import Path
 from shutil import copyfile
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -13,7 +13,7 @@ from imod.msw.pkgbase import MetaSwapPackage
 from imod.msw.regrid.regrid_schemes import MeteoGridRegridMethod
 from imod.msw.timeutil import to_metaswap_timeformat
 from imod.msw.utilities.common import find_in_file_list
-from imod.typing import GridDataDict
+from imod.typing import Imod5DataDict
 from imod.util.regrid_method_type import EmptyRegridMethod, RegridMethodType
 
 
@@ -216,13 +216,14 @@ class MeteoGridCopy(MetaSwapPackage, IRegridPackage):
         self.dataset["path"] = path
 
     def write(self, directory: Path | str, *args):
-        path_metegrid = Path(self.dataset["path"].values[()])
+        directory = Path(directory)
+        path_metegrid = Path(str(self.dataset["path"].values[()]))
         new_path = directory / self._file_name
         copyfile(path_metegrid, new_path)
 
     @classmethod
-    def from_imod5_data(cls, imod5_data: dict[str, GridDataDict]) -> "MeteoGridCopy":
-        paths = imod5_data["extra"]["paths"]
+    def from_imod5_data(cls, imod5_data: Imod5DataDict) -> "MeteoGridCopy":
+        paths = cast(list[str], imod5_data["extra"]["paths"])
         filepath = find_in_file_list(cls._file_name, paths)
 
         return cls(filepath)

--- a/imod/msw/meteo_grid.py
+++ b/imod/msw/meteo_grid.py
@@ -1,5 +1,6 @@
 import csv
 from pathlib import Path
+from shutil import copyfile
 from typing import Optional, Union
 
 import numpy as np
@@ -11,6 +12,9 @@ from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.msw.pkgbase import MetaSwapPackage
 from imod.msw.regrid.regrid_schemes import MeteoGridRegridMethod
 from imod.msw.timeutil import to_metaswap_timeformat
+from imod.msw.utilities.common import find_in_file_list
+from imod.typing import GridDataDict
+from imod.util.regrid_method_type import EmptyRegridMethod, RegridMethodType
 
 
 class MeteoGrid(MetaSwapPackage, IRegridPackage):
@@ -188,3 +192,37 @@ class MeteoGrid(MetaSwapPackage, IRegridPackage):
                     f"Received excess dims {excess_dims} in {self.__class__} for "
                     f"{varname}, please provide data with {allowed_dims}"
                 )
+
+
+class MeteoGridCopy(MetaSwapPackage, IRegridPackage):
+    """
+    Class to copy existing ``mete_grid.inp``, which contains the meteorological
+    grid data. Next to a MeteoGridCopy instance, instances of
+    PrecipitationMapping and EvapotranspirationMapping are required as well to
+    specify meteorological information to MetaSWAP.
+
+    Parameters
+    ----------
+    path: Path to mete_grid.inp file
+    """
+
+    _file_name = "mete_grid.inp"
+    _meteo_dirname = "meteo_grids"
+
+    _regrid_method: RegridMethodType = EmptyRegridMethod()
+
+    def __init__(self, path: Path | str):
+        super().__init__()
+        self.dataset["path"] = path
+
+    def write(self, directory: Path | str, *args):
+        path_metegrid = Path(self.dataset["path"])
+        new_path = directory / self._file_name
+        copyfile(path_metegrid, new_path)
+
+    @classmethod
+    def from_imod5_data(cls, imod5_data: dict[str, GridDataDict]) -> "MeteoGridCopy":
+        paths = imod5_data["extra"]["paths"]
+        filepath = find_in_file_list(cls._file_name, paths)
+
+        return cls(filepath)

--- a/imod/msw/meteo_grid.py
+++ b/imod/msw/meteo_grid.py
@@ -216,7 +216,7 @@ class MeteoGridCopy(MetaSwapPackage, IRegridPackage):
         self.dataset["path"] = path
 
     def write(self, directory: Path | str, *args):
-        path_metegrid = Path(self.dataset["path"])
+        path_metegrid = Path(self.dataset["path"].values[()])
         new_path = directory / self._file_name
         copyfile(path_metegrid, new_path)
 

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -10,16 +10,10 @@ import imod
 from imod.mf6.utilities.regrid import RegridderWeightsCache
 from imod.msw.fixed_format import VariableMetaData
 from imod.msw.pkgbase import MetaSwapPackage
+from imod.msw.utilities.common import find_in_file_list
 from imod.prepare import common
 from imod.typing import GridDataArray, GridDataDict, IntArray
 from imod.util.regrid_method_type import RegridMethodType
-
-
-def find_in_file_list(filename: str, paths: list[str]) -> str:
-    for file in paths:
-        if filename == Path(file[0]).name.lower():
-            return file[0]
-    raise ValueError(f"could not find {filename} in list of paths: {paths}")
 
 
 def open_first_meteo_grid(mete_grid_path: str, column_nr: int) -> xr.DataArray:

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -17,7 +17,7 @@ from imod.typing import GridDataArray, Imod5DataDict, IntArray
 from imod.util.regrid_method_type import RegridMethodType
 
 
-def _is_parsable_and_existing_path(potential_path: str, mete_grid_path: Path):
+def _is_parsable_and_existing_path(potential_path: str, mete_grid_path: Path) -> bool:
     """
     mete_grid.inp can contain values like "0.", which are converted to float by
     MetaSWAP. String is converted to path and checked if existing path.

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -18,17 +18,17 @@ from imod.util.regrid_method_type import RegridMethodType
 
 def open_first_meteo_grid(mete_grid_path: str | Path, column_nr: int) -> xr.DataArray:
     """
-    Find first meteo grid path in mete_grid.inp. Only read the first grid, so it
-    can be used to generate meteomappings.
+    Find and open first meteo grid path in mete_grid.inp. This grid is enough to
+    generate meteomappings.
     """
     if column_nr not in [2, 3]:
         raise ValueError("Column nr should be 2 or 3")
 
     mete_grid_path = Path(mete_grid_path)
 
-    f = open(mete_grid_path, "r")
-    lines = f.readlines()
-    meteo_filepath = Path(lines[0].split(",")[column_nr].replace('"', ""))
+    with open(mete_grid_path, "r") as f:
+        first_line = f.readline()
+    meteo_filepath = Path(first_line.split(",")[column_nr].replace('"', ""))
     return imod.rasterio.open(mete_grid_path / ".." / meteo_filepath)
 
 

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -34,7 +34,8 @@ def _is_parsable_and_existing_path(potential_path: str, mete_grid_path: Path) ->
 def open_first_meteo_grid(mete_grid_path: str | Path, column_nr: int) -> xr.DataArray:
     """
     Find and open first meteo grid path in mete_grid.inp. This grid is enough to
-    generate meteomappings.
+    generate meteomappings. There can be floats before in the column which
+    should be skipped.
     """
     if column_nr not in [2, 3]:
         raise ValueError("Column nr should be 2 or 3")

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -33,7 +33,7 @@ def open_first_meteo_grid(mete_grid_path: str, column_nr: int) -> xr.DataArray:
     f = open(mete_grid_path, "r")
     lines = f.readlines()
     meteo_filepath = Path(lines[0].split(",")[column_nr].replace('"', ""))
-    return imod.rasterio.open(meteo_filepath)
+    return imod.rasterio.open(mete_grid_path / ".." / meteo_filepath)
 
 
 def open_first_meteo_grid_from_imod5_data(

--- a/imod/msw/utilities/common.py
+++ b/imod/msw/utilities/common.py
@@ -1,6 +1,15 @@
+from pathlib import Path
+
 from imod.typing import GridDataArray
 from imod.typing.grid import concat
 
 
 def concat_imod5(arg1: GridDataArray, arg2: GridDataArray) -> GridDataArray:
     return concat([arg1, arg2], dim="subunit").assign_coords(subunit=[0, 1])
+
+
+def find_in_file_list(filename: str, paths: list[str]) -> str:
+    for file in paths:
+        if filename == Path(file[0]).name.lower():
+            return file[0]
+    raise ValueError(f"could not find {filename} in list of paths: {paths}")

--- a/imod/tests/test_msw/test_evapotranspiration_mapping.py
+++ b/imod/tests/test_msw/test_evapotranspiration_mapping.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 from pathlib import Path
 
@@ -5,6 +6,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from numpy.testing import assert_equal
+from pytest_cases import parametrize_with_cases
 
 from imod import msw
 
@@ -128,9 +130,8 @@ def test_evapotranspiration_mapping_out_of_bound(svat_index):
             evapotranspiration_mapping.write(output_dir, index, svat, None, None)
 
 
-def test_evapotranspiration_from_imod5(tmpdir_factory):
-    datadir = Path(tmpdir_factory.mktemp("evapotranspiration_mapping"))
-
+def setup_meteo_grid(datadir):
+    """Setup precipitation grid and write mete_grid.inp"""
     # Arrange
     x = [-0.5, 1.5, 3.5]
     y = [4.5, 2.5, 0.5]
@@ -141,22 +142,54 @@ def test_evapotranspiration_from_imod5(tmpdir_factory):
     time = [np.datetime64(t) for t in ["2001-01-01", "2001-01-02", "2001-01-03"]]
     time_da = xr.DataArray([1.0, 1.0, 1.0], coords={"time": time})
 
-    evapotranspiration = create_meteo_grid(x, y, subunit, dx, dy).isel(
-        subunit=0, drop=True
-    )
-    evapotranspiration_times = time_da * evapotranspiration
-    mete_grid = msw.MeteoGrid(evapotranspiration_times, evapotranspiration_times)
+    precipitation = create_meteo_grid(x, y, subunit, dx, dy).isel(subunit=0, drop=True)
+    precipitation_times = time_da * precipitation
+    mete_grid = msw.MeteoGrid(precipitation_times, precipitation_times)
     mete_grid.write(datadir)
+    return precipitation
+
+
+class MeteGridCases:
+    """
+    Cases return strings to replace in mete_grid.inp, to set paths to floats.
+    """
+
+    def case_all_paths(self):
+        return r"nothing_to_replace"
+
+    def case_some_paths(self):
+        return r'"meteo_grids\\(\w+)_20010101000000.asc"'
+
+    def case_no_paths(self):
+        return r'"meteo_grids\\(\w+)_([0-9]+).asc"'
+
+
+@parametrize_with_cases("replace_string", cases=MeteGridCases)
+def test_evapotranspiration_from_imod5(tmpdir_factory, replace_string, request):
+    datadir = Path(tmpdir_factory.mktemp("evapotranspiration_mapping"))
+    evapotranspiration = setup_meteo_grid(datadir)
 
     paths = [["foo"], [datadir / "mete_grid.inp"], ["bar"]]
     imod5_data = {"extra": {"paths": paths}}
 
-    # Act
-    evapotranspiration_mapping = msw.EvapotranspirationMapping.from_imod5_data(
-        imod5_data
-    )
-    actual = evapotranspiration_mapping.meteo
+    # Replace text in existing mete_grid.inp
+    with open(datadir / "mete_grid.inp", "r") as f:
+        text = f.read()
+    text_replaced = re.sub(replace_string, '"0.0"', text)
+    with open(datadir / "mete_grid.inp", "w") as f:
+        f.write(text_replaced)
 
-    # Assert
-    assert len(actual.coords["time"]) == 1
-    xr.testing.assert_equal(evapotranspiration, actual.isel(time=0, drop=True))
+    # Act
+    if request.node.callspec.id == "no_paths":
+        with pytest.raises(ValueError):
+            msw.EvapotranspirationMapping.from_imod5_data(imod5_data)
+
+    else:
+        evapotranspiration_mapping = msw.EvapotranspirationMapping.from_imod5_data(
+            imod5_data
+        )
+        actual = evapotranspiration_mapping.meteo
+
+        # Assert
+        assert len(actual.coords["time"]) == 1
+        xr.testing.assert_equal(evapotranspiration, actual.isel(time=0, drop=True))

--- a/imod/tests/test_msw/test_evapotranspiration_mapping.py
+++ b/imod/tests/test_msw/test_evapotranspiration_mapping.py
@@ -37,6 +37,7 @@ def svat_index() -> xr.DataArray:
     index = (svat != 0).values.ravel()
     return svat, index
 
+
 def create_meteo_grid(x, y, subunit, dx, dy):
     # fmt: off
     return xr.DataArray(
@@ -55,6 +56,7 @@ def create_meteo_grid(x, y, subunit, dx, dy):
         coords={"subunit": subunit, "y": y, "x": x, "dx": dx, "dy": dy}
     )
     # fmt: on
+
 
 def test_evapotranspiration_mapping_simple(fixed_format_parser, svat_index):
     svat, index = svat_index
@@ -139,7 +141,9 @@ def test_evapotranspiration_from_imod5(tmpdir_factory):
     time = [np.datetime64(t) for t in ["2001-01-01", "2001-01-02", "2001-01-03"]]
     time_da = xr.DataArray([1.0, 1.0, 1.0], coords={"time": time})
 
-    evapotranspiration = create_meteo_grid(x, y, subunit, dx, dy).isel(subunit=0, drop=True)
+    evapotranspiration = create_meteo_grid(x, y, subunit, dx, dy).isel(
+        subunit=0, drop=True
+    )
     evapotranspiration_times = time_da * evapotranspiration
     mete_grid = msw.MeteoGrid(evapotranspiration_times, evapotranspiration_times)
     mete_grid.write(datadir)
@@ -148,7 +152,9 @@ def test_evapotranspiration_from_imod5(tmpdir_factory):
     imod5_data = {"extra": {"paths": paths}}
 
     # Act
-    evapotranspiration_mapping = msw.EvapotranspirationMapping.from_imod5_data(imod5_data)
+    evapotranspiration_mapping = msw.EvapotranspirationMapping.from_imod5_data(
+        imod5_data
+    )
     actual = evapotranspiration_mapping.meteo
 
     # Assert

--- a/imod/tests/test_msw/test_meteo_grid.py
+++ b/imod/tests/test_msw/test_meteo_grid.py
@@ -1,4 +1,5 @@
 import csv
+import filecmp
 import os
 import tempfile
 from pathlib import Path
@@ -125,7 +126,7 @@ def test_regrid_meteo(simple_2d_grid_with_subunits):
     assert np.all(regridded_ponding.dataset["y"].values == new_grid["y"].values)
 
 
-def test_meteocopy():
+def test_meteo_grid_copy():
     # Arrange
     meteo_grid = setup_meteo_grid()
 
@@ -134,5 +135,7 @@ def test_meteocopy():
         meteo_grid.write(grid_dir)
 
         meteo_grid_copy = MeteoGridCopy(grid_dir / "mete_grid.inp")
-        
+        copy_dir = Path(output_dir) / "copied"
+        meteo_grid_copy.write(copy_dir)
 
+        assert filecmp.cmp(grid_dir / "mete_grid.inp", copy_dir / "mete_grid.inp")

--- a/imod/tests/test_msw/test_meteo_grid.py
+++ b/imod/tests/test_msw/test_meteo_grid.py
@@ -11,7 +11,7 @@ from numpy import nan
 from numpy.testing import assert_equal
 
 from imod.mf6.utilities.regrid import RegridderWeightsCache
-from imod.msw import MeteoGrid
+from imod.msw import MeteoGrid, MeteoGridCopy
 
 
 def setup_meteo_grid():
@@ -123,3 +123,16 @@ def test_regrid_meteo(simple_2d_grid_with_subunits):
 
     assert np.all(regridded_ponding.dataset["x"].values == new_grid["x"].values)
     assert np.all(regridded_ponding.dataset["y"].values == new_grid["y"].values)
+
+
+def test_meteocopy():
+    # Arrange
+    meteo_grid = setup_meteo_grid()
+
+    with tempfile.TemporaryDirectory() as output_dir:
+        grid_dir = Path(output_dir) / "grid"
+        meteo_grid.write(grid_dir)
+
+        meteo_grid_copy = MeteoGridCopy(grid_dir / "mete_grid.inp")
+        
+

--- a/imod/tests/test_msw/test_meteo_grid.py
+++ b/imod/tests/test_msw/test_meteo_grid.py
@@ -154,7 +154,11 @@ def test_meteogridcopy_from_imod5():
 
         imod5_data = {}
         imod5_data["extra"] = {}
-        imod5_data["extra"]["paths"] = [["foo"], [(grid_dir / "mete_grid.inp").resolve()], ["bar"]]
+        imod5_data["extra"]["paths"] = [
+            ["foo"],
+            [(grid_dir / "mete_grid.inp").resolve()],
+            ["bar"],
+        ]
 
         meteo_grid_copy = MeteoGridCopy.from_imod5_data(imod5_data)
         copy_dir = Path(output_dir) / "copied"

--- a/imod/tests/test_msw/test_meteo_grid.py
+++ b/imod/tests/test_msw/test_meteo_grid.py
@@ -126,16 +126,40 @@ def test_regrid_meteo(simple_2d_grid_with_subunits):
     assert np.all(regridded_ponding.dataset["y"].values == new_grid["y"].values)
 
 
-def test_meteo_grid_copy():
+def test_meteogridcopy_write():
     # Arrange
     meteo_grid = setup_meteo_grid()
 
     with tempfile.TemporaryDirectory() as output_dir:
         grid_dir = Path(output_dir) / "grid"
+        grid_dir.mkdir(exist_ok=True, parents=True)
         meteo_grid.write(grid_dir)
 
         meteo_grid_copy = MeteoGridCopy(grid_dir / "mete_grid.inp")
         copy_dir = Path(output_dir) / "copied"
+        copy_dir.mkdir(exist_ok=True, parents=True)
+        # Act
         meteo_grid_copy.write(copy_dir)
+        # Assert
+        assert filecmp.cmp(grid_dir / "mete_grid.inp", copy_dir / "mete_grid.inp")
 
+
+def test_meteogridcopy_from_imod5():
+    meteo_grid = setup_meteo_grid()
+
+    with tempfile.TemporaryDirectory() as output_dir:
+        grid_dir = Path(output_dir) / "grid"
+        grid_dir.mkdir(exist_ok=True, parents=True)
+        meteo_grid.write(grid_dir)
+
+        imod5_data = {}
+        imod5_data["extra"] = {}
+        imod5_data["extra"]["paths"] = [["foo"], [(grid_dir / "mete_grid.inp").resolve()], ["bar"]]
+
+        meteo_grid_copy = MeteoGridCopy.from_imod5_data(imod5_data)
+        copy_dir = Path(output_dir) / "copied"
+        copy_dir.mkdir(exist_ok=True, parents=True)
+        # Act
+        meteo_grid_copy.write(copy_dir)
+        # Assert
         assert filecmp.cmp(grid_dir / "mete_grid.inp", copy_dir / "mete_grid.inp")

--- a/imod/tests/test_msw/test_precipitation_mapping.py
+++ b/imod/tests/test_msw/test_precipitation_mapping.py
@@ -2,6 +2,7 @@ import tempfile
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
 from numpy.testing import assert_equal
@@ -9,30 +10,8 @@ from numpy.testing import assert_equal
 from imod import msw
 
 
-def test_precipitation_mapping_simple(fixed_format_parser):
-    x_meteo = [-0.5, 1.5, 3.5]
-    y_meteo = [0.5, 2.5, 4.5]
-    subunit_meteo = [0, 1]
-    dx_meteo = 2.0
-    dy_meteo = 2.0
-    # fmt: off
-    precipitation = xr.DataArray(
-        np.array(
-            [
-                [[1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0]],
-
-                [[1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0]],
-            ]
-        ),
-        dims=("subunit", "y", "x"),
-        coords={"subunit": subunit_meteo, "y": y_meteo, "x": x_meteo, "dx": dx_meteo, "dy": dy_meteo}
-    )
-    # fmt: on
-
+@pytest.fixture(scope="function")
+def svat_index() -> xr.DataArray:
     x_svat = [1.0, 2.0, 3.0]
     y_svat = [1.0, 2.0, 3.0]
     subunit_svat = [0, 1]
@@ -57,7 +36,39 @@ def test_precipitation_mapping_simple(fixed_format_parser):
     )
     # fmt: on
     index = (svat != 0).values.ravel()
+    return svat, index
 
+
+def create_meteo_grid(x, y, subunit, dx, dy):
+    # fmt: off
+    return xr.DataArray(
+        np.array(
+            [
+                [[1.0, 1.0, 1.0],
+                 [1.0, 1.0, 1.0],
+                 [1.0, 1.0, 1.0]],
+
+                [[1.0, 1.0, 1.0],
+                 [1.0, 1.0, 1.0],
+                 [1.0, 1.0, 1.0]],
+            ]
+        ),
+        dims=("subunit", "y", "x"),
+        coords={"subunit": subunit, "y": y, "x": x, "dx": dx, "dy": dy}
+    )
+    # fmt: on
+
+
+def test_precipitation_mapping_simple(fixed_format_parser, svat_index):
+    svat, index = svat_index
+
+    x = [-0.5, 1.5, 3.5]
+    y = [0.5, 2.5, 4.5]
+    subunit = [0, 1]
+    dx = 2.0
+    dy = 2.0
+
+    precipitation = create_meteo_grid(x, y, subunit, dx, dy)
     precipitation_mapping = msw.PrecipitationMapping(precipitation)
 
     with tempfile.TemporaryDirectory() as output_dir:
@@ -74,55 +85,16 @@ def test_precipitation_mapping_simple(fixed_format_parser):
     assert_equal(results["column"], np.array([2, 2, 2, 2, 2, 3]))
 
 
-def test_precipitation_mapping_negative_dy_meteo(fixed_format_parser):
-    x_meteo = [-0.5, 1.5, 3.5]
-    y_meteo = [4.5, 2.5, 0.5]
-    subunit_meteo = [0, 1]
-    dx_meteo = 2.0
-    dy_meteo = -2.0
-    # fmt: off
-    precipitation = xr.DataArray(
-        np.array(
-            [
-                [[1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0]],
+def test_precipitation_mapping_negative_dy_meteo(fixed_format_parser, svat_index):
+    svat, index = svat_index
 
-                [[1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0]],
-            ]
-        ),
-        dims=("subunit", "y", "x"),
-        coords={"subunit": subunit_meteo, "y": y_meteo, "x": x_meteo, "dx": dx_meteo, "dy": dy_meteo}
-    )
-    # fmt: on
+    x = [-0.5, 1.5, 3.5]
+    y = [4.5, 2.5, 0.5]
+    subunit = [0, 1]
+    dx = 2.0
+    dy = -2.0
 
-    x_svat = [1.0, 2.0, 3.0]
-    y_svat = [1.0, 2.0, 3.0]
-    subunit_svat = [0, 1]
-    dx_svat = 1.0
-    dy_svat = 1.0
-
-    # fmt: off
-    svat = xr.DataArray(
-        np.array(
-            [
-                [[0, 1, 0],
-                 [0, 0, 0],
-                 [0, 2, 0]],
-
-                [[0, 3, 0],
-                 [4, 5, 6],
-                 [0, 0, 0]],
-            ]
-        ),
-        dims=("subunit", "y", "x"),
-        coords={"subunit": subunit_svat, "y": y_svat, "x": x_svat, "dx": dx_svat, "dy": dy_svat}
-    )
-    # fmt: on
-    index = (svat != 0).values.ravel()
-
+    precipitation = create_meteo_grid(x, y, subunit, dx, dy)
     precipitation_mapping = msw.PrecipitationMapping(precipitation)
 
     with tempfile.TemporaryDirectory() as output_dir:
@@ -139,53 +111,17 @@ def test_precipitation_mapping_negative_dy_meteo(fixed_format_parser):
     assert_equal(results["column"], np.array([2, 2, 2, 2, 2, 3]))
 
 
-def test_precipitation_mapping_negative_dy_meteo_svat(fixed_format_parser):
-    x_meteo = [-0.5, 1.5, 3.5]
-    y_meteo = [4.5, 2.5, 0.5]
-    subunit_meteo = [0, 1]
-    dx_meteo = 2.0
-    dy_meteo = -2.0
-    # fmt: off
-    precipitation = xr.DataArray(
-        np.array(
-            [
-                [[1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0]],
+def test_precipitation_mapping_negative_dy_meteo_svat(fixed_format_parser, svat_index):
+    svat, index = svat_index
+    svat = svat.assign_coords(y=[3.0, 2.0, 1.0], dy=-1.0)
 
-                [[1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0]],
-            ]
-        ),
-        dims=("subunit", "y", "x"),
-        coords={"subunit": subunit_meteo, "y": y_meteo, "x": x_meteo, "dx": dx_meteo, "dy": dy_meteo}
-    )
-    # fmt: on
-    x_svat = [1.0, 2.0, 3.0]
-    y_svat = [3.0, 2.0, 1.0]
-    subunit_svat = [0, 1]
-    dx_svat = 1.0
-    dy_svat = 1.0
+    x = [-0.5, 1.5, 3.5]
+    y = [4.5, 2.5, 0.5]
+    subunit = [0, 1]
+    dx = 2.0
+    dy = -2.0
 
-    # fmt: off
-    svat = xr.DataArray(
-        np.array(
-            [
-                [[0, 1, 0],
-                 [0, 0, 0],
-                 [0, 2, 0]],
-
-                [[0, 3, 0],
-                 [4, 5, 6],
-                 [0, 0, 0]],
-            ]
-        ),
-        dims=("subunit", "y", "x"),
-        coords={"subunit": subunit_svat, "y": y_svat, "x": x_svat, "dx": dx_svat, "dy": dy_svat}
-    )
-    # fmt: on
-    index = (svat != 0).values.ravel()
+    precipitation = create_meteo_grid(x, y, subunit, dx, dy)
     precipitation_mapping = msw.PrecipitationMapping(precipitation)
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
@@ -201,56 +137,16 @@ def test_precipitation_mapping_negative_dy_meteo_svat(fixed_format_parser):
     assert_equal(results["column"], np.array([2, 2, 2, 2, 2, 3]))
 
 
-def test_precipitation_mapping_out_of_bound():
-    x_meteo = [-0.5, 1.5, 3.5]
-    y_meteo = [2.5, 4.5, 6.5]
-    subunit_meteo = [0, 1]
-    dx_meteo = 2.0
-    dy_meteo = 2.0
+def test_precipitation_mapping_out_of_bound(svat_index):
+    svat, index = svat_index
 
-    # fmt: off
-    precipitation = xr.DataArray(
-        np.array(
-            [
-                [[1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0]],
+    x = [-0.5, 1.5, 3.5]
+    y = [2.5, 4.5, 6.5]
+    subunit = [0, 1]
+    dx = 2.0
+    dy = 2.0
 
-                [[1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0],
-                 [1.0, 1.0, 1.0]],
-            ]
-        ),
-        dims=("subunit", "y", "x"),
-        coords={"subunit": subunit_meteo, "y": y_meteo, "x": x_meteo, "dx": dx_meteo, "dy": dy_meteo}
-    )
-    # fmt: on
-
-    x_svat = [1.0, 2.0, 3.0]
-    y_svat = [1.0, 2.0, 3.0]
-    subunit_svat = [0, 1]
-    dx_svat = 1.0
-    dy_svat = 1.0
-
-    # fmt: off
-    svat = xr.DataArray(
-        np.array(
-            [
-                [[0, 1, 0],
-                 [0, 0, 0],
-                 [0, 2, 0]],
-
-                [[0, 3, 0],
-                 [4, 5, 6],
-                 [0, 0, 0]],
-            ]
-        ),
-        dims=("subunit", "y", "x"),
-        coords={"subunit": subunit_svat, "y": y_svat, "x": x_svat, "dx": dx_svat, "dy": dy_svat}
-    )
-    # fmt: on
-    index = (svat != 0).values.ravel()
-
+    precipitation = create_meteo_grid(x, y, subunit, dx, dy)
     precipitation_mapping = msw.PrecipitationMapping(precipitation)
 
     with tempfile.TemporaryDirectory() as output_dir:
@@ -258,3 +154,26 @@ def test_precipitation_mapping_out_of_bound():
         # The grid is out of bounds, which is why we expect a ValueError to be raisen
         with pytest.raises(ValueError):
             precipitation_mapping.write(output_dir, index, svat, None, None)
+
+
+def test_from_imod5(tmpdir_factory):
+    datadir = tmpdir_factory.mktemp("precipitation_mapping")
+
+    x = [-0.5, 1.5, 3.5]
+    y = [0.5, 2.5, 4.5]
+    subunit = [0, 1]
+    dx = 2.0
+    dy = 2.0
+
+    time = [np.datetime64(t) for t in["2001-01-01", "2001-01-02", "2001-01-03"]]
+    time_da = xr.DataArray([1.0, 1.0, 1.0], coords={"time": time})
+
+    precipitation = create_meteo_grid(x, y, subunit, dx, dy)
+    precipitation_times = time_da * precipitation
+    mete_grid = msw.MeteoGrid(precipitation_times, precipitation_times)
+    mete_grid.write(datadir)
+
+    imod5_data = {"paths": [["foo"], [datadir / "mete_grid.inp"], ["bar"]]}
+    precipitation_mapping = msw.PrecipitationMapping.from_imod5_data(imod5_data)
+
+    xr.testing.assert_equal(precipitation, precipitation_mapping.meteo)

--- a/imod/tests/test_msw/test_precipitation_mapping.py
+++ b/imod/tests/test_msw/test_precipitation_mapping.py
@@ -155,7 +155,7 @@ def test_precipitation_mapping_out_of_bound(svat_index):
             precipitation_mapping.write(output_dir, index, svat, None, None)
 
 
-def test_from_imod5(tmpdir_factory):
+def test_precipitation_from_imod5(tmpdir_factory):
     datadir = Path(tmpdir_factory.mktemp("precipitation_mapping"))
 
     # Arrange

--- a/imod/typing/__init__.py
+++ b/imod/typing/__init__.py
@@ -12,6 +12,7 @@ from numpy.typing import NDArray
 GridDataArray: TypeAlias = Union[xr.DataArray, xu.UgridDataArray]
 GridDataset: TypeAlias = Union[xr.Dataset, xu.UgridDataset]
 GridDataDict: TypeAlias = dict[str, GridDataArray]
+Imod5DataDict: TypeAlias = dict[str, GridDataDict | dict[str, list[str]]]
 ScalarAsDataArray: TypeAlias = Union[xr.DataArray, xu.UgridDataArray]
 ScalarAsDataset: TypeAlias = Union[xr.Dataset, xu.UgridDataset]
 UnstructuredData: TypeAlias = Union[xu.UgridDataset, xu.UgridDataArray]


### PR DESCRIPTION
Fixes #1292

# Description
Context: MetaSWAP can map meteorological grids, which have a coarser grid but a very fine time resolution, to its svats. 
The ``mete_grid.inp`` file contains paths to meteorological information, stored in ASCII grids, and there are separate mapping files ``"svat2precgrid.inp"`` and ``"svat2etrefgrid.inp"``. Nota bene: MetaSWAP has hardcoded filenames for packages, hence why I can search for "mete_grid.inp". 

Adds the following:
- A ``MeteoGridCopy`` class to copy "mete_grid.inp" files, to avoid having to read and write the crazy amount of meteo files that exist in existing databases.
- A ``MeteoMapping.from_imod5_data`` method which looks for the first ascii grid in the ``mete_grid.inp`` file, and reads that to derive mappings from meteorological cell to metaswap grid cell.
- Add ``Imod5DataDict`` type alias, which can be implemented for other ``from_imod5_data`` methods in the future.

Only thing I doubt now is that I naively copy ``mete_grid.inp``, which works when the paths to ASCII grids are absolute, but not when they are relative. I don't think iMOD5 does this as well, so present databases all contain absolute paths. @HendrikKok do you foresee a usecase to support relative paths in ``MeteoGridCopy``?

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
