### PR TITLE
Issue #1296 validation quick fixes

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -16,6 +16,8 @@ Fixed
   cells with zero thickness where IDOMAIN = 0. Before, only cells with a zero
   thickness and IDOMAIN = -1 were supported, else the software threw a ``not all
   values comply with criterion: > bottom``.
+- Fix bug where no ``ValidationError`` was thrown if there is an active RCH, DRN,
+  GHB, or RIV cell where idomain = -1.
 
 
 [0.18.0]

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+[Unreleased]
+------------
+
+Fixed
+~~~~~
+
+- Relaxed validation for `imod.mf6.StructuredDiscretization` to also support
+  cells with zero thickness where IDOMAIN = 0. Before, only cells with a zero
+  thickness and IDOMAIN = -1 were supported, else the software threw a ``not all
+  values comply with criterion: > bottom``.
+
 
 [0.18.0]
 --------

--- a/imod/mf6/dis.py
+++ b/imod/mf6/dis.py
@@ -85,7 +85,7 @@ class StructuredDiscretization(Package, IRegridPackage, IMaskingSettings):
             AnyValueSchema(">", 0),
         ),
         "top": (
-            AllValueSchema(">", "bottom", ignore=("idomain", "==", -1)),
+            AllValueSchema(">", "bottom", ignore=("idomain", "<=", 0)),
             IdentityNoDataSchema(other="idomain", is_other_notnull=(">", 0)),
             # No need to check coords: dataset ensures they align with idomain.
         ),

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -635,7 +635,7 @@ class AllInsideNoDataSchema(NoDataComparisonSchema):
         valid = self.is_notnull(obj)
         other_valid = self.is_other_notnull(other_obj)
 
-        valid, other_valid = align_other_obj_with_coords(valid, other_obj)
+        valid, other_valid = align_other_obj_with_coords(valid, other_valid)
 
         if (valid & ~other_valid).any():
             raise ValidationError(f"data values found at nodata values of {self.other}")

--- a/imod/tests/test_mf6/test_mf6_dis.py
+++ b/imod/tests/test_mf6/test_mf6_dis.py
@@ -113,6 +113,12 @@ def test_top_exceeding_bottom(idomain_and_bottom):
     errors = dis._validate(dis._write_schemata, idomain=idomain)
     assert len(errors) == 0
 
+    # Or inactive
+    idomain[0:2, :, :] = 0
+    dis = imod.mf6.StructuredDiscretization(top=-400.0, bottom=bottom, idomain=idomain)
+    errors = dis._validate(dis._write_schemata, idomain=idomain)
+    assert len(errors) == 0
+
 
 def test_overlaying_bottom_inactive(idomain_and_bottom):
     """

--- a/imod/tests/test_mf6/test_mf6_drn.py
+++ b/imod/tests/test_mf6/test_mf6_drn.py
@@ -153,6 +153,22 @@ def test_check_conductance_zero(drainage):
         assert var == "conductance"
 
 
+@pytest.mark.parametrize("nodata_idomain", [0, -1])
+def test_validate_inside_nodata(drainage, nodata_idomain):
+    idomain = drainage["elevation"].astype(np.int16)
+    top = 1.0
+    bottom = top - idomain.coords["layer"]
+
+    idomain[:, 2, 2] = nodata_idomain
+
+    dis = imod.mf6.StructuredDiscretization(top=top, bottom=bottom, idomain=idomain)
+    drn = imod.mf6.Drainage(**drainage)
+    errors = drn._validate(drn._write_schemata, **dis.dataset)
+    assert len(errors) == 1
+    for var, error in errors.items():
+        assert var == "elevation"
+
+
 def test_validate_concentration(transient_concentration_drainage):
     idomain = transient_concentration_drainage["elevation"].astype(np.int16)
     top = 1.0


### PR DESCRIPTION
Fixes #1296

# Description
We ran into two edge cases with Validation giving false positive for the DIS, and false negative for the RCH. 

This PR:
- Relaxes the validation of zero thicknesses, to also ignore cells where IDOMAIN = 0, instead only ignoring IDOMAIN = -1
- Fixes a bug in AllInsideNoData scheme, where not the right object was passed through, resulting in no validation error for the RCH package, where it should have. I added a test for the DRN package, where the same holds.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
