### PR TITLE
Issue #1298 Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug] - <Descriptive title>"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Reproduce**
+The more information you can provide us, the quicker we respond and fix the problem.
+
+1. What error message do you get?
+2. Can you create a minimum reproducible example?
+    - Can you create a small script that reproduces the error?
+    - OR if you have a complex model: Clip a small part out of it which reproduces the error, see [the ``clip_box`` method](https://deltares.github.io/imod-python/api/generated/mf6/imod.mf6.Modflow6Simulation.clip_box.html). Then dump the clipped model [with the dump method](https://deltares.github.io/imod-python/api/generated/mf6/imod.mf6.Modflow6Simulation.dump.html). You can attach these files to the issue.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Windows 11]
+ - iMOD Python Version [e.g. 0.18.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,20 +7,24 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+**Bug description**
 A clear and concise description of what the bug is.
 
-**Reproduce**
-The more information you can provide us, the quicker we respond and fix the problem.
-
+**Steps to reproduce**
 1. What error message do you get?
 2. Can you create a minimum reproducible example?
     - Can you create a small script that reproduces the error?
-    - OR if you have a complex model: Clip a small part out of it which reproduces the error, see [the ``clip_box`` method](https://deltares.github.io/imod-python/api/generated/mf6/imod.mf6.Modflow6Simulation.clip_box.html). Then dump the clipped model [with the dump method](https://deltares.github.io/imod-python/api/generated/mf6/imod.mf6.Modflow6Simulation.dump.html). You can attach these files to the issue.
+    - OR if you have a complex model: Clip a small part out of it which
+      reproduces the error, see [the ``clip_box``
+      method](https://deltares.github.io/imod-python/api/generated/mf6/imod.mf6.Modflow6Simulation.clip_box.html).
+      Then dump the clipped model [with the dump
+      method](https://deltares.github.io/imod-python/api/generated/mf6/imod.mf6.Modflow6Simulation.dump.html).
+      You can attach these files to the issue.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. Windows 11]
  - iMOD Python Version [e.g. 0.18.0]
 
-**Additional context**
-Add any other context about the problem here.
+**Additional context** 
+Add any other context about the problem here. The more information you can
+provide us, the quicker we respond and fix the problem.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE] - <descriptive title>"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. For example: "I'm always frustrated when [...]"
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Fixes #1298 

This PR adds issue templates, these are mainly to help users provide useful information for us in their bug reports.

1. **Bug report**: For bug reports, contains some pointers to how people can create a Minimum Reproducible Example, and some info to help us.
2. **Feature request**: For feature request.
3. **Custom template**: I think most of our developer issues will be created with this.

