### PR TITLE
Issue #1313 recharge from imod5 cap data

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -14,6 +14,8 @@ Added
 
 - :class:`imod.msw.MeteoGridCopy` to copy existing `mete_grid.inp` files, so
   ASCII grids in large existing meteo databases do not have to be read.
+- :meth:`imod.mf6.Recharge.from_imod5_cap_data` to construct a recharge package
+  for coupling a MODFLOW6 model to MetaSWAP.
 
 Fixed
 ~~~~~

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -330,6 +330,9 @@ class GroundwaterFlowModel(Modflow6Model):
                     wel_key, imod5_data, times
                 )
 
+        if "cap" in imod5_keys:
+            result["msw-rch"] = Recharge.from_imod5_cap_data(imod5_data)  # type: ignore
+
         # import ghb's
         imod5_keys = list(imod5_data.keys())
         ghb_keys = [key for key in imod5_keys if key[0:3] == "ghb"]

--- a/imod/mf6/rch.py
+++ b/imod/mf6/rch.py
@@ -28,7 +28,7 @@ from imod.schemata import (
     IndexesSchema,
     OtherCoordsSchema,
 )
-from imod.typing import Imod5DataDict, GridDataDict, GridDataArray
+from imod.typing import GridDataArray, GridDataDict, Imod5DataDict
 from imod.typing.grid import (
     enforce_dim_order,
     is_planar_grid,
@@ -250,7 +250,11 @@ class Recharge(BoundaryCondition, IRegridPackage):
         active, _ = is_msw_active_cell(target_dis, cap_data, msw_area)
 
         data = {}
-        data["rate"] = xr.DataArray(0.0).where(active)
+        layer_da = xr.full_like(
+            target_dis.dataset.coords["layer"], np.nan, dtype=np.float64
+        )
+        layer_da.loc[{"layer": 1}] = 0.0
+        data["rate"] = layer_da.where(active)
 
         return cls(**data, validate=True, fixed_cell=False)
 

--- a/imod/mf6/rch.py
+++ b/imod/mf6/rch.py
@@ -218,7 +218,7 @@ class Recharge(BoundaryCondition, IRegridPackage):
             # create an array indicating in which cells rch is active
             is_rch_cell = allocate_rch_cells(
                 ALLOCATION_OPTION.at_first_active,
-                new_idomain == 1,
+                new_idomain > 0,
                 planar_rate_regridded,
             )
 
@@ -228,6 +228,23 @@ class Recharge(BoundaryCondition, IRegridPackage):
             new_package_data["rate"] = rch_rate
 
         return Recharge(**new_package_data, validate=True, fixed_cell=False)
+
+    @classmethod
+    def from_imod5_cap_data(
+        cls,
+        imod5_data: dict[str, dict[str, GridDataArray]],
+        target_dis: StructuredDiscretization,
+    ) -> "Recharge":
+        """
+        Construct an rch-package from iMOD5 data in the CAP package, loaded with
+        the :func:`imod.formats.prj.open_projectfile_data` function.
+        """
+        cap_data = imod5_data["cap"]
+        new_idomain = target_dis.dataset["idomain"]
+
+        # Find which cells are active, basically same logic as in
+        # msw.GridData.from_imod5_data. Maybe cache that somewhere?
+
 
     @classmethod
     def get_regrid_methods(cls) -> RechargeRegridMethod:

--- a/imod/mf6/rch.py
+++ b/imod/mf6/rch.py
@@ -242,7 +242,9 @@ class Recharge(BoundaryCondition, IRegridPackage):
     ) -> "Recharge":
         """
         Construct an rch-package from iMOD5 data in the CAP package, loaded with
-        the :func:`imod.formats.prj.open_projectfile_data` function.
+        the :func:`imod.formats.prj.open_projectfile_data` function. Package is
+        used to couple MODFLOW6 to MetaSWAP models. Active cells will have a
+        recharge rate of 0.0.
         """
         cap_data = cast(GridDataDict, imod5_data["cap"])
 

--- a/imod/msw/grid_data.py
+++ b/imod/msw/grid_data.py
@@ -3,7 +3,6 @@ from typing import Optional
 import numpy as np
 import xarray as xr
 
-from imod.logging import LogLevel, logger
 from imod.mf6 import StructuredDiscretization
 from imod.mf6.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.regrid.regrid_schemes import (
@@ -13,63 +12,14 @@ from imod.mf6.utilities.regrid import RegridderWeightsCache
 from imod.msw.fixed_format import VariableMetaData
 from imod.msw.pkgbase import MetaSwapPackage
 from imod.msw.regrid.regrid_schemes import GridDataRegridMethod
-from imod.msw.utilities.common import concat_imod5
-from imod.typing import GridDataArray, GridDataDict
-from imod.typing.grid import ones_like
+from imod.msw.utilities.imod5_converter import (
+    get_cell_area_from_imod5_data,
+    get_landuse_from_imod5_data,
+    get_rootzone_depth_from_imod5_data,
+    is_msw_active_cell,
+)
+from imod.typing import GridDataDict
 from imod.util.spatial import get_cell_area, spatial_reference
-
-
-def get_cell_area_from_imod5_data(
-    imod5_cap: GridDataDict,
-) -> GridDataArray:
-    # area's per type of svats
-    mf6_area = get_cell_area(imod5_cap["wetted_area"])
-    wetted_area = imod5_cap["wetted_area"]
-    urban_area = imod5_cap["urban_area"]
-    rural_area = mf6_area - (wetted_area + urban_area)
-    if (wetted_area > mf6_area).any():
-        logger.log(
-            loglevel=LogLevel.WARNING,
-            message=f"wetted area was set to the max cell area of {mf6_area}",
-            additional_depth=0,
-        )
-        wetted_area = wetted_area.where(wetted_area <= mf6_area, other=mf6_area)
-    if (rural_area < 0.0).any():
-        logger.log(
-            loglevel=LogLevel.WARNING,
-            message="found urban area > than (cel-area - wetted area). Urban area was set to 0",
-            additional_depth=0,
-        )
-        urban_area = urban_area.where(rural_area > 0.0, other=0.0)
-    rural_area = mf6_area - (wetted_area + urban_area)
-    return concat_imod5(rural_area, urban_area)
-
-
-def get_landuse_from_imod5_data(
-    imod5_cap: GridDataDict,
-) -> GridDataArray:
-    """
-    Get landuse from imod5 capillary zone data. This adds two subunits, one
-    based on the landuse grid, which specifies rural landuse. The other
-    specifies urban landuse, which is coded to value 18.
-    """
-    rural_landuse = imod5_cap["landuse"]
-    # Urban landuse = 18
-    urban_landuse = ones_like(rural_landuse) * 18
-    return concat_imod5(rural_landuse, urban_landuse)
-
-
-def get_rootzone_depth_from_imod5_data(
-    imod5_cap: GridDataDict,
-) -> GridDataArray:
-    """
-    Get rootzone depth from imod5 capillary zone data. Also does a unit
-    conversion: iMOD5 specifies rootzone thickness in centimeters, whereas
-    MetaSWAP requires rootzone depth in meters.
-    """
-    rootzone_thickness = imod5_cap["rootzone_thickness"] * 0.01
-    # rootzone depth is equal for both svats.
-    return concat_imod5(rootzone_thickness, rootzone_thickness)
 
 
 class GridData(MetaSwapPackage, IRegridPackage):
@@ -194,11 +144,8 @@ class GridData(MetaSwapPackage, IRegridPackage):
         data["surface_elevation"] = imod5_cap["surface_elevation"]
         data["soil_physical_unit"] = imod5_cap["soil_physical_unit"]
 
-        mf6_top_active = target_dis["idomain"].isel(layer=0, drop=True)
-        subunit_active = (
-            (imod5_cap["boundary"] == 1) & (data["area"] > 0) & (mf6_top_active >= 1)
-        )
-        active = subunit_active.all(dim="subunit")
+        active, subunit_active = is_msw_active_cell(target_dis, imod5_cap, data["area"])
+
         data_active = {
             key: (
                 griddata.where(subunit_active)

--- a/imod/msw/utilities/imod5_converter.py
+++ b/imod/msw/utilities/imod5_converter.py
@@ -1,0 +1,87 @@
+from imod.logging import LogLevel, logger
+from imod.mf6 import StructuredDiscretization
+from imod.msw.utilities.common import concat_imod5
+from imod.typing import GridDataArray, GridDataDict
+from imod.typing.grid import ones_like
+from imod.util.spatial import get_cell_area
+
+
+def get_cell_area_from_imod5_data(
+    imod5_cap: GridDataDict,
+) -> GridDataArray:
+    # area's per type of svats
+    mf6_area = get_cell_area(imod5_cap["wetted_area"])
+    wetted_area = imod5_cap["wetted_area"]
+    urban_area = imod5_cap["urban_area"]
+    rural_area = mf6_area - (wetted_area + urban_area)
+    if (wetted_area > mf6_area).any():
+        logger.log(
+            loglevel=LogLevel.WARNING,
+            message=f"wetted area was set to the max cell area of {mf6_area}",
+            additional_depth=0,
+        )
+        wetted_area = wetted_area.where(wetted_area <= mf6_area, other=mf6_area)
+    if (rural_area < 0.0).any():
+        logger.log(
+            loglevel=LogLevel.WARNING,
+            message="found urban area > than (cel-area - wetted area). Urban area was set to 0",
+            additional_depth=0,
+        )
+        urban_area = urban_area.where(rural_area > 0.0, other=0.0)
+    rural_area = mf6_area - (wetted_area + urban_area)
+    return concat_imod5(rural_area, urban_area)
+
+
+def get_landuse_from_imod5_data(
+    imod5_cap: GridDataDict,
+) -> GridDataArray:
+    """
+    Get landuse from imod5 capillary zone data. This adds two subunits, one
+    based on the landuse grid, which specifies rural landuse. The other
+    specifies urban landuse, which is coded to value 18.
+    """
+    rural_landuse = imod5_cap["landuse"]
+    # Urban landuse = 18
+    urban_landuse = ones_like(rural_landuse) * 18
+    return concat_imod5(rural_landuse, urban_landuse)
+
+
+def get_rootzone_depth_from_imod5_data(
+    imod5_cap: GridDataDict,
+) -> GridDataArray:
+    """
+    Get rootzone depth from imod5 capillary zone data. Also does a unit
+    conversion: iMOD5 specifies rootzone thickness in centimeters, whereas
+    MetaSWAP requires rootzone depth in meters.
+    """
+    rootzone_thickness = imod5_cap["rootzone_thickness"] * 0.01
+    # rootzone depth is equal for both svats.
+    return concat_imod5(rootzone_thickness, rootzone_thickness)
+
+
+def is_msw_active_cell(
+    target_dis: StructuredDiscretization,
+    imod5_cap: GridDataDict,
+    msw_area: GridDataArray,
+) -> tuple[GridDataArray, GridDataArray]:
+    """
+    Return grid of cells that are active in the coupled computation, based on
+    following criteria:
+
+    - Active in top layer MODFLOW6
+    - Active in boundary array in CAP package
+    - MetaSWAP area > 0
+
+    Returns
+    -------
+    active: xr.DataArray
+        Active cells in any of the subunits
+    subunit_active: xr.DataArray
+        Cells active per subunit
+    """
+    mf6_top_active = target_dis["idomain"].isel(layer=0, drop=True)
+    subunit_active = (
+        (imod5_cap["boundary"] == 1) & (msw_area > 0) & (mf6_top_active >= 1)
+    )
+    active = subunit_active.any(dim="subunit")
+    return active, subunit_active

--- a/imod/msw/utilities/imod5_converter.py
+++ b/imod/msw/utilities/imod5_converter.py
@@ -1,5 +1,3 @@
-from functools import lru_cache
-
 from imod.logging import LogLevel, logger
 from imod.mf6 import StructuredDiscretization
 from imod.msw.utilities.common import concat_imod5
@@ -11,20 +9,10 @@ from imod.util.spatial import get_cell_area
 def get_cell_area_from_imod5_data(
     imod5_cap: GridDataDict,
 ) -> GridDataArray:
-    # Unpack grids and call into private function, so that only 2 grids have to
-    # be cached.
+    # area's per type of svats
+    mf6_area = get_cell_area(imod5_cap["wetted_area"])
     wetted_area = imod5_cap["wetted_area"]
     urban_area = imod5_cap["urban_area"]
-    return _get_cell_area_from_imod5_data(wetted_area, urban_area)
-
-
-@lru_cache(maxsize=2)
-def _get_cell_area_from_imod5_data(
-    wetted_area: GridDataArray, urban_area: GridDataArray
-) -> GridDataArray:
-    # area's per type of svats
-    mf6_area = get_cell_area(wetted_area)
-
     rural_area = mf6_area - (wetted_area + urban_area)
     if (wetted_area > mf6_area).any():
         logger.log(


### PR DESCRIPTION
Fixes #1313

# Description
Construct an rch-package from iMOD5 data in the CAP package, loaded with the ``open_projectfile_data`` function. Package is
used to couple MODFLOW6 to MetaSWAP models. Active cells will have a recharge rate of 0.0.

At the moment, MetaSWAP can only be coupled to the first layer, as this is also the case for ``primod``. iMOD Coupler these days supports coupling to other layers as well, but ``primod`` doesn't. Picking this up for iMOD Python and ``primod`` is worthy a separate story.

In detail:
- Add ``Recharge.from_imod5_cap_data`` class method, to construct an empty Recharge package with 0.0 rate.
- Minor refactor: Put ``GridData`` helper functions to ``msw/utilities/imod5_converter.py``, so that they can be reused.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
