### PR TITLE
Issue #1314 gxg chunking error

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -18,6 +18,9 @@ Fixed
   ``NotImplementedError`` when attempting to regrid an unstructured model to a
   structured grid.
 - :class:`imod.msw.Sprinkling` now correctly writes source svats to scap_svat.inp file.
+- :func:`imod.evaluate.calculate_gxg`, upon providing a head dataarray chunked
+  over time, will no longer error with ``ValueError: Object has inconsistent
+  chunks along dimension bimonth. This can be fixed by calling unify_chunks().``
 
 
 Changed

--- a/imod/evaluate/head.py
+++ b/imod/evaluate/head.py
@@ -118,7 +118,7 @@ def _calculate_gxg(
     # First compute LG3 and HG3 per hydrological year, then compute the mean over the total.
     if gxg_data.chunks is not None:
         # If data is lazily loaded/chunked, process data of one year at a time.
-        gxg_data = gxg_data.chunk({"hydroyear": 1})
+        gxg_data = gxg_data.chunk({"hydroyear": 1, "bimonth": -1})
         lg3 = xr.map_blocks(lowest3_mean, gxg_data, template=gxg_data.isel(bimonth=0))
         hg3 = xr.map_blocks(highest3_mean, gxg_data, template=gxg_data.isel(bimonth=0))
     else:

--- a/imod/tests/test_evaluate/test_head.py
+++ b/imod/tests/test_evaluate/test_head.py
@@ -1,10 +1,9 @@
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 import imod
-
-import pytest
 
 
 def test_convert_pointwaterhead_freshwaterhead_scalar():

--- a/imod/tests/test_evaluate/test_head.py
+++ b/imod/tests/test_evaluate/test_head.py
@@ -4,6 +4,8 @@ import xarray as xr
 
 import imod
 
+import pytest
+
 
 def test_convert_pointwaterhead_freshwaterhead_scalar():
     # fresh water
@@ -33,7 +35,8 @@ def test_convert_pointwaterhead_freshwaterhead_da():
     assert fwh.equals(fwh2.round(5))
 
 
-def test_calculate_gxg():
+@pytest.mark.parametrize("chunk", [False, True])
+def test_calculate_gxg(chunk: bool):
     data = (np.ones((1, 2, 49)) * np.arange(49)).T
     coords = {
         "time": pd.date_range("2000-04-01", periods=49, freq="SMS"),
@@ -42,6 +45,8 @@ def test_calculate_gxg():
     }
     dims = ("time", "y", "x")
     da = xr.DataArray(data, coords, dims)
+    if chunk:
+        da = da.chunk({"time": 1})
 
     coords_ref = {"y": [0.5, 1.5], "x": [0.5]}
     dims_ref = ("y", "x")
@@ -59,7 +64,8 @@ def test_calculate_gxg():
     assert gxg["ghg"].round(5).equals(0 - ghg_ref)
 
 
-def test_calculate_gxg_nan():
+@pytest.mark.parametrize("chunk", [False, True])
+def test_calculate_gxg_nan(chunk: bool):
     data = (np.ones((1, 2, 49)) * np.arange(49)).T
     # This invalidates the second year: it no longer forms a complete
     # "hydrological year" with 24 entries.
@@ -72,6 +78,8 @@ def test_calculate_gxg_nan():
     }
     dims = ("time", "y", "x")
     da = xr.DataArray(data, coords, dims)
+    if chunk:
+        da = da.chunk({"time": 1})
 
     coords_ref = {"y": [0.5, 1.5], "x": [0.5]}
     dims_ref = ("y", "x")


### PR DESCRIPTION
Fixes #1314

# Description
Fixes error ``ValueError: Object has inconsistent
  chunks along dimension bimonth. This can be fixed by calling unify_chunks().`` upon providing a DataArray chunked over time (as is the default for imod.mf6.out.open_head) to ``imod.evaluate.calculate_gxg``.

I had to explicitly set a chunksize to the "bimonth" dimension. I set it to the complete ``bimonth`` dimension, as this seemed to resolve the issue. You can verify this locally by undoing the change to ``imod/evaluate/head.py`` and then running the chunked test cases I added. This will raise the same error as described above.

Is this preserving the intended chunking behavior @Huite? Inferring from the comment ("If data is lazily loaded/chunked, process data of one year at a time"), my fix seems to do the right thing.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
