### PR TITLE
Add from_imod5_data method and test

### DIFF
--- a/imod/tests/test_msw/test_scaling_factors.py
+++ b/imod/tests/test_msw/test_scaling_factors.py
@@ -10,11 +10,12 @@ from imod.mf6.utilities.regrid import (
     RegridderWeightsCache,
 )
 from imod.msw import ScalingFactors
+from imod.typing.grid import ones_like
 
 
-def setup_scaling_factor():
+def setup_scaling_factor_grids():
     x = [1.0, 2.0, 3.0]
-    y = [1.0, 2.0, 3.0]
+    y = [3.0, 2.0, 1.0]
     subunit = [0, 1]
     dx = 1.0
     dy = 1.0
@@ -63,18 +64,18 @@ def setup_scaling_factor():
     # fmt: on
     index = (svat != 0).values.ravel()
 
+    return scale, depth_perched_water_table, index, svat
+
+
+def test_simple_model(fixed_format_parser):
+    scale, depth_perched_water_table, index, svat = setup_scaling_factor_grids()
+
     scaling_factors = ScalingFactors(
         scale_soil_moisture=scale,
         scale_hydraulic_conductivity=scale,
         scale_pressure_head=scale,
         depth_perched_water_table=depth_perched_water_table,
     )
-
-    return scaling_factors, index, svat
-
-
-def test_simple_model(fixed_format_parser):
-    scaling_factors, index, svat = setup_scaling_factor()
 
     with tempfile.TemporaryDirectory() as output_dir:
         output_dir = Path(output_dir)
@@ -95,8 +96,16 @@ def test_simple_model(fixed_format_parser):
     )
 
 
-def test_regrid_scaling_factor(fixed_format_parser, simple_2d_grid_with_subunits):
-    scaling_factors, _, _ = setup_scaling_factor()
+def test_regrid_scaling_factor(simple_2d_grid_with_subunits):
+    scale, depth_perched_water_table, _, _ = setup_scaling_factor_grids()
+
+    scaling_factors = ScalingFactors(
+        scale_soil_moisture=scale,
+        scale_hydraulic_conductivity=scale,
+        scale_pressure_head=scale,
+        depth_perched_water_table=depth_perched_water_table,
+    )
+
     new_grid = simple_2d_grid_with_subunits
 
     regrid_context = RegridderWeightsCache()
@@ -105,3 +114,34 @@ def test_regrid_scaling_factor(fixed_format_parser, simple_2d_grid_with_subunits
 
     assert np.all(regridded_scaling_factor.dataset["x"].values == new_grid["x"].values)
     assert np.all(regridded_scaling_factor.dataset["y"].values == new_grid["y"].values)
+
+
+def test_from_imod5_data(fixed_format_parser):
+    scale, depth_perched_water_table, index, svat = setup_scaling_factor_grids()
+
+    imod5_data = {"cap": {}}
+    scale_rural = scale.sel(subunit=0, drop=True)
+    imod5_data["cap"]["boundary"] = ones_like(scale_rural)
+    imod5_data["cap"]["soil_moisture_fraction"] = scale_rural
+    imod5_data["cap"]["conductivitiy_factor"] = scale_rural
+    imod5_data["cap"]["perched_water_table_level"] = depth_perched_water_table
+
+    scaling_factors = ScalingFactors.from_imod5_data(imod5_data)
+
+    with tempfile.TemporaryDirectory() as output_dir:
+        output_dir = Path(output_dir)
+        scaling_factors.write(output_dir, index, svat, None, None)
+
+        results = fixed_format_parser(
+            output_dir / ScalingFactors._file_name, ScalingFactors._metadata_dict
+        )
+
+    assert_equal(results["svat"], np.array([1, 2, 3, 4]))
+    assert_almost_equal(results["scale_soil_moisture"], np.array([0.5, 1.0, 1.0, 1.0]))
+    assert_almost_equal(
+        results["scale_hydraulic_conductivity"], np.array([0.5, 1.0, 1.0, 1.0])
+    )
+    assert_almost_equal(results["scale_pressure_head"], np.array([1.0, 1.0, 1.0, 1.0]))
+    assert_almost_equal(
+        results["depth_perched_water_table"], np.array([0.5, 1.0, 0.5, 0.7])
+    )


### PR DESCRIPTION
Fixes #1324

# Description
Adds a ``ScalingFactors.from_imod5_data`` method. I think, the final missing constructor method.
Scaling factors for urban areas are set 1.0, not sure if iMOD5 does this as well @HendrikKok?

# Checklist
- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
