### PR TITLE
Add pixi badge to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,8 @@
    :target: https://choosealicense.com/licenses/mit/
 .. image:: https://img.shields.io/conda/vn/conda-forge/imod.svg
    :target: https://github.com/conda-forge/imod-feedstock
+.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json
+   :target: https://pixi.sh
 
 The ``imod`` Python package is an open source project to make working with
 MODFLOW groundwater models in Python easier. It builds on top of popular

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,8 @@ iMOD Python: make massive MODFLOW models
    :target: https://choosealicense.com/licenses/mit/
 .. image:: https://img.shields.io/conda/vn/conda-forge/imod.svg
    :target: https://github.com/conda-forge/imod-feedstock
+.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json
+   :target: https://pixi.sh
 
 The ``imod`` Python package is an open source project to make working with
 MODFLOW groundwater models in Python easier. It builds on top of popular


### PR DESCRIPTION
[Given that the pixi team is kind enough to put a link to our project (and other Deltares products) on their website](https://pixi.sh/latest/Community/), we might as well return the favor by putting a badge in our readme and index page as well. Looks as follows:

![image](https://github.com/user-attachments/assets/3cdd6a80-837f-433d-b9aa-139fcc561d62)

