### PR TITLE
Issue #1339 Update pixi to v0.39.2

### DIFF
--- a/.teamcity/Dockerfile/Dockerfile
+++ b/.teamcity/Dockerfile/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/server:ltsc2022
 LABEL maintainer="sunny.titus@deltares.nl"
 
-ARG PIXI_VERSION=v0.34.0
+ARG PIXI_VERSION=v0.39.2
 
 ## Setup user
 USER "NT Authority\System"

--- a/.teamcity/_Self/MainProject.kt
+++ b/.teamcity/_Self/MainProject.kt
@@ -17,7 +17,7 @@ import jetbrains.buildServer.configs.kotlin.triggers.vcs
 object MainProject : Project({
     params {
         param("DockerContainer", "containers.deltares.nl/hydrology_product_line_imod/windows-pixi")
-        param("DockerVersion", "v0.34.0")
+        param("DockerVersion", "v0.39.2")
     }
 
     buildType(Lint)

--- a/docs/developing/docker.rst
+++ b/docs/developing/docker.rst
@@ -26,7 +26,7 @@ To build the image:
 .. code-block:: console
 
   docker context use desktop-windows  
-  docker build -t windows-pixi:34.0 . -m 2GB  
+  docker build -t windows-pixi:v0.34.0 . -m 2GB  
 
 The image tag is not randomly chosen. It matches the Pixi version shipped with the image. So make sure the tag equals the version inside the dockerfile.
 
@@ -54,8 +54,8 @@ After you connected to the registry you can tag and push your image:
 
 .. code-block:: console
 
-    docker tag windows-pixi:34.0 containers.deltares.nl/hydrology_product_line_imod/windows-pixi:34.0
-    docker push containers.deltares.nl/hydrology_product_line_imod/windows-pixi:34.0
+    docker tag windows-pixi:v0.34.0 containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.34.0
+    docker push containers.deltares.nl/hydrology_product_line_imod/windows-pixi:v0.34.0
 
 Again, make sure the tags match the ``PIXI_VERSION`` inside the dockerfile.
 


### PR DESCRIPTION
Fixes #1339 

# Description
This PR updates pixi to version v0.39.2.
An error in the documentation regarding the docker tag has been corrected

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
