### PR TITLE
Issue #1342 Also deepcopy HFB package upon calling clip_box

### DIFF
--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -1,5 +1,4 @@
 import abc
-import copy
 import json
 import textwrap
 import typing
@@ -457,11 +456,9 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
             ds_vars.remove(var)
 
         cls = type(self)
-        new = cls._from_dataset(copy.deepcopy(self.dataset[ds_vars]))
+        new = cls._from_dataset(deepcopy(self.dataset[ds_vars]))
         new.line_data = gpd.GeoDataFrame(
-            copy.deepcopy(
-                self.dataset[self._get_variable_names_for_gdf()].to_dataframe()
-            ),
+            deepcopy(self.dataset[self._get_variable_names_for_gdf()].to_dataframe()),
             geometry="geometry",
         )
 
@@ -800,10 +797,7 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
         -------
         sliced : Package
         """
-        cls = type(self)
-        new = cls._from_dataset(copy.deepcopy(self.dataset))
-        new.line_data = self.line_data
-        return new
+        return deepcopy(self)
 
     def mask(self, _) -> Package:
         """

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -911,10 +911,33 @@ def test_custom_deepcopy():
             "layer": [1],
         },
     )
-    hfb = HorizontalFlowBarrierResistance(geometry)
+    hfb = SingleLayerHorizontalFlowBarrierResistance(geometry)
 
     # Act
     hfb_copy = deepcopy(hfb)
 
     # Assert
     assert hfb_copy.dataset.identical(hfb.dataset)
+
+
+def test_clip_box():
+    # Arrange
+    barrier_y = [11.0, 5.0, -1.0]
+    barrier_x = [5.0, 5.0, 5.0]
+
+    geometry = gpd.GeoDataFrame(
+        geometry=[linestrings(barrier_x, barrier_y)],
+        data={
+            "resistance": [1200.0],
+            "layer": [1],
+        },
+    )
+    hfb = SingleLayerHorizontalFlowBarrierResistance(geometry)
+
+    # Act
+    hfb_clipped = hfb.clip_box(y_max=7.0)
+
+    # Assert
+    # HFB currently not clipped but copied
+    # FUTURE: Line data might be clipped in the future.
+    assert hfb_clipped.dataset.identical(hfb.dataset)


### PR DESCRIPTION
Fixes #1342

# Description
- Replace custom copy logic in ``clip_box`` with a call to ``deepcopy``, which works since https://github.com/Deltares/imod-python/pull/1327.
- Also add missing unit test for ``clip_box``

# Checklist

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
