### PR TITLE
Issue #1347 fix hfb clip box

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -33,6 +33,9 @@ Added
 Fixed
 ~~~~~
 
+- Fixed bug where :meth:`HorizontalFlowBarrierResistance.clip_box`,
+  :meth:`HorizontalFlowBarrierSingleLayerResistance.clip_box` methods only
+  returned deepcopy instead of actually clipping the line geometries.
 - Fixed bug where :class:`HorizontalFlowBarrierResistance`, 
   :class:`HorizontalFlowBarrierSingleLayerResistance` and other HFB packages could not 
   be clipped or copied with xarray >= 2024.10.0.

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -20,6 +20,7 @@ from imod.mf6.interfaces.ilinedatapackage import ILineDataPackage
 from imod.mf6.mf6_hfb_adapter import Mf6HorizontalFlowBarrier
 from imod.mf6.package import Package
 from imod.mf6.utilities.clip import (
+    bounding_polygon_from_line_data_and_clip_box,
     clip_line_gdf_by_bounding_polygon,
     clip_line_gdf_by_grid,
 )
@@ -808,16 +809,9 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
 
         if x_min or x_max or y_min or y_max:
             # Create bounding polygon
-            line_minx, line_miny, line_maxx, line_maxy = self.line_data.total_bounds
-            # Use pandas clip, as it gracefully deals with lower=None and upper=None
-            x_min, x_max = pd.Series([line_minx, line_maxx]).clip(
-                lower=x_min, upper=x_max
+            bounding_gdf = bounding_polygon_from_line_data_and_clip_box(
+                self.line_data, x_min, x_max, y_min, y_max
             )
-            y_min, y_max = pd.Series([line_miny, line_maxy]).clip(
-                lower=y_min, upper=y_max
-            )
-            bbox = shapely.box(x_min, y_min, x_max, y_max)
-            bounding_gdf = gpd.GeoDataFrame([0], geometry=[bbox])
             new.line_data = clip_line_gdf_by_bounding_polygon(
                 self.line_data, bounding_gdf
             )

--- a/imod/mf6/utilities/clip.py
+++ b/imod/mf6/utilities/clip.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
+import pandas as pd
 import xarray as xr
 import xugrid as xu
 from fastcore.dispatch import typedispatch
@@ -18,6 +20,14 @@ from imod.mf6.utilities.hfb import (
 from imod.typing import GeoDataFrameType, GridDataArray
 from imod.typing.grid import bounding_polygon, is_spatial_grid
 from imod.util.imports import MissingOptionalModule
+
+if TYPE_CHECKING:
+    import geopandas as gpd
+else:
+    try:
+        import geopandas as gpd
+    except ImportError:
+        gpd = MissingOptionalModule("geopandas")
 
 try:
     import shapely
@@ -155,3 +165,19 @@ def clip_line_gdf_by_grid(
     # Clip line with polygon
     bounding_gdf = bounding_polygon(active)
     return clip_line_gdf_by_bounding_polygon(gdf, bounding_gdf)
+
+
+def bounding_polygon_from_line_data_and_clip_box(
+    line_data: GeoDataFrameType,
+    x_min: Optional[float] = None,
+    x_max: Optional[float] = None,
+    y_min: Optional[float] = None,
+    y_max: Optional[float] = None,
+) -> GeoDataFrameType:
+    line_minx, line_miny, line_maxx, line_maxy = line_data.total_bounds
+    # Use pandas clip, as it gracefully deals with lower=None and upper=None
+    x_min, x_max = pd.Series([line_minx, line_maxx]).clip(lower=x_min, upper=x_max)
+    y_min, y_max = pd.Series([line_miny, line_maxy]).clip(lower=y_min, upper=y_max)
+    bbox = shapely.box(x_min, y_min, x_max, y_max)
+    dummy_value = 0
+    return gpd.GeoDataFrame([dummy_value], geometry=[bbox])

--- a/imod/mf6/utilities/clip.py
+++ b/imod/mf6/utilities/clip.py
@@ -134,13 +134,9 @@ def _clip_linestring(
     return clipped_line_data
 
 
-def clip_line_gdf_by_grid(
-    gdf: GeoDataFrameType, active: GridDataArray
+def clip_line_gdf_by_bounding_polygon(
+    gdf: GeoDataFrameType, bounding_gdf: GeoDataFrameType
 ) -> GeoDataFrameType:
-    """Clip GeoDataFrame by bounding polygon of grid"""
-    # Clip line with polygon
-    bounding_gdf = bounding_polygon(active)
-
     if (shapely.get_type_id(gdf.geometry) == shapely.GeometryType.POLYGON).any():
         # Shapely returns z linestrings when clipping our vertical z polygons.
         # To work around this convert polygons to zlinestrings to clip.
@@ -150,3 +146,12 @@ def clip_line_gdf_by_grid(
         return clipped_hfb_zlinestrings_to_zpolygons(clipped_linestrings)
     else:
         return _clip_linestring(gdf, bounding_gdf)
+
+
+def clip_line_gdf_by_grid(
+    gdf: GeoDataFrameType, active: GridDataArray
+) -> GeoDataFrameType:
+    """Clip GeoDataFrame by bounding polygon of grid"""
+    # Clip line with polygon
+    bounding_gdf = bounding_polygon(active)
+    return clip_line_gdf_by_bounding_polygon(gdf, bounding_gdf)

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -7,6 +7,7 @@ import pytest
 import xarray as xr
 import xugrid as xu
 from numpy.testing import assert_array_equal
+from pytest_cases import parametrize_with_cases
 from shapely import Polygon, get_coordinates, linestrings
 
 from imod.mf6 import (
@@ -954,3 +955,72 @@ def test_clip_box():
     # Case 4: y_max outside range, entirely empty geodataframe
     hfb_clipped = hfb.clip_box(y_max=-2.0)
     assert hfb_clipped.line_data.empty
+
+
+class HfbCases:
+    def case_vertical(self):
+        barrier_y = [11.0, 5.0, -1.0]
+        barrier_x = [5.0, 5.0, 5.0]
+
+        geometry = gpd.GeoDataFrame(
+            geometry=[linestrings(barrier_x, barrier_y)],
+            data={
+                "resistance": [1200.0],
+                "layer": [1],
+            },
+        )
+        expected_y = np.array([6.0, 4.0, 2.0, 0.0])
+        return geometry, expected_y
+
+    def case_horizontal(self):
+        barrier_y = [5.0, 5.0, 5.0]
+        barrier_x = [11.0, 5.0, -1.0]
+
+        geometry = gpd.GeoDataFrame(
+            geometry=[linestrings(barrier_x, barrier_y)],
+            data={
+                "resistance": [1200.0],
+                "layer": [1],
+            },
+        )
+        expected_y = np.array([6.0, 6.0, 6.0, 6.0, 6.0, 6.0])
+        return geometry, expected_y
+
+    def case_diagonal(self):
+        barrier_y = [11.0, 5.0, -1.0]
+        barrier_x = [11.0, 5.0, -1.0]
+
+        geometry = gpd.GeoDataFrame(
+            geometry=[linestrings(barrier_x, barrier_y)],
+            data={
+                "resistance": [1200.0],
+                "layer": [1],
+            },
+        )
+        expected_y = np.array([6.0, 6.0, 4.0, 4.0, 2.0, 2.0, 0.0])
+        return geometry, expected_y
+
+
+@parametrize_with_cases("hfb_case, expected_y", cases=HfbCases)
+def test_clipbox_and_to_mf6_pkg(structured_flow_model, hfb_case, expected_y):
+    # Arrange
+    dis = structured_flow_model["dis"]
+    top, bottom, idomain = (
+        dis["top"],
+        dis["bottom"],
+        dis["idomain"],
+    )
+    k = xr.ones_like(idomain)
+
+    hfb = SingleLayerHorizontalFlowBarrierResistance(hfb_case)
+    y_max = 7.0
+
+    # Act
+    hfb_clipped = hfb.clip_box(y_max=y_max)
+    mf6_hfb = hfb_clipped.to_mf6_pkg(idomain, top, bottom, k)
+
+    # Assert
+    actual_y = idomain.coords["y"].values[mf6_hfb["cell_id1"][0] - 1]
+
+    assert np.all(actual_y <= y_max)
+    np.testing.assert_equal(expected_y, actual_y)


### PR DESCRIPTION
Fixes #1347 

# Description
Fix HFB ``clip_box`` method, as that only returned a deepcopy instead of returning clipped line geometries.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
