### PR TITLE
Issue #1349 turn off strict hfb validation

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -61,6 +61,10 @@ Changed
 - If ``"cap"`` package present in ``imod5_data``,
   :meth:`imod.mf6.GroundwaterFlowModel.from_imod5_data` now automatically adds a
   well for metaswap sprinkling named ``"msw-sprinkling"``
+- Less strict validation for :class:`HorizontalFlowBarrierResistance`,
+  :class:`HorizontalFlowBarrierSingleLayerResistance` and other HFB packages for
+  simulations which are imported with
+  :meth:`imod.mf6.Modflow6Simulation.from_imod5_data`
 
 
 [0.18.1] - 2024-11-20

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -344,7 +344,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
             ``ValidationError``.
         """
         write_context = WriteContext(Path(directory), use_binary, use_absolute_paths)
-        validate_context = ValidationContext(validate, validate)
+        validate_context = ValidationContext(validate, validate, validate)
 
         status_info = self._write(
             modelname, globaltimes, write_context, validate_context
@@ -410,7 +410,14 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
                 pkg_name = HFB_PKGNAME
                 top, bottom, idomain = self._get_domain_geometry()
                 k = self._get_k()
-                mf6_hfb_pkg = merge_hfb_packages(mf6_hfb_ls, idomain, top, bottom, k)
+                mf6_hfb_pkg = merge_hfb_packages(
+                    mf6_hfb_ls,
+                    idomain,
+                    top,
+                    bottom,
+                    k,
+                    validate_context.strict_hfb_validation,
+                )
                 mf6_hfb_pkg._write(
                     pkgname=pkg_name,
                     globaltimes=globaltimes,

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1419,6 +1419,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
 
         simulation = Modflow6Simulation("imported_simulation")
         simulation._validation_context.strict_well_validation = False
+        simulation._validation_context.strict_hfb_validation = False
 
         # import GWF model,
         groundwaterFlowModel = GroundwaterFlowModel.from_imod5_data(

--- a/imod/mf6/utilities/mf6hfb.py
+++ b/imod/mf6/utilities/mf6hfb.py
@@ -21,6 +21,7 @@ def merge_hfb_packages(
     top: GridDataArray,
     bottom: GridDataArray,
     k: GridDataArray,
+    strict_hfb_validation: bool = True,
 ) -> Mf6HorizontalFlowBarrier:
     """
     Merges HorizontalFlowBarrier packages into single package as MODFLOW 6
@@ -40,10 +41,13 @@ def merge_hfb_packages(
         Grid with bottom of model layers.
     k: GridDataArray
         Grid with hydraulic conductivities.
+    strict_hfb_validation: bool
+        Turn on strict horizontal flow barrier validation.
     """
 
     barrier_ls = [
-        hfb._to_connected_cells_dataset(idomain, top, bottom, k) for hfb in hfb_ls
+        hfb._to_connected_cells_dataset(idomain, top, bottom, k, strict_hfb_validation)
+        for hfb in hfb_ls
     ]
     barrier_dataset = xr.concat(barrier_ls, dim="cell_id")
 

--- a/imod/mf6/validation_context.py
+++ b/imod/mf6/validation_context.py
@@ -5,3 +5,4 @@ from dataclasses import dataclass
 class ValidationContext:
     validate: bool = True
     strict_well_validation: bool = True
+    strict_hfb_validation: bool = True

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -511,6 +511,7 @@ def test_to_mf6_layered_hfb__error():
     indirect=True,
 )
 @pytest.mark.parametrize("inactivity_marker", [0, -1])
+@pytest.mark.parametrize("strict_hfb_validation", [True, False])
 @patch("imod.mf6.mf6_hfb_adapter.Mf6HorizontalFlowBarrier.__new__", autospec=True)
 def test_to_mf6_remove_invalid_edges(
     mf6_flow_barrier_mock,
@@ -518,6 +519,7 @@ def test_to_mf6_remove_invalid_edges(
     inactivity_marker,
     barrier_x_loc,
     expected_number_barriers,
+    strict_hfb_validation,
 ):
     # Arrange.
     idomain, top, bottom = parameterizable_basic_dis
@@ -545,10 +547,10 @@ def test_to_mf6_remove_invalid_edges(
     hfb = HorizontalFlowBarrierResistance(geometry)
 
     # Act.
-    if expected_number_barriers == 0:
+    if strict_hfb_validation and (expected_number_barriers == 0):
         pytest.xfail("Test expected to fail if expected number barriers = 0")
 
-    _ = hfb.to_mf6_pkg(idomain, top, bottom, k)
+    _ = hfb.to_mf6_pkg(idomain, top, bottom, k, strict_hfb_validation=strict_hfb_validation)
 
     # Assert.
     _, args = mf6_flow_barrier_mock.call_args

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -550,7 +550,9 @@ def test_to_mf6_remove_invalid_edges(
     if strict_hfb_validation and (expected_number_barriers == 0):
         pytest.xfail("Test expected to fail if expected number barriers = 0")
 
-    _ = hfb.to_mf6_pkg(idomain, top, bottom, k, strict_hfb_validation=strict_hfb_validation)
+    _ = hfb.to_mf6_pkg(
+        idomain, top, bottom, k, strict_hfb_validation=strict_hfb_validation
+    )
 
     # Assert.
     _, args = mf6_flow_barrier_mock.call_args

--- a/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
+++ b/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
@@ -259,8 +259,12 @@ def test_merge__middle_layer_inactive_domain(
     modellayers["idomain"].loc[2, :, :] = inactive_value
 
     hfb_ls = [
-        SingleLayerHorizontalFlowBarrierResistance(make_layer_geometry(single_resistance, 1)),
-        SingleLayerHorizontalFlowBarrierResistance(make_layer_geometry(single_resistance, 2)),
+        SingleLayerHorizontalFlowBarrierResistance(
+            make_layer_geometry(single_resistance, 1)
+        ),
+        SingleLayerHorizontalFlowBarrierResistance(
+            make_layer_geometry(single_resistance, 2)
+        ),
     ]
 
     # Act

--- a/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
+++ b/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
@@ -58,6 +58,20 @@ def make_layer_geometry(resistance, layer):
     return geometry
 
 
+def make_layer_geometry__outside_domain(resistance, layer):
+    barrier_y = [11.0, 5.0, -1.0]
+    barrier_x = [-9990.0, -9990.0, -9990.0]
+
+    geometry = gpd.GeoDataFrame(
+        geometry=[shapely.linestrings(barrier_x, barrier_y)],
+        data={
+            "resistance": [resistance],
+            "layer": [layer],
+        },
+    )
+    return geometry
+
+
 def make_depth_geometry(resistance, top, bot):
     barrier_y = [11.0, 5.0, -1.0]
     barrier_x = [5.0, 5.0, 5.0]
@@ -227,4 +241,30 @@ def test_merge_mixed_hfbs__multiple_layer(modellayers):
     assert mf6_hfb["cell_id"].shape == (18,)
     assert np.all(np.unique(mf6_hfb["layer"]) == np.array([1, 2, 3]))
     expected_resistance = 2 * single_resistance
+    assert (expected_resistance == 1 / mf6_hfb["hydraulic_characteristic"]).all()
+
+
+@pytest.mark.parametrize("strict_hfb_validation", [True, False])
+def test_merge_with_inactive_domain__to_pkg_single_layer(modellayers_single_layer, strict_hfb_validation):
+    # Arrange
+    single_resistance = 400.0
+
+    geometry = make_layer_geometry(single_resistance, 1)
+    modellayers_single_layer["idomain"] = xr.zeros_like(modellayers_single_layer["idomain"], dtype=int)
+
+    hfb_ls = [
+        SingleLayerHorizontalFlowBarrierResistance(geometry),
+        SingleLayerHorizontalFlowBarrierResistance(geometry),
+    ]
+
+    # Act
+    if strict_hfb_validation:
+        pytest.xfail("Test expected to fail for hfb in inactive domain")
+    
+    mf6_hfb = merge_hfb_packages(hfb_ls, strict_hfb_validation=strict_hfb_validation, **modellayers_single_layer)
+
+    # Assert
+    assert mf6_hfb["cell_id"].shape == (6,)
+    assert (mf6_hfb["layer"] == 1).all()
+    expected_resistance = single_resistance
     assert (expected_resistance == 1 / mf6_hfb["hydraulic_characteristic"]).all()

--- a/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
+++ b/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
@@ -245,17 +245,22 @@ def test_merge_mixed_hfbs__multiple_layer(modellayers):
 
 
 @pytest.mark.parametrize("strict_hfb_validation", [True, False])
-def test_merge_in_inactive_domain(
-    modellayers, strict_hfb_validation
+@pytest.mark.parametrize("inactive_value", [0, -1])
+def test_merge__middle_layer_inactive_domain(
+    modellayers, strict_hfb_validation, inactive_value
 ):
+    """
+    Test where middle layer is deactivated, HFB assigned to that layer should be
+    ignored.
+    """
     # Arrange
     single_resistance = 400.0
 
-    modellayers["idomain"].loc[1, :, :] = 1
+    modellayers["idomain"].loc[2, :, :] = inactive_value
 
     hfb_ls = [
-        make_layer_geometry(single_resistance, 1),
-        make_layer_geometry(single_resistance, 2),
+        SingleLayerHorizontalFlowBarrierResistance(make_layer_geometry(single_resistance, 1)),
+        SingleLayerHorizontalFlowBarrierResistance(make_layer_geometry(single_resistance, 2)),
     ]
 
     # Act

--- a/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
+++ b/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
@@ -245,20 +245,17 @@ def test_merge_mixed_hfbs__multiple_layer(modellayers):
 
 
 @pytest.mark.parametrize("strict_hfb_validation", [True, False])
-def test_merge_with_inactive_domain__to_pkg_single_layer(
-    modellayers_single_layer, strict_hfb_validation
+def test_merge_in_inactive_domain(
+    modellayers, strict_hfb_validation
 ):
     # Arrange
     single_resistance = 400.0
 
-    geometry = make_layer_geometry(single_resistance, 1)
-    modellayers_single_layer["idomain"] = xr.zeros_like(
-        modellayers_single_layer["idomain"], dtype=int
-    )
+    modellayers["idomain"].loc[1, :, :] = 1
 
     hfb_ls = [
-        SingleLayerHorizontalFlowBarrierResistance(geometry),
-        SingleLayerHorizontalFlowBarrierResistance(geometry),
+        make_layer_geometry(single_resistance, 1),
+        make_layer_geometry(single_resistance, 2),
     ]
 
     # Act
@@ -266,7 +263,7 @@ def test_merge_with_inactive_domain__to_pkg_single_layer(
         pytest.xfail("Test expected to fail for hfb in inactive domain")
 
     mf6_hfb = merge_hfb_packages(
-        hfb_ls, strict_hfb_validation=strict_hfb_validation, **modellayers_single_layer
+        hfb_ls, strict_hfb_validation=strict_hfb_validation, **modellayers
     )
 
     # Assert

--- a/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
+++ b/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
@@ -245,12 +245,16 @@ def test_merge_mixed_hfbs__multiple_layer(modellayers):
 
 
 @pytest.mark.parametrize("strict_hfb_validation", [True, False])
-def test_merge_with_inactive_domain__to_pkg_single_layer(modellayers_single_layer, strict_hfb_validation):
+def test_merge_with_inactive_domain__to_pkg_single_layer(
+    modellayers_single_layer, strict_hfb_validation
+):
     # Arrange
     single_resistance = 400.0
 
     geometry = make_layer_geometry(single_resistance, 1)
-    modellayers_single_layer["idomain"] = xr.zeros_like(modellayers_single_layer["idomain"], dtype=int)
+    modellayers_single_layer["idomain"] = xr.zeros_like(
+        modellayers_single_layer["idomain"], dtype=int
+    )
 
     hfb_ls = [
         SingleLayerHorizontalFlowBarrierResistance(geometry),
@@ -260,8 +264,10 @@ def test_merge_with_inactive_domain__to_pkg_single_layer(modellayers_single_laye
     # Act
     if strict_hfb_validation:
         pytest.xfail("Test expected to fail for hfb in inactive domain")
-    
-    mf6_hfb = merge_hfb_packages(hfb_ls, strict_hfb_validation=strict_hfb_validation, **modellayers_single_layer)
+
+    mf6_hfb = merge_hfb_packages(
+        hfb_ls, strict_hfb_validation=strict_hfb_validation, **modellayers_single_layer
+    )
 
     # Assert
     assert mf6_hfb["cell_id"].shape == (6,)

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -242,7 +242,7 @@ def bounding_polygon(active: xr.DataArray) -> GeoDataFrameType:
     to_polygonize = active.where(active, other=np.nan)
     polygons_gdf = _polygonize(to_polygonize)
     # Filter polygons with inactive values (NaN)
-    is_active_polygon = polygons_gdf["value"] == 1.0
+    is_active_polygon = polygons_gdf["value"] > 0
     return polygons_gdf.loc[is_active_polygon]
 
 


### PR DESCRIPTION
Fixes #1349

# Description
- Add ``strict_hfb_validation`` setting to ``ValidationContext``. It is set to False upon calling ``Modflow6Simulation.from_imod5_data``
- When ``ValidationContext.strict_hfb_validation`` is set to False, no error is thrown when no vectors could be snapped to grid.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
