### PR TITLE
Issue #496 Introduce DeprecationWarning for legacy Regridder

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -68,7 +68,12 @@ Changed
   :class:`HorizontalFlowBarrierSingleLayerResistance` and other HFB packages for
   simulations which are imported with
   :meth:`imod.mf6.Modflow6Simulation.from_imod5_data`
-
+- DeprecationWarning thrown upon initializing :class:`imod.prepare.Regridder`.
+  This object will be removed in the final 1.0 release. `Use the xugrid
+  regridder to regrid individual grids instead.
+  <https://deltares.github.io/xugrid/examples/regridder_overview.html>`_ To
+  regrid entire MODFLOW6 packages or simulations, `see the user guide here.
+  <https://deltares.github.io/imod-python/user_guide/regridding.html>`_.
 
 [0.18.1] - 2024-11-20
 ---------------------

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -69,7 +69,7 @@ Changed
   simulations which are imported with
   :meth:`imod.mf6.Modflow6Simulation.from_imod5_data`
 - DeprecationWarning thrown upon initializing :class:`imod.prepare.Regridder`.
-  This object will be removed in the final 1.0 release. `Use the xugrid
+  We plan to remove this object in the final 1.0 release. `Use the xugrid
   regridder to regrid individual grids instead.
   <https://deltares.github.io/xugrid/examples/regridder_overview.html>`_ To
   regrid entire MODFLOW6 packages or simulations, `see the user guide here.

--- a/imod/prepare/regrid.py
+++ b/imod/prepare/regrid.py
@@ -25,6 +25,8 @@ values from the source array (src), and pass it on to the aggregation method.
 The single aggregated value is then filled into the destination array (dst).
 """
 
+import textwrap
+import warnings
 from collections import namedtuple
 from typing import List, Sequence
 
@@ -296,6 +298,16 @@ def _nd_regrid(src, dst, src_coords, dst_coords, iter_regrid, use_relative_weigh
     return iter_dst.reshape(dst.shape)
 
 
+WARNING_MSG = textwrap.dedent(
+    """{name} is deprecated and will be removed in the
+    final v1.0 release. Use the regridder in xugrid instead. To regrid a single
+    array, see:
+    https://deltares.github.io/xugrid/examples/regridder_overview.html. To
+    regrid Modflow6 packages or entire simulations, see the user guide:
+    https://deltares.github.io/imod-python/user-guide/08-regridding.html."""
+)
+
+
 class Regridder(object):
     """
     Object to repeatedly regrid similar objects. Compiles once on first call,
@@ -368,6 +380,11 @@ class Regridder(object):
     def __init__(
         self, method, ndim_regrid=None, use_relative_weights=False, extra_overlap=0
     ):
+        warnings.warn(
+            WARNING_MSG.format(name=self.__class__.__name__),
+            DeprecationWarning,
+        )
+
         _method = common._get_method(method, common.METHODS)
         self.method = _method
         self.ndim_regrid = ndim_regrid

--- a/imod/prepare/regrid.py
+++ b/imod/prepare/regrid.py
@@ -299,7 +299,7 @@ def _nd_regrid(src, dst, src_coords, dst_coords, iter_regrid, use_relative_weigh
 
 
 WARNING_MSG = textwrap.dedent(
-    """{name} is deprecated and will be removed in the
+    """{name} is deprecated and we plan to remove it in the
     final v1.0 release. Use the regridder in xugrid instead. To regrid a single
     array, see:
     https://deltares.github.io/xugrid/examples/regridder_overview.html. To

--- a/imod/tests/test_regrid.py
+++ b/imod/tests/test_regrid.py
@@ -556,3 +556,8 @@ def test_no_overlap():
     out = imod.prepare.Regridder(method=weightedmean).regrid(source, like)
     assert out.shape == (2,)
     assert out.isnull().all()
+
+
+def test_deprecation_warn_upon_init():
+    with pytest.warns(DeprecationWarning):
+        _ = imod.prepare.Regridder(method="mean")


### PR DESCRIPTION
Fixes #496

# Description
Throw DeprecationWarning warning upon initiating the legacy Regridder object:

![image](https://github.com/user-attachments/assets/7fe2dcdc-57fc-40d9-9ff7-d20a6ce1f300)

We plan to remove this object in the release, but some user testing has to be done to see whether the xugrid regridders are a full replacement.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
