### PR TITLE
Issue #1355 Slight optimization for performance regrid array

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -52,6 +52,7 @@ Fixed
 - :func:`imod.evaluate.calculate_gxg`, upon providing a head dataarray chunked
   over time, will no longer error with ``ValueError: Object has inconsistent
   chunks along dimension bimonth. This can be fixed by calling unify_chunks().``
+- Improved performance of regridding package data.
 
 
 Changed

--- a/imod/mf6/utilities/regrid.py
+++ b/imod/mf6/utilities/regrid.py
@@ -168,7 +168,7 @@ def _regrid_array(
 
     # the dataarray might be a scalar. If it is, then it does not need regridding.
     if scalar_da:
-        return da.values[()]  # type: ignore [attr-defined]
+        return da.values[()]
 
     if isinstance(da, xr.DataArray):
         coords = da.coords

--- a/imod/mf6/utilities/regrid.py
+++ b/imod/mf6/utilities/regrid.py
@@ -162,11 +162,12 @@ def _regrid_array(
     """
 
     # skip regridding for scalar arrays with no valid values (such as "None")
-    if is_scalar(da) and not _is_valid(da.values[()]):
+    scalar_da: bool = is_scalar(da)
+    if scalar_da and not _is_valid(da.values[()]):
         return None
 
     # the dataarray might be a scalar. If it is, then it does not need regridding.
-    if is_scalar(da):
+    if scalar_da:
         return da.values[()]  # type: ignore [attr-defined]
 
     if isinstance(da, xr.DataArray):

--- a/imod/mf6/utilities/regrid.py
+++ b/imod/mf6/utilities/regrid.py
@@ -161,8 +161,8 @@ def _regrid_array(
     - None
     """
 
-    # skip regridding for arrays with no valid values (such as "None")
-    if not _is_valid(da.values[()]):
+    # skip regridding for scalar arrays with no valid values (such as "None")
+    if is_scalar(da) and not _is_valid(da.values[()]):
         return None
 
     # the dataarray might be a scalar. If it is, then it does not need regridding.


### PR DESCRIPTION
Fixes #1355

# Description
Slight performance improvement: Avoid checking if all arrays is_invalid. Only do when ``is_scalar``.

For test with 1e9 cells:

Before fix:
567 ms ± 26.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
After fix:
545 ms ± 19.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

Second time I ran these tests:
Before fix:
530 ms ± 21.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
After fix:
503 ms ± 29.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

Script to run:

```python
import imod
import numpy as np
from imod.mf6.utilities.regrid import _regrid_array, RegridderWeightsCache, RegridderType
import xarray as xr

dx = 1.
dy = -1.
xmin = 0.0
xmax = 10000.0
ymin = 0.0
ymax = 10000.0
layer = np.arange(10) + 1

da = xr.ones_like(imod.util.empty_3d(dx=dx, xmin=xmin, xmax=xmax, dy=dy, ymin=ymin, ymax=ymax, layer=layer))
target = imod.util.empty_2d(dx=10.0, xmin=xmin, xmax=xmax, dy=-10.0, ymin=ymin, ymax=ymax)

regridder_collection = RegridderWeightsCache()
regridder_name = RegridderType.OVERLAP 
regridder_function = "mean"

# In IPython, run:
# %timeit _regrid_array(da, regridder_collection, regridder_name, regridder_function, target)
```


# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
