### PR TITLE
Issue #984 known imod5 issues

### DIFF
--- a/docs/faq/imod5_backwards_compatibility.rst
+++ b/docs/faq/imod5_backwards_compatibility.rst
@@ -15,16 +15,16 @@ Known issues
 - ISG files cannot be read directly. The workaround is to rasterize the ISG
   files to IDF files using the iMOD5 BATCH function ISGGRID.
 - MetaSWAP sprinkling wells defined as IPF files are not supported.
-- MetaSWAP's "flexible drainage" ("Peilgestuurde drainage" in Dutch) not
+- MetaSWAP's "flexible drainage" ("Peilgestuurde drainage" in Dutch) is not
   supported.
 - IPEST is not supported.
 
 Notes
 -----
 
-- if STO package in projectfile is absent, error is thrown when trying to write
+- if STO package in projectfile is absent, an error is thrown when trying to write
   the :class:`imod.mf6.Modflow6Simulation` object to disk. This is due to the
-  fact that the STO package is mandatory in MODFLOW6. A workaround is to add a
+  fact that the STO package is mandatory in iMOD Python. A workaround is to add a
   :class:`imod.mf6.StorageCoefficient` package to the projectfile before calling
   :meth:`imod.mf6.Modflow6Simulation.write`.
 - When importing models with the ANI package, make sure to activate the "XT3D"
@@ -33,7 +33,7 @@ Notes
   preset from MODFLOW6 ("Moderate") is set. This is because the solvers between
   iMODLFOW and MODFLOW6 are different. You are advised to test settings
   yourself.
-- The imported imod5 discretization for the model is created by taking the
+- The imported iMOD5 discretization for the model is created by taking the
   smallest grid and finest resolution amongst the TOP, BOT, and BND grids. This
   differs from iMOD5, where the first BND grid is used as target grid. All input
   grids are regridded towards this target grid. Therefore, be careful when you

--- a/docs/faq/imod5_backwards_compatibility.rst
+++ b/docs/faq/imod5_backwards_compatibility.rst
@@ -2,9 +2,43 @@ iMOD5 backwards compatibility
 =============================
 
 iMOD Python tries to be as backwards compatible with iMOD5 as our resources
-allow. Below you can find tables with the status of support for important iMOD5
-features. If you miss an important feature in the table, `feel free to open an
-issue on our issueboard <https://github.com/Deltares/imod-python/issues>`_.
+allow. Below you can find some known issues, notes, and more detailed tables
+with the status of support for important iMOD5 features. If you miss an
+important feature or run into any issues, `feel free to open an issue on our
+issueboard <https://github.com/Deltares/imod-python/issues>`_.
+
+Known issues
+------------
+
+- Constants are only supported for the CAP package. For other packages, the
+  constants will cause an error.
+- ISG files cannot be read directly. The workaround is to rasterize the ISG
+  files to IDF files using the iMOD5 BATCH function ISGGRID.
+- MetaSWAP sprinkling wells defined as IPF files are not supported.
+- MetaSWAP's "flexible drainage" ("Peilgestuurde drainage" in Dutch) not
+  supported.
+- IPEST is not supported.
+
+Notes
+-----
+
+- if STO package in projectfile is absent, error is thrown when trying to write
+  the :class:`imod.mf6.Modflow6Simulation` object to disk. This is due to the
+  fact that the STO package is mandatory in MODFLOW6. A workaround is to add a
+  :class:`imod.mf6.StorageCoefficient` package to the projectfile before calling
+  :meth:`imod.mf6.Modflow6Simulation.write`.
+- When importing models with the ANI package, make sure to activate the "XT3D"
+  in the NodePropertyFlow package of the model.
+- Solver settings (PCG) are NOT imported from iMOD5, instead a solver settings
+  preset from MODFLOW6 ("Moderate") is set. This is because the solvers between
+  iMODLFOW and MODFLOW6 are different. You are advised to test settings
+  yourself.
+- The imported imod5 discretization for the model is created by taking the
+  smallest grid and finest resolution amongst the TOP, BOT, and BND grids. This
+  differs from iMOD5, where the first BND grid is used as target grid. All input
+  grids are regridded towards this target grid. Therefore, be careful when you
+  have a very fine resolution in one of these packages.
+
 
 Files
 -----

--- a/docs/faq/known-issues.rst
+++ b/docs/faq/known-issues.rst
@@ -6,10 +6,31 @@ Modflow 6 versions
 
 iMOD Python is tested to work with Modflow 6 versions:
 
-* All 6.2 versions
-* All 6.3 versions
+* All 6.2, 6.3 versions
 * 6.4.0, 6.4.2
+* All 6.4, and 6.5 versions
 
 Confirmed to not work:
 
 * 6.4.1
+
+
+iMOD5 Backwards compatibility
+-----------------------------
+
+For a detailed description of known issues with iMOD5 backwards compatibility,
+see :doc:`imod5-backwards-compatibility`.
+
+
+Python versions
+---------------
+
+iMOD Python v1.0b0 is tested to work with Python versions:
+
+* 3.10
+* 3.11
+* 3.12
+
+Confirmed to not work (yet):
+
+* 3.13

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python 3.10 up until 3.12**. 
+You'll need **Python 3.10, 3.11, or 3.12**. 
 
 The recommended way to install Python depends on your experience: Are you new to
 the Python packaging ecosystem or already got experience with it? If you already

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python 3.10 or greater**. 
+You'll need **Python 3.10 up until 3.12**. 
 
 The recommended way to install Python depends on your experience: Are you new to
 the Python packaging ecosystem or already got experience with it? If you already


### PR DESCRIPTION
Fixes #984 

# Description
- Adds "Known Issues" section to iMOD5 Backwards Compatibility page
- "Known Issues" page refers to iMOD5 Backwards compatibility page
- Set max support Python version to 3.12

