### PR TITLE
Issue #1103 Dump iMOD Python version number to toml

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -29,6 +29,7 @@ Added
   settings.
 - :func:`imod.data.tutorial_03` to load data for the iMOD Documentation
   tutorial.
+- :meth:`imod.mf6.Modflow6Simulation.dump` now saves iMOD Python version number.
 
 Fixed
 ~~~~~

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -871,6 +871,9 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         directory.mkdir(parents=True, exist_ok=True)
 
         toml_content: DefaultDict[str, dict] = collections.defaultdict(dict)
+        # Dump version number
+        toml_content["version"] = {"imod-python": imod.__version__}
+        # Dump models and exchanges
         for key, value in self.items():
             cls_name = type(value).__name__
             if isinstance(value, Modflow6Model):
@@ -917,6 +920,13 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         toml_path = pathlib.Path(toml_path)
         with open(toml_path, "rb") as f:
             toml_content = tomli.load(f)
+
+        version_saved = toml_content.pop("version")
+        if version_saved["imod-python"] != imod.__version__:
+            warnings.warn(
+                f"Version mismatch: imod-python {imod.__version__} != imod-python {version_saved['imod-python']}",
+                UserWarning,
+            )
 
         simulation = Modflow6Simulation(name=toml_path.stem)
         for key, entry in toml_content.items():

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -924,7 +924,9 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         version_saved = toml_content.pop("version")
         if version_saved["imod-python"] != imod.__version__:
             warnings.warn(
-                f"Version mismatch: imod-python {imod.__version__} != imod-python {version_saved['imod-python']}",
+                "iMOD Python version in current environment different from version with which simulation was dumped."
+                f" Environment version: {imod.__version__}, version dumped simulation: imod-python {version_saved['imod-python']}"
+                " Versions might be incompatible.",
                 UserWarning,
             )
 

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -87,7 +87,7 @@ def test_dump_version_number__version_written(twri_model, tmpdir_factory):
 
 
 @pytest.mark.usefixtures("twri_model")
-def test_dump_version_number__warning_thrown(twri_model, tmpdir_factory):
+def test_dump_version_number__version_incompatible(twri_model, tmpdir_factory):
     """
     Tested if a warning is thrown when there is a mismatch between version
     numbers of saved model and current iMOD Python version.
@@ -104,7 +104,29 @@ def test_dump_version_number__warning_thrown(twri_model, tmpdir_factory):
     with open(toml_path_adapted, "wb") as f:
         tomli_w.dump(toml_content, f)
     # Act
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match="0.0.0"):
+        imod.mf6.Modflow6Simulation.from_file(toml_path_adapted)
+
+
+@pytest.mark.usefixtures("twri_model")
+def test_dump_version_number__no_version(twri_model, tmpdir_factory):
+    """
+    Tested if a warning is thrown when there is a mismatch between version
+    numbers of saved model and current iMOD Python version.
+    """
+    # Arrange
+    tmp_path = tmpdir_factory.mktemp("twri")
+    twri_model.dump(tmp_path)
+    toml_path = tmp_path / f"{twri_model.name}.toml"
+    with open(toml_path, "rb") as f:
+        toml_content = tomli.load(f)
+    toml_content.pop("version")
+
+    toml_path_adapted = tmp_path / f"{twri_model.name}_adapted.toml"
+    with open(toml_path_adapted, "wb") as f:
+        tomli_w.dump(toml_content, f)
+    # Act
+    with pytest.warns(UserWarning, match="No version information"):
         imod.mf6.Modflow6Simulation.from_file(toml_path_adapted)
 
 

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 import textwrap
 from copy import deepcopy
 from datetime import datetime
@@ -7,7 +8,6 @@ from filecmp import dircmp
 from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock
-import sys
 
 import numpy as np
 import pandas as pd
@@ -19,7 +19,7 @@ import xarray as xr
 import xugrid as xu
 
 import imod
-from imod.logging import LogLevel, LoggerType
+from imod.logging import LoggerType, LogLevel
 from imod.mf6 import LayeredWell, Well
 from imod.mf6.model import Modflow6Model
 from imod.mf6.multimodel.modelsplitter import PartitionInfo
@@ -121,6 +121,7 @@ def test_from_file_version_logged__version_in_dumped(twri_model, tmpdir_factory)
         log = log_file.read()
         assert f"iMOD Python version in current environment: {imod.__version__}" in log
         assert "iMOD Python version in dumped simulation: 0.0.0" in log
+
 
 @pytest.mark.usefixtures("twri_model")
 def test_from_file_version_logged__no_version_in_dumped(twri_model, tmpdir_factory):


### PR DESCRIPTION
Fixes #1103

# Description
Dump iMOD Python version number to toml, throw ``UserWarning`` if version number mismatch upon loading dumped data or when no version number could be found.

Also remove python version check for pytest as we are not going below 3.7
 
# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
