### PR TITLE
Issue #1364 post release

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -6,8 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+[1.0.0rc1] - 2024-12-20
+-----------------------
+
+Small post-release fix for installation instructions in documentation.
+
 [1.0.0rc0] - 2024-12-20
-----------------------
+-----------------------
 
 Added
 ~~~~~

--- a/docs/developing/releasing.rst
+++ b/docs/developing/releasing.rst
@@ -26,3 +26,28 @@ The TeamCity pipeline will:
 1. Create a release on GitHub
 2. Create the imod-python package and upload it to PyPi
 3. Build the documentation and deploy it
+
+The release is now available on PyPi but not yet on conda-forge. The conda-forge
+bot will automatically open a PR to update `the imod feedstock.
+<https://github.com/conda-forge/imod-feedstock>`_ It usually takes a few hours
+before the bot opens a PR. This PR will be reviewed by the imod-feedstock
+maintainers and merged if everything is in order. 
+
+Release a pre-release
+^^^^^^^^^^^^^^^^^^^^^
+
+To release a pre-release, follow the same steps as above, but add a ``rc`` to the
+version + a build number. For example: ``1.0.0rc0`` for the first release candidate.
+
+PyPI will automatically recognize this as a pre-release, thus will not show it
+as a stable build. To get the pre-release on conda-forge, you need to:
+
+1. Fork `the imod-feedstock <https://github.com/conda-forge/imod-feedstock>`_
+2. Checkout the ``rc`` branch of the imod-feedstock
+3. Update the version in the ``recipe/meta.yaml`` file to the pre-release version, e.g. ``1.0.0rc0``
+4. Update the sha256 checksum in the ``recipe/meta.yaml`` file, you can generate one by running:
+   ``curl -sL https://pypi.io/packages/source/i/imod/imod-{{version}}.tar.gz | openssl sha256`` 
+   (TIP: On Windows, you can install curl and openssl via pixi)
+5. Commit and push the changes to your fork
+6. Open a PR to the imod-feedstock and make sure it merges to the ``rc`` branch.
+7. This will trigger a few CI jobs. When these succeed, the branch can be merged.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,11 +28,12 @@ Install beta release
 
 To install a beta release with pixi::
 
+  pixi config prepend default-channels "conda-forge/label/imod_rc"
   pixi add imod=1.0.0rc0
 
 Or with conda::
 
-  conda install imod=1.0.0rc0
+  conda install -c conda-forge/label/imod_rc -c conda-forge imod=1.0.0rc0
 
 Or with pip::
 

--- a/imod/__init__.py
+++ b/imod/__init__.py
@@ -15,4 +15,4 @@ from imod import (
 )
 from imod.formats import gen, idf, ipf, prj, rasterio
 
-__version__ = "1.0.0rc0"
+__version__ = "1.0.0rc1"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imod-python"
-version = "1.0.0rc0"
+version = "1.0.0rc1"
 description = "Make massive MODFLOW models"
 authors = ["Deltares <imod.info@deltares.nl>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
Fixes #1364

# Description
- Adds installation instructions to release release candidate
- Bump release candidate number, as combining release candidate labels and post-release labels is ill-advised by the python docs:

> Creating post-releases of pre-releases is strongly discouraged, as it makes the version identifier difficult to parse for human readers. In general, it is substantially clearer to simply create a new pre-release by incrementing the numeric component.

See https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases