### PR TITLE
Issue #1177 negative layer allocation

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -6,6 +6,25 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+[Unreleased]
+------------
+
+Added
+~~~~~
+
+- :meth:`imod.mf6.Recharge.from_imod5_data`,
+  :meth:`imod.mf6.River.from_imod5_data`,
+  :meth:`imod.mf6.Drainage.from_imod5_data`, and
+  :meth:`imod.mf6.GeneralHeadBoundary.from_imod5_data` now assign negative layer
+  numbers to the first active layer.
+
+Changed
+~~~~~~~
+
+- :func:`imod.formats.prj.open_projectfile_data` now also assigns negative and
+  zero layer numbers to grid coordinates.
+
+
 [1.0.0rc1] - 2024-12-20
 -----------------------
 

--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -709,12 +709,12 @@ def _process_boundary_condition_entry(entry: Dict, periods: Dict[str, datetime])
 
     # 0 signifies that the layer must be determined on the basis of
     # bottom elevation and stage.
+    # -1 signifies that the layer must be determined on the basis of
+    # top active cells.
     layer = entry["layer"]
-    if layer <= 0:
-        layer is None
-    else:
-        coords["layer"] = layer
-        dims = dims + ("layer",)
+
+    coords["layer"] = layer
+    dims = dims + ("layer",)
 
     if "path" not in entry:
         path = None
@@ -727,8 +727,7 @@ def _process_boundary_condition_entry(entry: Dict, periods: Dict[str, datetime])
     header["addition"] = entry["addition"]
     header["factor"] = entry["factor"]
     header["dims"] = dims
-    if layer is not None:
-        header["layer"] = layer
+    header["layer"] = layer
     if time is not None:
         header["time"] = time
 

--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -707,12 +707,7 @@ def _process_boundary_condition_entry(entry: Dict, periods: Dict[str, datetime])
         dims = ("time",)
         coords["time"] = time
 
-    # 0 signifies that the layer must be determined on the basis of
-    # bottom elevation and stage.
-    # -1 signifies that the layer must be determined on the basis of
-    # top active cells.
     layer = entry["layer"]
-
     coords["layer"] = layer
     dims = dims + ("layer",)
 

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -215,7 +215,7 @@ class Drainage(BoundaryCondition, IRegridPackage):
         bottom = dis.dataset["bottom"]
         idomain = dis.dataset["idomain"]
 
-        if has_negative_layer(planar_data["head"]):
+        if has_negative_layer(planar_data["elevation"]):
             allocation_option = ALLOCATION_OPTION.at_first_active
 
         # Enforce planar data, remove all layer dimension information

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -34,7 +34,7 @@ from imod.schemata import (
     OtherCoordsSchema,
 )
 from imod.typing import GridDataArray
-from imod.typing.grid import enforce_dim_order, is_planar_grid
+from imod.typing.grid import enforce_dim_order, has_negative_layer, is_planar_grid
 from imod.util.expand_repetitions import expand_repetitions
 
 
@@ -214,6 +214,15 @@ class Drainage(BoundaryCondition, IRegridPackage):
         top = dis.dataset["top"]
         bottom = dis.dataset["bottom"]
         idomain = dis.dataset["idomain"]
+
+        if has_negative_layer(planar_data["head"]):
+            allocation_option = ALLOCATION_OPTION.at_first_active
+
+        # Enforce planar data, remove all layer dimension information
+        planar_data = {
+            key: grid.isel({"layer": 0}, drop=True, missing_dims="ignore")
+            for key, grid in planar_data.items()
+        }
 
         drn_allocation = allocate_drn_cells(
             allocation_option,

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -190,7 +190,9 @@ class Drainage(BoundaryCondition, IRegridPackage):
     ) -> dict[str, GridDataArray]:
         """
         Allocate and distribute planar data for given discretization and npf
-        package.
+        package. If layer number of ``planar_data`` is negative,
+        ``allocation_option`` is overrided and set to
+        ALLOCATION_OPTION.at_first_active.
 
         Parameters
         ----------
@@ -201,7 +203,9 @@ class Drainage(BoundaryCondition, IRegridPackage):
         npf: imod.mf6.NodePropertyFlow
             Node property flow package.
         allocation_option: ALLOCATION_OPTION
-            allocation option.
+            allocation option. If planar data is assigned to a negative layer
+            number, this option is overridden and set to
+            ALLOCATION_OPTION.at_first_active.
         distributing_option: DISTRIBUTING_OPTION
             distributing option.
 
@@ -270,6 +274,8 @@ class Drainage(BoundaryCondition, IRegridPackage):
 
         Parameters
         ----------
+        key: str
+            Packagename of the iMOD5 data to use.
         imod5_data: dict
             Dictionary with iMOD5 data. This can be constructed from the
             :func:`imod.formats.prj.open_projectfile_data` method.
@@ -282,7 +288,9 @@ class Drainage(BoundaryCondition, IRegridPackage):
         target_npf: NodePropertyFlow package
             The conductivity information, used to compute drainage flux
         allocation_option: ALLOCATION_OPTION
-            allocation option.
+            allocation option. If package data is assigned to a negative layer
+            number, this option is overridden and set to
+            ALLOCATION_OPTION.at_first_active.
         distributing_option: dict[str, DISTRIBUTING_OPTION]
             distributing option.
         time_min: datetime

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -230,14 +230,14 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         layered_data["head"] = planar_data["head"].where(ghb_allocation)
         layered_data["head"] = enforce_dim_order(layered_data["head"])
 
-        conductance = planar_data["conductance"]
-        if "layer" in conductance.coords:
-            conductance = conductance.isel({"layer": 0}, drop=True)
+        planar_conductance = planar_data["conductance"]
+        if "layer" in planar_conductance.coords:
+            planar_conductance = planar_conductance.isel({"layer": 0}, drop=True)
 
         layered_data["conductance"] = distribute_ghb_conductance(
             distributing_option,
             ghb_allocation,
-            conductance,
+            planar_conductance,
             top,
             bottom,
             npf.dataset["k"],

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -193,7 +193,9 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
     ) -> dict[str, GridDataArray]:
         """
         Allocate and distribute planar data for given discretization and npf
-        package.
+        package. If layer number of ``planar_data`` is negative,
+        ``allocation_option`` is overrided and set to
+        ALLOCATION_OPTION.at_first_active.
 
         Parameters
         ----------
@@ -204,7 +206,9 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         npf: imod.mf6.NodePropertyFlow
             Node property flow package.
         allocation_option: ALLOCATION_OPTION
-            allocation option.
+            allocation option. If planar data is assigned to a negative layer
+            number, this option is overridden and set to
+            ALLOCATION_OPTION.at_first_active.
         distributing_option: DISTRIBUTING_OPTION
             distributing option.
 
@@ -286,7 +290,9 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         target_npf: NodePropertyFlow package
             The conductivity information, used to compute GHB flux
         allocation_option: ALLOCATION_OPTION
-            allocation option.
+            allocation option. If package data is assigned to a negative layer
+            number, this option is overridden and set to
+            ALLOCATION_OPTION.at_first_active.
         time_min: datetime
             Begin-time of the simulation. Used for expanding period data.
         time_max: datetime

--- a/imod/mf6/rch.py
+++ b/imod/mf6/rch.py
@@ -166,11 +166,11 @@ class Recharge(BoundaryCondition, IRegridPackage):
         cls,
         planar_data: dict[str, GridDataArray],
         dis: StructuredDiscretization,
-        allocation_option: ALLOCATION_OPTION,
     ) -> dict[str, GridDataArray]:
         """
         Allocate and distribute planar data for given discretization and npf
-        package.
+        package. To allocate cells, the allocation option
+        ALLOCATION_OPTION.at_first_active is set.
 
         Parameters
         ----------
@@ -180,10 +180,6 @@ class Recharge(BoundaryCondition, IRegridPackage):
             Model discretization package.
         npf: imod.mf6.NodePropertyFlow
             Node property flow package.
-        allocation_option: ALLOCATION_OPTION
-            allocation option.
-        distributing_option: DISTRIBUTING_OPTION
-            distributing option.
 
         Returns
         -------

--- a/imod/mf6/rch.py
+++ b/imod/mf6/rch.py
@@ -251,9 +251,7 @@ class Recharge(BoundaryCondition, IRegridPackage):
 
         # if rate has only layer 0, then it is planar.
         if is_planar_grid(regridded_package_data["rate"]):
-            layered_data = cls.allocate_planar_data(
-                regridded_package_data, target_dis, ALLOCATION_OPTION.at_first_active
-            )
+            layered_data = cls.allocate_planar_data(regridded_package_data, target_dis)
             regridded_package_data.update(layered_data)
 
         return cls(**regridded_package_data, validate=True, fixed_cell=False)

--- a/imod/mf6/rch.py
+++ b/imod/mf6/rch.py
@@ -162,6 +162,50 @@ class Recharge(BoundaryCondition, IRegridPackage):
         return errors
 
     @classmethod
+    def allocate_planar_data(
+        cls,
+        planar_data: dict[str, GridDataArray],
+        dis: StructuredDiscretization,
+        allocation_option: ALLOCATION_OPTION,
+    ) -> dict[str, GridDataArray]:
+        """
+        Allocate and distribute planar data for given discretization and npf
+        package.
+
+        Parameters
+        ----------
+        planar_data: dict[str, GridDataArray]
+            Dictionary with planar grid data.
+        dis: imod.mf6.StructuredDiscretization
+            Model discretization package.
+        npf: imod.mf6.NodePropertyFlow
+            Node property flow package.
+        allocation_option: ALLOCATION_OPTION
+            allocation option.
+        distributing_option: DISTRIBUTING_OPTION
+            distributing option.
+
+        Returns
+        -------
+        dict[str, GridDataArray]
+            Dictionary with layered grid data.
+        """
+        idomain = dis.dataset["idomain"]
+        if "layer" in planar_data["rate"].dims:
+            planar_data["rate"] = planar_data["rate"].isel(layer=0, drop=True)
+        # create an array indicating in which cells rch is active
+        is_rch_cell = allocate_rch_cells(
+            ALLOCATION_OPTION.at_first_active,
+            idomain > 0,
+            planar_data["rate"],
+        )
+        # remove rch from cells where it is not allocated and broadcast over layers.
+        layered_data = {}
+        layered_data["rate"] = planar_data["rate"].where(is_rch_cell)
+        layered_data["rate"] = enforce_dim_order(layered_data["rate"])
+        return layered_data
+
+    @classmethod
     def from_imod5_data(
         cls,
         imod5_data: dict[str, dict[str, GridDataArray]],
@@ -201,38 +245,22 @@ class Recharge(BoundaryCondition, IRegridPackage):
         data = {
             "rate": convert_unit_rch_rate(imod5_data["rch"]["rate"]),
         }
-        new_package_data = {}
-
         # first regrid the inputs to the target grid.
         if regridder_types is None:
             regridder_settings = Recharge.get_regrid_methods()
 
-        new_package_data = _regrid_package_data(
+        regridded_package_data = _regrid_package_data(
             data, new_idomain, regridder_settings, regrid_cache, {}
         )
 
         # if rate has only layer 0, then it is planar.
-        if is_planar_grid(new_package_data["rate"]):
-            if "layer" in new_package_data["rate"].dims:
-                planar_rate_regridded = new_package_data["rate"].isel(
-                    layer=0, drop=True
-                )
-            else:
-                planar_rate_regridded = new_package_data["rate"]
-
-            # create an array indicating in which cells rch is active
-            is_rch_cell = allocate_rch_cells(
-                ALLOCATION_OPTION.at_first_active,
-                new_idomain > 0,
-                planar_rate_regridded,
+        if is_planar_grid(regridded_package_data["rate"]):
+            layered_data = cls.allocate_planar_data(
+                regridded_package_data, target_dis, ALLOCATION_OPTION.at_first_active
             )
+            regridded_package_data.update(layered_data)
 
-            # remove rch from cells where it is not allocated and broadcast over layers.
-            rch_rate = planar_rate_regridded.where(is_rch_cell)
-            rch_rate = enforce_dim_order(rch_rate)
-            new_package_data["rate"] = rch_rate
-
-        return cls(**new_package_data, validate=True, fixed_cell=False)
+        return cls(**regridded_package_data, validate=True, fixed_cell=False)
 
     @classmethod
     def from_imod5_cap_data(

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -38,7 +38,7 @@ from imod.schemata import (
     OtherCoordsSchema,
 )
 from imod.typing import GridDataArray
-from imod.typing.grid import enforce_dim_order, is_planar_grid
+from imod.typing.grid import enforce_dim_order, has_negative_layer, is_planar_grid
 from imod.util.expand_repetitions import expand_repetitions
 
 
@@ -235,6 +235,15 @@ class River(BoundaryCondition, IRegridPackage):
         top = dis.dataset["top"]
         bottom = dis.dataset["bottom"]
         idomain = dis.dataset["idomain"]
+
+        if has_negative_layer(planar_data["head"]):
+            allocation_option = ALLOCATION_OPTION.at_first_active
+
+        # Enforce planar data, remove all layer dimension information
+        planar_data = {
+            key: grid.isel({"layer": 0}, drop=True, missing_dims="ignore")
+            for key, grid in planar_data.items()
+        }
 
         riv_allocation, _ = allocate_riv_cells(
             allocation_option,

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -212,7 +212,9 @@ class River(BoundaryCondition, IRegridPackage):
     ) -> dict[str, GridDataArray]:
         """
         Allocate and distribute planar data for given discretization and npf
-        package.
+        package. If layer number of ``planar_data`` is negative,
+        ``allocation_option`` is overrided and set to
+        ALLOCATION_OPTION.at_first_active.
 
         Parameters
         ----------
@@ -223,7 +225,9 @@ class River(BoundaryCondition, IRegridPackage):
         npf: imod.mf6.NodePropertyFlow
             Node property flow package.
         allocation_option: ALLOCATION_OPTION
-            allocation option.
+            allocation option. If planar data is assigned to a negative layer
+            number, this option is overridden and set to
+            ALLOCATION_OPTION.at_first_active.
         distributing_option: DISTRIBUTING_OPTION
             distributing option.
 
@@ -337,7 +341,9 @@ class River(BoundaryCondition, IRegridPackage):
         time_max: datetime
             End-time of the simulation. Used for expanding period data.
         allocation_option: ALLOCATION_OPTION
-            allocation option.
+            allocation option. If package data is assigned to a negative layer
+            number, this option is overridden and set to
+            ALLOCATION_OPTION.at_first_active.
         distributing_option: DISTRIBUTING_OPTION
             distributing option.
         regridder_types: RiverRegridMethod, optional

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -367,9 +367,7 @@ class River(BoundaryCondition, IRegridPackage):
             data, target_idomain, regridder_types, regrid_cache, {}
         )
 
-        infiltration_factor = regridded_package_data.pop(
-            "infiltration_factor"
-        )
+        infiltration_factor = regridded_package_data.pop("infiltration_factor")
 
         if is_planar:
             # allocate and distribute planar data

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -202,6 +202,91 @@ class River(BoundaryCondition, IRegridPackage):
         super().__init__(cleaned_dict)
 
     @classmethod
+    def allocate_and_distribute_planar_data(
+        cls,
+        planar_data: dict[str, GridDataArray],
+        dis: StructuredDiscretization,
+        npf: NodePropertyFlow,
+        allocation_option: ALLOCATION_OPTION,
+        distributing_option: DISTRIBUTING_OPTION,
+    ) -> dict[str, GridDataArray]:
+        """
+        Allocate and distribute planar data for given discretization and npf
+        package.
+
+        Parameters
+        ----------
+        planar_data: dict[str, GridDataArray]
+            Dictionary with planar grid data.
+        dis: imod.mf6.StructuredDiscretization
+            Model discretization package.
+        npf: imod.mf6.NodePropertyFlow
+            Node property flow package.
+        allocation_option: ALLOCATION_OPTION
+            allocation option.
+        distributing_option: DISTRIBUTING_OPTION
+            distributing option.
+
+        Returns
+        -------
+        dict[str, GridDataArray]
+            Dictionary with layered grid data.
+        """
+        top = dis.dataset["top"]
+        bottom = dis.dataset["bottom"]
+        idomain = dis.dataset["idomain"]
+
+        riv_allocation, _ = allocate_riv_cells(
+            allocation_option,
+            idomain > 0,
+            top,
+            bottom,
+            planar_data["stage"],
+            planar_data["bottom_elevation"],
+        )
+
+        layered_data = {}
+        layered_data["conductance"] = distribute_riv_conductance(
+            distributing_option,
+            riv_allocation,
+            planar_data["conductance"],
+            top,
+            bottom,
+            npf.dataset["k"],
+            planar_data["stage"],
+            planar_data["bottom_elevation"],
+        )
+
+        # create layered arrays of stage and bottom elevation
+        layered_data["stage"] = planar_data["stage"].where(riv_allocation)
+        layered_data["stage"] = enforce_dim_order(layered_data["stage"])
+        layered_data["bottom_elevation"] = planar_data["bottom_elevation"].where(
+            riv_allocation
+        )
+        layered_data["bottom_elevation"] = enforce_dim_order(
+            layered_data["bottom_elevation"]
+        )
+
+        # due to regridding, the layered_bottom_elevation could be smaller than the
+        # bottom, so here we overwrite it with bottom if that's
+        # the case.
+        layer_bottom_above_bottom_elevation = bottom > layered_data["bottom_elevation"]
+
+        if layer_bottom_above_bottom_elevation.any():
+            logging.logger.log(
+                loglevel=LogLevel.WARNING,
+                message="Note: riv bottom was detected below model bottom. Updated the riv's bottom.",
+                additional_depth=0,
+            )
+            layered_data["bottom_elevation"] = xr.where(
+                layer_bottom_above_bottom_elevation,
+                bottom,
+                layered_data["bottom_elevation"],
+            )
+
+        return layered_data
+
+    @classmethod
     def from_imod5_data(
         cls,
         key: str,
@@ -244,7 +329,7 @@ class River(BoundaryCondition, IRegridPackage):
             End-time of the simulation. Used for expanding period data.
         allocation_option: ALLOCATION_OPTION
             allocation option.
-        distributing_option: dict[str, DISTRIBUTING_OPTION]
+        distributing_option: DISTRIBUTING_OPTION
             distributing option.
         regridder_types: RiverRegridMethod, optional
             Optional dataclass with regridder types for a specific variable.
@@ -261,12 +346,7 @@ class River(BoundaryCondition, IRegridPackage):
         this can happen if the infiltration factor is 0 or 1 everywhere.
         """
 
-        logger = logging.logger
-        # gather discretrizations
-        target_top = target_dis.dataset["top"]
-        target_bottom = target_dis.dataset["bottom"]
         target_idomain = target_dis.dataset["idomain"]
-        target_k = target_npf.dataset["k"]
 
         # gather input data
         data = {
@@ -277,7 +357,7 @@ class River(BoundaryCondition, IRegridPackage):
                 deep=True
             ),
         }
-        is_planar_conductance = is_planar_grid(data["conductance"])
+        is_planar = is_planar_grid(data["conductance"])
 
         # set up regridder methods
         if regridder_types is None:
@@ -287,57 +367,20 @@ class River(BoundaryCondition, IRegridPackage):
             data, target_idomain, regridder_types, regrid_cache, {}
         )
 
-        conductance = regridded_package_data["conductance"]
-        infiltration_factor = regridded_package_data["infiltration_factor"]
+        infiltration_factor = regridded_package_data.pop(
+            "infiltration_factor"
+        )
 
-        if is_planar_conductance:
-            riv_allocation = allocate_riv_cells(
+        if is_planar:
+            # allocate and distribute planar data
+            layered_data = cls.allocate_and_distribute_planar_data(
+                regridded_package_data,
+                target_dis,
+                target_npf,
                 allocation_option,
-                target_idomain == 1,
-                target_top,
-                target_bottom,
-                regridded_package_data["stage"],
-                regridded_package_data["bottom_elevation"],
-            )
-
-            regridded_package_data["conductance"] = distribute_riv_conductance(
                 distributing_option,
-                riv_allocation[0],
-                conductance,
-                target_top,
-                target_bottom,
-                target_k,
-                regridded_package_data["stage"],
-                regridded_package_data["bottom_elevation"],
             )
-
-            # create layered arrays of stage and bottom elevation
-            layered_stage = regridded_package_data["stage"].where(riv_allocation[0])
-            layered_stage = enforce_dim_order(layered_stage)
-            regridded_package_data["stage"] = layered_stage
-
-            layered_bottom_elevation = regridded_package_data["bottom_elevation"].where(
-                riv_allocation[0]
-            )
-            layered_bottom_elevation = enforce_dim_order(layered_bottom_elevation)
-
-            # due to regridding, the layered_bottom_elevation could be smaller than the
-            # bottom, so here we overwrite it with bottom if that's
-            # the case.
-
-            if np.any((target_bottom > layered_bottom_elevation).values[()]):
-                logger.log(
-                    loglevel=LogLevel.WARNING,
-                    message="Note: riv bottom was detected below model bottom. Updated the riv's bottom.",
-                    additional_depth=0,
-                )
-            layered_bottom_elevation = xr.where(
-                target_bottom > layered_bottom_elevation,
-                target_bottom,
-                layered_bottom_elevation,
-            )
-
-            regridded_package_data["bottom_elevation"] = layered_bottom_elevation
+            regridded_package_data.update(layered_data)
 
         # update the conductance of the river package to account for the infiltration
         # factor
@@ -345,7 +388,6 @@ class River(BoundaryCondition, IRegridPackage):
             regridded_package_data["conductance"], infiltration_factor
         )
         regridded_package_data["conductance"] = river_conductance
-        regridded_package_data.pop("infiltration_factor")
         regridded_package_data["bottom_elevation"] = enforce_dim_order(
             regridded_package_data["bottom_elevation"]
         )

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -236,7 +236,7 @@ class River(BoundaryCondition, IRegridPackage):
         bottom = dis.dataset["bottom"]
         idomain = dis.dataset["idomain"]
 
-        if has_negative_layer(planar_data["head"]):
+        if has_negative_layer(planar_data["stage"]):
             allocation_option = ALLOCATION_OPTION.at_first_active
 
         # Enforce planar data, remove all layer dimension information
@@ -388,6 +388,9 @@ class River(BoundaryCondition, IRegridPackage):
                 distributing_option,
             )
             regridded_package_data.update(layered_data)
+            infiltration_factor = infiltration_factor.isel(
+                {"layer": 0}, drop=True, missing_dims="ignore"
+            )
 
         # update the conductance of the river package to account for the infiltration
         # factor

--- a/imod/tests/test_mf6/test_mf6_rch.py
+++ b/imod/tests/test_mf6/test_mf6_rch.py
@@ -335,7 +335,7 @@ def test_planar_rch_from_imod5_constant(imod5_dataset, tmp_path):
     target_discretization = StructuredDiscretization.from_imod5_data(data)
 
     # create a planar grid with time-independent recharge
-    data["rch"]["rate"]["layer"].values[0] = 0
+    data["rch"]["rate"]["layer"].values[0] = -1
     assert not is_transient_data_grid(data["rch"]["rate"])
     assert is_planar_grid(data["rch"]["rate"])
 
@@ -364,8 +364,8 @@ def test_planar_rch_from_imod5_transient(imod5_dataset, tmp_path):
     input_recharge = data["rch"]["rate"].copy(deep=True)
     input_recharge = input_recharge.expand_dims({"time": [0, 1, 2]})
 
-    # make it planar by setting the layer coordinate to 0
-    input_recharge = input_recharge.assign_coords({"layer": [0]})
+    # make it planar by setting the layer coordinate to -1
+    input_recharge = input_recharge.assign_coords({"layer": [-1]})
 
     # update the data set
     data["rch"]["rate"] = input_recharge
@@ -397,7 +397,7 @@ def test_non_planar_rch_from_imod5_constant(imod5_dataset, tmp_path):
 
     # the input for recharge is on the second layer of the targetgrid
     original_rch = data["rch"]["rate"].copy(deep=True)
-    data["rch"]["rate"] = data["rch"]["rate"].assign_coords({"layer": [0]})
+    data["rch"]["rate"] = data["rch"]["rate"].assign_coords({"layer": [-1]})
     input_recharge = nan_like(data["khv"]["kh"])
     input_recharge.loc[{"layer": 2}] = data["rch"]["rate"].isel(layer=0)
 

--- a/imod/tests/test_typing/test_typing_grid.py
+++ b/imod/tests/test_typing/test_typing_grid.py
@@ -7,6 +7,7 @@ from imod.typing.grid import (
     GridCache,
     as_ugrid_dataarray,
     enforce_dim_order,
+    has_negative_layer,
     is_planar_grid,
     is_spatial_grid,
     is_transient_data_grid,
@@ -100,6 +101,27 @@ def test_is_planar_grid(basic_dis, basic_unstructured_dis):
         # set layer coordinates as present and -1
         bottom_layer.coords["layer"].values[0] = -1
         assert is_planar_grid(bottom_layer)
+
+
+def test_has_negative_layer(basic_dis, basic_unstructured_dis):
+    discretizations = [basic_dis, basic_unstructured_dis]
+    for discr in discretizations:
+        ibound, _, _ = discr
+
+        # layer coordinates is present
+        assert not has_negative_layer(ibound)
+
+        # set layer coordinates as present but empty
+        bottom_layer = ibound.sel(layer=3)
+        assert not has_negative_layer(bottom_layer)
+
+        # set layer coordinates as present and not empty or -1
+        bottom_layer = bottom_layer.expand_dims({"layer": [9]})
+        assert not has_negative_layer(bottom_layer)
+
+        # set layer coordinates as present and -1
+        bottom_layer.coords["layer"].values[0] = -1
+        assert has_negative_layer(bottom_layer)
 
 
 def test_is_spatial_grid__structured(basic_dis):

--- a/imod/tests/test_typing/test_typing_grid.py
+++ b/imod/tests/test_typing/test_typing_grid.py
@@ -89,12 +89,16 @@ def test_is_planar_grid(basic_dis, basic_unstructured_dis):
         bottom_layer = ibound.sel(layer=3)
         assert is_planar_grid(bottom_layer)
 
-        # set layer coordinates as  present and not  empty or 0
+        # set layer coordinates as present and not empty or 0
         bottom_layer = bottom_layer.expand_dims({"layer": [9]})
         assert not is_planar_grid(bottom_layer)
 
-        # set layer coordinates as  present and   0
+        # set layer coordinates as present and 0
         bottom_layer.coords["layer"].values[0] = 0
+        assert is_planar_grid(bottom_layer)
+
+        # set layer coordinates as present and -1
+        bottom_layer.coords["layer"].values[0] = -1
         assert is_planar_grid(bottom_layer)
 
 

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -435,6 +435,20 @@ def is_planar_grid(
     return False
 
 
+def has_negative_layer(
+    grid: xr.DataArray | xr.Dataset | xu.UgridDataArray | xu.UgridDataset,
+) -> bool:
+    if not is_spatial_grid(grid):
+        return False
+    if "layer" not in grid.coords:
+        return False
+    if grid["layer"].shape == ():
+        return False
+    if grid["layer"][0] < 0:
+        return True
+    return False
+
+
 def is_transient_data_grid(
     grid: xr.DataArray | xr.Dataset | xu.UgridDataArray | xu.UgridDataset,
 ):

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -430,7 +430,7 @@ def is_planar_grid(
         return True
     if grid["layer"].shape == ():
         return True
-    if grid["layer"][0] == 0 and len(grid["layer"]) == 1:
+    if grid["layer"][0] <= 0 and len(grid["layer"]) == 1:
         return True
     return False
 

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -421,9 +421,11 @@ def is_empty(object: object) -> bool:  # noqa: F811
 def is_planar_grid(
     grid: xr.DataArray | xr.Dataset | xu.UgridDataArray | xu.UgridDataset,
 ) -> bool:
-    # Returns True if the grid is planar. It has then a layer coordinate with
-    # length 1 and value 0, or an empty layer coordinate axis, or no layer coordinate at all
-    # and it should have either x, y coordinates or cellface/edge coordinates.
+    # Returns True if the grid is planar.
+    # A grid is considered planar when:
+    # - it is a spatial grid (x, y coordinates or cellface/edge coordinates)
+    # - it has no layer coordinates, or, it has a single layer coordinate with
+    #   value less or equal to zero
     if not is_spatial_grid(grid):
         return False
     if "layer" not in grid.coords:


### PR DESCRIPTION
Fixes #1177

# Description
iMOD5 assigns grids with negative layer numbers in the projectfile to the first active cells.
This PR allows iMOD Python to do the same.

PR implements/changes the following:
- Add utility function ``has_negative_layer`` to check for negative layer number.
- ``is_planar_grid`` now also returns true for negative layer number.
- Assign negative and zero layer number to layer coordinate in ``open_projectfile_data`` instead of dropping them.
- Move all logic to deal with planar data to separate classmethod in ``River.from_imod5_data``, ``Drainage.from_imod5_data``, ``Recharge.from_imod5_data``, ``GeneralHeadBoundary.from_imod5_data``. Could be used for generalization, suggested here https://github.com/Deltares/imod-python/issues/994
- If grid provided with negative layer coord, assign to to first active cell in ``River.from_imod5_data``, ``Drainage.from_imod5_data``, ``Recharge.from_imod5_data``, ``GeneralHeadBoundary.from_imod5_data``

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
