### PR TITLE
Issue #1379 clip wel timeseries before resampling

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -28,6 +28,12 @@ Changed
   consistent with MODFLOW6. Previously this could only be indicated with 1 and
   -1.
 
+Fixed
+~~~~~
+
+- :meth:`imod.mf6.Well.from_imod5_data` and
+  :meth:`imod.mf6.LayeredWell.from_imod5_data` ignore well rates preceding first
+  element of ``times``.
 
 [1.0.0rc1] - 2024-12-20
 -----------------------

--- a/imod/tests/test_mf6/test_utilities/test_resampling.py
+++ b/imod/tests/test_mf6/test_utilities/test_resampling.py
@@ -101,6 +101,28 @@ def test_timeseries_resampling_4():
     )
 
 
+def test_timeseries_resampling_5():
+    # In this test, we resample a timeseries to a finer output discretization.
+    # The original times have several preceding timesteps, which need to be
+    # clipped off.
+    original_times = [datetime(1899, 1, 1), datetime(1909, 1, 1)] + [
+        datetime(1989, 1, i) for i in [1, 3, 5, 7, 9]
+    ]
+    original_rates = [0.0, 0.0, 200.0, 200.0, 300.0, 400.0, 500.0]
+    original_timeseries = initialize_timeseries(original_times, original_rates)
+
+    new_dates = [datetime(1989, 1, 2), datetime(1989, 1, 3), datetime(1989, 1, 4)]
+    new_timeseries = resample_timeseries(original_timeseries, new_dates)
+
+    expected_times = [datetime(1989, 1, 2), datetime(1989, 1, 3), datetime(1989, 1, 4)]
+    expected_rates = [200.0, 200.0, 200.0]
+    expected_timeseries = initialize_timeseries(expected_times, expected_rates)
+
+    pd.testing.assert_frame_equal(
+        new_timeseries, expected_timeseries, check_dtype=False
+    )
+
+
 def test_timeseries_resampling_coarsen_and_refine():
     # In this test, we resample a timeseries for a coarser output discretization.
     # Then we refine it again to the original discretization.

--- a/imod/util/expand_repetitions.py
+++ b/imod/util/expand_repetitions.py
@@ -56,7 +56,7 @@ def resample_timeseries(
     Parameters
     ----------
     well_rate:  pd.DataFrame
-        input timeseries for well
+        input timeseries for a single well
     times: datetime
         list of times on which the output dataframe should have entries.
 
@@ -75,6 +75,13 @@ def resample_timeseries(
         on="time",
         validate="m:m",
     ).fillna(method="ffill")
+    # Catch case where multiple well rates precede first timestep on multiple
+    # occasions, these have to be clipped to avoid including them in the
+    # computation of weighted averages later in the function. We only want to
+    # include one well timestep before the first output timestep at maximum.
+    n_before_first_timestep = (intermediate_df["time"] < times[0]).cumsum()
+    to_preserve = n_before_first_timestep == n_before_first_timestep.max()
+    intermediate_df = intermediate_df[to_preserve]
 
     # The entries before the start of the well timeseries do not have data yet,
     # so we fill them in here. Keep rate to zero and pad the location columns with

--- a/imod/util/expand_repetitions.py
+++ b/imod/util/expand_repetitions.py
@@ -78,7 +78,7 @@ def resample_timeseries(
     # Catch case where multiple well rates precede first timestep on multiple
     # occasions, these have to be clipped to avoid including them in the
     # computation of weighted averages later in the function. We only want to
-    # include one well timestep before the first output timestep at maximum.
+    # include the last well timestep BEFORE the first output timestep.
     n_before_first_timestep = (intermediate_df["time"] < times[0]).cumsum()
     to_preserve = n_before_first_timestep == n_before_first_timestep.max()
     intermediate_df = intermediate_df[to_preserve]


### PR DESCRIPTION
Fixes #1379

# Description
Fix bug in ``resample_timeseries`` where all timesteps in the iMOD5 well database preceding simulation ``times`` were included in the time weighted averaging of the first timestep. Only the last timestep preceding ``times`` should be included, the rest should be ignored/discarded.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
