### PR TITLE
Issue #1381 average well rates at steady state

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -27,6 +27,10 @@ Changed
   > 0 to indicate an active cell and <0 to indicate a vertical passthrough cell,
   consistent with MODFLOW6. Previously this could only be indicated with 1 and
   -1.
+- :meth:`imod.mf6.Well.from_imod5_data` and
+  :meth:`imod.mf6.LayeredWell.from_imod5_data` upon receiving ``len(times) <=
+  2``, the simulation is assumed to be "steady-state" and well timeseries are
+  averaged.
 
 Fixed
 ~~~~~

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -28,9 +28,9 @@ Changed
   consistent with MODFLOW6. Previously this could only be indicated with 1 and
   -1.
 - :meth:`imod.mf6.Well.from_imod5_data` and
-  :meth:`imod.mf6.LayeredWell.from_imod5_data` upon receiving ``len(times) <=
-  2``, the simulation is assumed to be "steady-state" and well timeseries are
-  averaged.
+  :meth:`imod.mf6.LayeredWell.from_imod5_data` now also accept the argument
+  ``times = "steady-state"``, for the simulation is assumed to be "steady-state"
+  and well timeseries are averaged.
 
 Fixed
 ~~~~~

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -271,8 +271,8 @@ class GroundwaterFlowModel(Modflow6Model):
         result["npf"] = npf_pkg
 
         # import sto
-        transient = "sto" in imod5_data.keys()
-        if transient:
+        is_transient = "sto" in imod5_data.keys()
+        if is_transient:
             result["sto"] = StorageCoefficient.from_imod5_data(
                 imod5_data,
                 grid,
@@ -309,10 +309,7 @@ class GroundwaterFlowModel(Modflow6Model):
         imod5_keys = list(imod5_data.keys())
 
         # import wells
-        if transient:
-            wel_times: StressPeriodTimesType = times
-        else:
-            wel_times = "steady-state"
+        wel_times: StressPeriodTimesType = times if is_transient else "steady-state"
         wel_keys = [key for key in imod5_keys if key[0:3] == "wel"]
         for wel_key in wel_keys:
             wel_key_truncated = wel_key[:16]
@@ -327,15 +324,15 @@ class GroundwaterFlowModel(Modflow6Model):
                     """
                 )
                 raise KeyError(msg)
-            layer = np.array(imod5_data[wel_key]["layer"])
-            if np.any(layer == 0):
-                result[wel_key_truncated] = Well.from_imod5_data(
-                    wel_key, imod5_data, wel_times
-                )
-            else:
-                result[wel_key_truncated] = LayeredWell.from_imod5_data(
-                    wel_key, imod5_data, wel_times
-                )
+
+            wel_layer = imod5_data[wel_key]["layer"].values
+            is_allocated = np.any(wel_layer == 0)
+            wel_args = (wel_key, imod5_data, wel_times)
+            result[wel_key_truncated] = (
+                Well.from_imod5_data(*wel_args)
+                if is_allocated
+                else LayeredWell.from_imod5_data(*wel_args)
+            )
 
         if "cap" in imod5_keys:
             result["msw-sprinkling"] = LayeredWell.from_imod5_cap_data(imod5_data)  # type: ignore

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -40,7 +40,7 @@ from imod.prepare.topsystem.default_allocation_methods import (
     SimulationAllocationOptions,
     SimulationDistributingOptions,
 )
-from imod.typing import GridDataArray
+from imod.typing import GridDataArray, StressPeriodTimesType
 from imod.typing.grid import zeros_like
 
 
@@ -310,7 +310,7 @@ class GroundwaterFlowModel(Modflow6Model):
 
         # import wells
         if steady_state:
-            wel_times = "steady-state"
+            wel_times: StressPeriodTimesType = "steady-state"
         else:
             wel_times = times
         wel_keys = [key for key in imod5_keys if key[0:3] == "wel"]

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -325,7 +325,7 @@ class GroundwaterFlowModel(Modflow6Model):
                 )
                 raise KeyError(msg)
 
-            wel_layer = imod5_data[wel_key]["layer"].values
+            wel_layer = np.array(imod5_data[wel_key]["layer"])
             is_allocated = np.any(wel_layer == 0)
             wel_args = (wel_key, imod5_data, wel_times)
             result[wel_key_truncated] = (

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -271,8 +271,8 @@ class GroundwaterFlowModel(Modflow6Model):
         result["npf"] = npf_pkg
 
         # import sto
-        steady_state = "sto" in imod5_data.keys()
-        if steady_state:
+        transient = "sto" in imod5_data.keys()
+        if transient:
             result["sto"] = StorageCoefficient.from_imod5_data(
                 imod5_data,
                 grid,
@@ -309,10 +309,10 @@ class GroundwaterFlowModel(Modflow6Model):
         imod5_keys = list(imod5_data.keys())
 
         # import wells
-        if steady_state:
-            wel_times: StressPeriodTimesType = "steady-state"
+        if transient:
+            wel_times: StressPeriodTimesType = times
         else:
-            wel_times = times
+            wel_times = "steady-state"
         wel_keys = [key for key in imod5_keys if key[0:3] == "wel"]
         for wel_key in wel_keys:
             wel_key_truncated = wel_key[:16]

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -271,7 +271,8 @@ class GroundwaterFlowModel(Modflow6Model):
         result["npf"] = npf_pkg
 
         # import sto
-        if "sto" in imod5_data.keys():
+        steady_state = "sto" in imod5_data.keys()
+        if steady_state:
             result["sto"] = StorageCoefficient.from_imod5_data(
                 imod5_data,
                 grid,
@@ -308,6 +309,10 @@ class GroundwaterFlowModel(Modflow6Model):
         imod5_keys = list(imod5_data.keys())
 
         # import wells
+        if steady_state:
+            wel_times = "steady-state"
+        else:
+            wel_times = times
         wel_keys = [key for key in imod5_keys if key[0:3] == "wel"]
         for wel_key in wel_keys:
             wel_key_truncated = wel_key[:16]
@@ -325,11 +330,11 @@ class GroundwaterFlowModel(Modflow6Model):
             layer = np.array(imod5_data[wel_key]["layer"])
             if np.any(layer == 0):
                 result[wel_key_truncated] = Well.from_imod5_data(
-                    wel_key, imod5_data, times
+                    wel_key, imod5_data, wel_times
                 )
             else:
                 result[wel_key_truncated] = LayeredWell.from_imod5_data(
-                    wel_key, imod5_data, times
+                    wel_key, imod5_data, wel_times
                 )
 
         if "cap" in imod5_keys:

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -133,7 +133,7 @@ def _process_timeseries(df_group, start_times):
 
 
 def _prepare_df_ipf_associated(
-    pkg_data: dict, start_times: list[datetime], all_well_times: list[datetime]
+    pkg_data: dict, all_well_times: list[datetime]
 ) -> pd.DataFrame:
     """Prepare dataframe for an ipf with associated timeseries in a textfile."""
     # Validate if associated wells are assigned multiple layers, factors,
@@ -210,7 +210,7 @@ def _unpack_package_data(
     start_times = times[:-1]  # Starts stress periods.
     has_associated = pkg_data["has_associated"]
     if has_associated:
-        return _prepare_df_ipf_associated(pkg_data, start_times, all_well_times)
+        return _prepare_df_ipf_associated(pkg_data, all_well_times)
     else:
         return _prepare_df_ipf_unassociated(pkg_data, start_times)
 

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -578,10 +578,13 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
             * Multiplication and addition factors need to remain constant through time
             * Same associated well cannot be assigned to multiple layers
         - The dataframe of the first projectfile timestamp is selected
-        - Rate timeseries are resampled with a time weighted mean to the
-          simulation times.
-        - When simulation times fall outside well timeseries range, the last
-          rate is forward filled.
+        - Timeseries are processed as follows:
+            * If ``len(times) > 2``, rate timeseries are resampled with a time
+              weighted mean to the simulation times. When simulation times fall
+              outside well timeseries range, the last rate is forward filled.
+            * If ``len(times) == 2``, the simulation is assumed to be
+              "steady-state" and an average rate is computed from the
+              timeseries.
         - Projectfile timestamps are not used. Even if assigned to a
           "steady-state" timestamp, the resulting dataset still uses simulation
           times.

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -300,10 +300,14 @@ def _times_is_steady_state(times: list[datetime] | Literal["steady-state"]) -> b
     return isinstance(times, str) and times == "steady-state"
 
 
-def _get_starttimes(times: list[datetime] | Literal["steady-state"]) -> list[datetime] | Literal["steady-state"]:
+def _get_starttimes(
+    times: list[datetime] | Literal["steady-state"],
+) -> list[datetime] | Literal["steady-state"]:
     if _times_is_steady_state(times):
         return times
-    elif hasattr(times, '__iter__') and isinstance(times[0], (datetime, np.datetime64, pd.Timestamp)):
+    elif hasattr(times, "__iter__") and isinstance(
+        times[0], (datetime, np.datetime64, pd.Timestamp)
+    ):
         return times[:-1]
     else:
         raise ValueError(
@@ -663,7 +667,7 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
         pkg_data = imod5_data[key]
         all_well_times = get_all_imod5_prj_well_times(imod5_data)
 
-        start_times = _get_starttimes(times) # Starts stress periods.
+        start_times = _get_starttimes(times)  # Starts stress periods.
         df = _unpack_package_data(pkg_data, start_times, all_well_times)
         cls._validate_imod5_depth_information(key, pkg_data, df)
 

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -47,7 +47,7 @@ from imod.schemata import (
 from imod.select.points import points_indices, points_values
 from imod.typing import GridDataArray, Imod5DataDict
 from imod.typing.grid import is_spatial_grid, ones_like
-from imod.util.expand_repetitions import resample_timeseries
+from imod.util.expand_repetitions import average_timeseries, resample_timeseries
 from imod.util.structured import values_within_range
 
 ABSTRACT_METH_ERROR_MSG = "Method in abstract base class called"
@@ -119,10 +119,17 @@ def _prepare_well_rates_from_groups(
     if has_associated:
         # Resample times per group
         unique_well_groups = [
-            resample_timeseries(df_group, start_times)
+            _process_timeseries(df_group, start_times)
             for df_group in unique_well_groups
         ]
     return _df_groups_to_da_rates(unique_well_groups)
+
+
+def _process_timeseries(df_group, start_times):
+    if len(start_times) > 1:
+        return resample_timeseries(df_group, start_times)
+    else:
+        return average_timeseries(df_group)
 
 
 def _prepare_df_ipf_associated(

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -655,6 +655,38 @@ def test_import_from_imod5__correct_well_type(imod5_dataset):
 
 @pytest.mark.unittest_jit
 @pytest.mark.usefixtures("imod5_dataset")
+def test_import_from_imod5__well_steady_state(imod5_dataset):
+    # Unpack
+    imod5_data = imod5_dataset[0]
+    period_data = imod5_dataset[1]
+
+    sto = imod5_data.pop("sto")
+
+    # Other arrangement
+    default_simulation_allocation_options = SimulationAllocationOptions
+    default_simulation_distributing_options = SimulationDistributingOptions
+    datelist = pd.date_range(start="1/1/1989", end="1/1/2013", freq="W")
+
+    # Act
+    simulation = Modflow6Simulation.from_imod5_data(
+        imod5_data,
+        period_data,
+        datelist,
+        default_simulation_allocation_options,
+        default_simulation_distributing_options,
+    )
+    # Assert
+    gwf = simulation["imported_model"]
+    assert "time" not in gwf["wel-WELLS_L3"].dataset.coords
+    assert "time" not in gwf["wel-WELLS_L4"].dataset.coords
+    assert "time" not in gwf["wel-WELLS_L5"].dataset.coords
+    # Teardown
+    # Reassign storage package again
+    imod5_data["sto"] = sto
+
+
+@pytest.mark.unittest_jit
+@pytest.mark.usefixtures("imod5_dataset")
 def test_import_from_imod5__nonstandard_regridding(imod5_dataset, tmp_path):
     imod5_data = imod5_dataset[0]
     period_data = imod5_dataset[1]

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -1019,6 +1019,19 @@ def test_import_and_convert_to_mf6(imod5_dataset, tmp_path, wel_class):
     mf6_well._write("wel", [], write_context)
 
 
+@parametrize("wel_class", [Well, LayeredWell])
+@pytest.mark.usefixtures("imod5_dataset")
+def test_import__as_steady_state(imod5_dataset, wel_class):
+    data = imod5_dataset[0]
+    times = "steady-state"
+    # Import grid-agnostic well from imod5 data (it contains 1 well)
+    wel = wel_class.from_imod5_data("wel-WELLS_L3", data, times)
+
+    assert "time" not in wel.dataset.coords
+    assert wel.dataset["rate"].shape == (1,)
+    np.testing.assert_almost_equal(wel.dataset["rate"].values, -323.89361702)
+
+
 @parametrize("wel_class", [Well])
 @pytest.mark.usefixtures("imod5_dataset")
 def test_import_and_cleanup(imod5_dataset, wel_class: Well):

--- a/imod/tests/test_mf6/test_utilities/test_resampling.py
+++ b/imod/tests/test_mf6/test_utilities/test_resampling.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pandas as pd
 
-from imod.util.expand_repetitions import resample_timeseries
+from imod.util.expand_repetitions import average_timeseries, resample_timeseries
 
 
 def initialize_timeseries(times: list[datetime], rates: list[float]) -> pd.DataFrame:
@@ -159,4 +159,23 @@ def test_timeseries_resampling_refine_and_coarsen():
 
     pd.testing.assert_frame_equal(
         original_timeseries, re_coarsened_timeseries, check_dtype=False
+    )
+
+
+def test_mean_timeseries():
+    # In this test, we compute the mean of a timeseries.
+    times = [datetime(1989, 1, i) for i in [1, 3, 4, 5, 6]]
+    rates = [i * 100 for i in range(1, 6)]
+    timeseries = initialize_timeseries(times, rates)
+
+    mean_timeseries = average_timeseries(timeseries)
+
+    dummy_times = [datetime(1989, 1, 1)]
+    expected_rates = [300.0]
+    expected_timeseries = initialize_timeseries(dummy_times, expected_rates)
+    col_order = ["x", "y", "id", "filt_top", "filt_bot", "rate"]
+    expected_timeseries = expected_timeseries[col_order]
+
+    pd.testing.assert_frame_equal(
+        mean_timeseries, expected_timeseries, check_dtype=False
     )

--- a/imod/tests/test_mf6/test_utilities/test_resampling.py
+++ b/imod/tests/test_mf6/test_utilities/test_resampling.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import numpy as np
 import pandas as pd
 
 from imod.util.expand_repetitions import average_timeseries, resample_timeseries
@@ -171,7 +172,7 @@ def test_mean_timeseries():
     mean_timeseries = average_timeseries(timeseries)
 
     dummy_times = [datetime(1989, 1, 1)]
-    expected_rates = [300.0]
+    expected_rates = np.mean(rates)
     expected_timeseries = initialize_timeseries(dummy_times, expected_rates)
     col_order = ["x", "y", "id", "filt_top", "filt_bot", "rate"]
     expected_timeseries = expected_timeseries[col_order]

--- a/imod/typing/__init__.py
+++ b/imod/typing/__init__.py
@@ -2,6 +2,7 @@
 Module to define type aliases.
 """
 
+from datetime import datetime
 from typing import TYPE_CHECKING, Literal, TypeAlias, TypedDict, TypeVar, Union
 
 import numpy as np
@@ -17,6 +18,7 @@ ScalarAsDataset: TypeAlias = Union[xr.Dataset, xu.UgridDataset]
 UnstructuredData: TypeAlias = Union[xu.UgridDataset, xu.UgridDataArray]
 FloatArray: TypeAlias = NDArray[np.floating]
 IntArray: TypeAlias = NDArray[np.int_]
+StressPeriodTimesType: TypeAlias = list[datetime] | Literal["steady-state"]
 
 
 class SelSettingsType(TypedDict, total=False):

--- a/imod/util/expand_repetitions.py
+++ b/imod/util/expand_repetitions.py
@@ -44,6 +44,24 @@ def expand_repetitions(
     return expanded
 
 
+def average_timeseries(well_rate: pd.DataFrame) -> pd.DataFrame:
+    """
+    Compute the mean value of the timeseries for a single well. Time column is
+    dropped.
+
+    Parameters
+    ----------
+    well_rate:  pd.DataFrame
+        input timeseries for a single well
+    """
+    # Take first item
+    output_frame = well_rate.iloc[[0]].drop(columns=["time", "rate"])
+    # Compute mean
+    col_index = output_frame.shape[1]
+    output_frame.insert(col_index, "rate", well_rate["rate"].mean())
+    return output_frame
+
+
 def resample_timeseries(
     well_rate: pd.DataFrame, times: list[datetime] | pd.DatetimeIndex
 ) -> pd.DataFrame:
@@ -98,7 +116,8 @@ def resample_timeseries(
 
     # compute time difference from perious to current row
     time_diff_col = intermediate_df["time"].diff()
-    intermediate_df.insert(7, "time_to_next", time_diff_col.values)
+    col_index = intermediate_df.shape[1] - 1
+    intermediate_df.insert(col_index, "time_to_next", time_diff_col.values)
 
     # shift the new column 1 place down so that they become the time to the next row
     intermediate_df["time_to_next"] = intermediate_df["time_to_next"].shift(-1)


### PR DESCRIPTION
Fixes #1381

# Description

Upon receiving simulation ``times`` with string "steady-state"
``Well.from_imod5_data`` now assumes the simulation is steady-state and well rates should be averaged. 
This brings well rates of packages a lot closer to what iMOD5 produces in the water balance for steady-state simulations.
``GroundwaterFlowModel.from_imod5_data`` sets ``times`` arg for ``Well.from_imod5_data`` to ``"steady-state"`` if no Storage package is present in the projectfile.

I opted for this for now as we currently lack of a clear API to construct steady-state simulations. See also #1308.


# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
