### PR TITLE
Issue #1383 Add support for ``ALLOCATION_OPTION.stage_to_riv_bot_drn_above`` in ``River.from_imod5_data``.

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -27,6 +27,11 @@ Changed
   > 0 to indicate an active cell and <0 to indicate a vertical passthrough cell,
   consistent with MODFLOW6. Previously this could only be indicated with 1 and
   -1.
+- The ``riv`` attribute of :class:`imod.prepare.SimulationAllocationOptions` has
+  the ``stage_to_riv_bot_drn_above`` of :func:`imod.prepare.ALLOCATION_OPTION`
+  now set as default. This means by default drainage cells are placed from the
+  first active cell to the river stage level when allocating rivers in
+  :meth:`imod.mf6.Simulation.from_imod5_data`.
 
 Fixed
 ~~~~~
@@ -34,6 +39,9 @@ Fixed
 - :meth:`imod.mf6.Well.from_imod5_data` and
   :meth:`imod.mf6.LayeredWell.from_imod5_data` ignore well rates preceding first
   element of ``times``.
+- :meth:`imod.mf6.River.from_imod5_data` now preserves the drainage cells
+  created with the ``stage_to_riv_bot_drn_above`` option of
+  :func:`imod.prepare.ALLOCATION_OPTION`.
 
 [1.0.0rc1] - 2024-12-20
 -----------------------

--- a/docs/api/prepare.rst
+++ b/docs/api/prepare.rst
@@ -49,6 +49,7 @@ Prepare model input
     distribute_drn_conductance
     distribute_ghb_conductance
     distribute_riv_conductance
+    split_conductance_with_infiltration_factor
 
     cleanup_drn
     cleanup_ghb

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -331,7 +331,7 @@ class River(BoundaryCondition, IRegridPackage):
             npf.dataset["k"],
         )
         riv_distribute_grids = (planar_data["stage"], planar_data["bottom_elevation"])
-        drn_distribute_grids = planar_data["bottom_elevation"]
+        drn_distribute_grids = (planar_data["bottom_elevation"],)
         bc_distribute_grids = (
             drn_distribute_grids
             if (drn_allocated is not None)

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from imod import logging
 from imod.logging import init_log_decorator, standard_log_decorator
-from imod.logging.loglevel import LogLevel
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.disv import VerticesDiscretization
@@ -474,9 +473,7 @@ class River(BoundaryCondition, IRegridPackage):
         """
         # gather input data
         varnames = ["conductance", "stage", "bottom_elevation", "infiltration_factor"]
-        data = {
-            varname: imod5_data[key][varname] for varname in varnames
-        }
+        data = {varname: imod5_data[key][varname] for varname in varnames}
         # Regrid the input data
         regridded_riv_pkg_data = regrid_imod5_pkg_data(
             River, data, target_dis, regridder_types, regrid_cache

--- a/imod/prepare/__init__.py
+++ b/imod/prepare/__init__.py
@@ -54,6 +54,7 @@ from imod.prepare.topsystem import (
     distribute_drn_conductance,
     distribute_ghb_conductance,
     distribute_riv_conductance,
+    split_conductance_with_infiltration_factor,
 )
 from imod.prepare.voxelize import Voxelizer
 from imod.prepare.wells import assign_wells

--- a/imod/prepare/topsystem/__init__.py
+++ b/imod/prepare/topsystem/__init__.py
@@ -10,6 +10,7 @@ from imod.prepare.topsystem.conductance import (
     distribute_drn_conductance,
     distribute_ghb_conductance,
     distribute_riv_conductance,
+    split_conductance_with_infiltration_factor,
 )
 from imod.prepare.topsystem.default_allocation_methods import (
     SimulationAllocationOptions,

--- a/imod/prepare/topsystem/default_allocation_methods.py
+++ b/imod/prepare/topsystem/default_allocation_methods.py
@@ -18,7 +18,7 @@ class SimulationAllocationOptions:
         ``first_active_to_elevation``.
     riv: ALLOCATION_OPTION
         allocation option to be used for river packages, defaults to
-        ``stage_to_riv_bot``.
+        ``stage_to_riv_bot_drn_above``.
     ghb: ALLOCATION_OPTION
         allocation option to be used for general head boundary packages,
         defaults to ``at_elevation``.

--- a/imod/prepare/topsystem/default_allocation_methods.py
+++ b/imod/prepare/topsystem/default_allocation_methods.py
@@ -38,7 +38,7 @@ class SimulationAllocationOptions:
     """
 
     drn: ALLOCATION_OPTION = ALLOCATION_OPTION.first_active_to_elevation
-    riv: ALLOCATION_OPTION = ALLOCATION_OPTION.stage_to_riv_bot
+    riv: ALLOCATION_OPTION = ALLOCATION_OPTION.stage_to_riv_bot_drn_above
     ghb: ALLOCATION_OPTION = ALLOCATION_OPTION.at_elevation
 
 

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -570,8 +570,6 @@ def compare_submodel_partition_info(first: PartitionInfo, second: PartitionInfo)
 def test_import_from_imod5(imod5_dataset, tmp_path):
     imod5_data = imod5_dataset[0]
     period_data = imod5_dataset[1]
-    default_simulation_allocation_options = SimulationAllocationOptions
-    default_simulation_distributing_options = SimulationDistributingOptions
 
     datelist = pd.date_range(start="1/1/1989", end="1/1/2013", freq="W")
 
@@ -579,8 +577,8 @@ def test_import_from_imod5(imod5_dataset, tmp_path):
         imod5_data,
         period_data,
         datelist,
-        default_simulation_allocation_options,
-        default_simulation_distributing_options,
+        SimulationAllocationOptions,
+        SimulationDistributingOptions,
     )
     simulation["imported_model"]["oc"] = OutputControl(
         save_head="last", save_budget="last"
@@ -606,8 +604,6 @@ def test_import_from_imod5(imod5_dataset, tmp_path):
 def test_from_imod5__strict_well_validation_set(imod5_dataset):
     imod5_data = imod5_dataset[0]
     period_data = imod5_dataset[1]
-    default_simulation_allocation_options = SimulationAllocationOptions
-    default_simulation_distributing_options = SimulationDistributingOptions
 
     datelist = pd.date_range(start="1/1/1989", end="1/1/1990", freq="W")
 
@@ -615,8 +611,8 @@ def test_from_imod5__strict_well_validation_set(imod5_dataset):
         imod5_data,
         period_data,
         datelist,
-        default_simulation_allocation_options,
-        default_simulation_distributing_options,
+        SimulationAllocationOptions,
+        SimulationDistributingOptions,
     )
     assert simulation._validation_context.strict_well_validation is False
     assert Modflow6Simulation("test")._validation_context.strict_well_validation is True
@@ -658,8 +654,6 @@ def test_import_from_imod5__correct_well_type(imod5_dataset):
 def test_import_from_imod5__nonstandard_regridding(imod5_dataset, tmp_path):
     imod5_data = imod5_dataset[0]
     period_data = imod5_dataset[1]
-    default_simulation_allocation_options = SimulationAllocationOptions
-    default_simulation_distributing_options = SimulationDistributingOptions
 
     regridding_option = {}
     regridding_option["npf"] = NodePropertyFlowRegridMethod()
@@ -671,8 +665,8 @@ def test_import_from_imod5__nonstandard_regridding(imod5_dataset, tmp_path):
         imod5_data,
         period_data,
         times,
-        default_simulation_allocation_options,
-        default_simulation_distributing_options,
+        SimulationAllocationOptions,
+        SimulationDistributingOptions,
         regridding_option,
     )
     simulation["imported_model"]["oc"] = OutputControl(
@@ -700,17 +694,14 @@ def test_import_from_imod5_no_storage_no_recharge(imod5_dataset, tmp_path):
     imod5_data.pop("rch")
     period_data = imod5_dataset[1]
 
-    default_simulation_allocation_options = SimulationAllocationOptions
-    default_simulation_distributing_options = SimulationDistributingOptions
-
     times = pd.date_range(start="1/1/2018", end="12/1/2018", freq="ME")
 
     simulation = Modflow6Simulation.from_imod5_data(
         imod5_data,
         period_data,
         times,
-        default_simulation_allocation_options,
-        default_simulation_distributing_options,
+        SimulationAllocationOptions,
+        SimulationDistributingOptions,
     )
     simulation["imported_model"]["oc"] = OutputControl(
         save_head="last", save_budget="last"

--- a/imod/tests/test_prepare/test_cleanup.py
+++ b/imod/tests/test_prepare/test_cleanup.py
@@ -167,7 +167,7 @@ def test_cleanup_riv__fix_bottom_elevation_to_stage(riv_data: dict, dis_data: di
 
 
 @parametrize_with_cases("riv_data, dis_data", cases=RivDisCases)
-def test_cleanup_riv__stage_equals_bottom_elevation(riv_data: dict, dis_data:dict):
+def test_cleanup_riv__stage_equals_bottom_elevation(riv_data: dict, dis_data: dict):
     """Assure no cleanup accidentily takes place when stage equals bottom_elevation"""
     dis_dict = _prepare_dis_dict(dis_data, cleanup_riv)
     # Arrange: Set bottom elevation equal to stage
@@ -180,13 +180,10 @@ def test_cleanup_riv__stage_equals_bottom_elevation(riv_data: dict, dis_data:dic
     np.testing.assert_equal(
         riv_data_cleaned["bottom_elevation"].values, riv_data_cleaned["stage"].values
     )
-    np.testing.assert_equal(
-        riv_data["stage"].values, riv_data_cleaned["stage"].values
-    )
+    np.testing.assert_equal(riv_data["stage"].values, riv_data_cleaned["stage"].values)
     np.testing.assert_equal(
         riv_data["bottom_elevation"].values, riv_data_cleaned["bottom_elevation"].values
     )
-
 
 
 @parametrize_with_cases("riv_data, dis_data", cases=RivDisCases)

--- a/imod/tests/test_prepare/test_cleanup.py
+++ b/imod/tests/test_prepare/test_cleanup.py
@@ -167,6 +167,29 @@ def test_cleanup_riv__fix_bottom_elevation_to_stage(riv_data: dict, dis_data: di
 
 
 @parametrize_with_cases("riv_data, dis_data", cases=RivDisCases)
+def test_cleanup_riv__stage_equals_bottom_elevation(riv_data: dict, dis_data:dict):
+    """Assure no cleanup accidentily takes place when stage equals bottom_elevation"""
+    dis_dict = _prepare_dis_dict(dis_data, cleanup_riv)
+    # Arrange: Set bottom elevation equal to stage
+    riv_data["bottom_elevation"] = riv_data["stage"].copy()
+    # Assure conductance not modified by previous tests.
+    np.testing.assert_equal(_first(riv_data["conductance"]), 1.0)
+    # Act
+    riv_data_cleaned = cleanup_riv(**dis_dict, **riv_data)
+    # Assert
+    np.testing.assert_equal(
+        riv_data_cleaned["bottom_elevation"].values, riv_data_cleaned["stage"].values
+    )
+    np.testing.assert_equal(
+        riv_data["stage"].values, riv_data_cleaned["stage"].values
+    )
+    np.testing.assert_equal(
+        riv_data["bottom_elevation"].values, riv_data_cleaned["bottom_elevation"].values
+    )
+
+
+
+@parametrize_with_cases("riv_data, dis_data", cases=RivDisCases)
 def test_cleanup_riv__raise_error(riv_data: dict, dis_data: dict):
     """
     Test if error raised when stage below model layer bottom and see if user is

--- a/imod/tests/test_prepare/test_topsystem.py
+++ b/imod/tests/test_prepare/test_topsystem.py
@@ -3,6 +3,7 @@ import xarray as xr
 from pytest_cases import parametrize_with_cases
 
 from imod.prepare.topsystem import (
+    ALLOCATION_OPTION,
     allocate_drn_cells,
     allocate_ghb_cells,
     allocate_rch_cells,
@@ -10,7 +11,6 @@ from imod.prepare.topsystem import (
     distribute_drn_conductance,
     distribute_ghb_conductance,
     distribute_riv_conductance,
-    ALLOCATION_OPTION
 )
 from imod.typing import GridDataArray
 from imod.typing.grid import is_unstructured, zeros_like


### PR DESCRIPTION
Fixes #1383 and #1060

It turned out the differences in #1383 were mainly caused by a lack of support of ``ALLOCATION_OPTION.stage_to_riv_bot_drn_above``, which is the default setting for iMOD5, but we didn't support it yet.
This was because we lacked some logic to do something with the extra addition Drainage package created by with this option during allocation. This PR implements the following:

- Support for ``ALLOCATION_OPTION.stage_to_riv_bot_drn_above`` in ``River.from_imod5_data``.
- Set ``ALLOCATION_OPTION.stage_to_riv_bot_drn_above`` as default allocation option for rivers
- Adapt some unittests to run with the new default option
- Add two unittests cases to ensure rivers are properly allocated and cleaned when ``stage`` equals ``bottom_elevation``. I first thought there was a bug in one of these functions, so I added this edge case. But they ran without issue! Still good to keep these tests for this edge case to ensure no mistakes creep into the code base over time.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
