### PR TITLE
Issue #1386 distribute conductance stage equals bottom elevation

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -46,6 +46,10 @@ Fixed
 - :meth:`imod.mf6.River.from_imod5_data` now preserves the drainage cells
   created with the ``stage_to_riv_bot_drn_above`` option of
   :func:`imod.prepare.ALLOCATION_OPTION`.
+- Bug in :func:`imod.prepare.distribute_riv_conductance` where conductances were
+  set to ``np.nan`` for cells where ``stage`` equals ``bottom_elevation`` when
+  :func:`imod.prepare.DISTRIBUTING_OPTION` was set to ``by_crosscut_thickness``,
+  ``by_crosscut_transmissivity``, ``by_corrected_transmissivity``.
 
 [1.0.0rc1] - 2024-12-20
 -----------------------

--- a/imod/prepare/topsystem/conductance.py
+++ b/imod/prepare/topsystem/conductance.py
@@ -347,7 +347,8 @@ def _compute_crosscut_thickness(
         raise ValueError("`bc_top` and `bc_bottom` cannot both be None.")
 
     top_layered = _enforce_layered_top(top, bottom)
-    thickness = _compute_layer_thickness(allocated, top, bottom)
+    layer_thickness = _compute_layer_thickness(allocated, top, bottom)
+    thickness = layer_thickness.copy()
     outside = zeros_like(allocated).astype(bool)
 
     if bc_top is not None:
@@ -368,6 +369,11 @@ def _compute_crosscut_thickness(
             top_layer_label
         ].where(is_below_surface, 1.0)
         thickness = thickness.where(~lower_layer_bc, corrected_thickness)
+
+    # Deal with case where bc_top and bc_bottom are equal.
+    if (bc_top is not None) and (bc_bottom is not None):
+        bc_top_equals_bc_bottom = bc_top == bc_bottom
+        thickness = thickness.where(~bc_top_equals_bc_bottom, layer_thickness)
 
     thickness = thickness.where(~outside, 0.0)
 

--- a/imod/tests/test_prepare/test_topsystem.py
+++ b/imod/tests/test_prepare/test_topsystem.py
@@ -466,6 +466,40 @@ def test_distribute_riv_conductance__equal_to_surface_level(
 
 
 @parametrize_with_cases(
+    argnames="active,top,bottom,stage,bottom_elevation",
+    prefix="riv_",
+)
+@parametrize_with_cases(
+    argnames="option,allocated_layer,_", prefix="distribution_", has_tag="riv"
+)
+def test_distribute_riv_conductance__stage_equal_to_bottom_elevation(
+    active, top, bottom, stage, bottom_elevation, option, allocated_layer, _
+):
+    allocated_layer.data = np.array([False, True, False, False])
+    expected = [np.nan, 1.0, np.nan, np.nan]
+    allocated = enforce_dim_order(active & allocated_layer)
+    k = xr.DataArray(
+        [2.0, 2.0, 1.0, 1.0], coords={"layer": [1, 2, 3, 4]}, dims=("layer",)
+    )
+
+    conductance = zeros_like(bottom_elevation) + 1.0
+
+    actual_da = distribute_riv_conductance(
+        option,
+        allocated,
+        conductance,
+        top,
+        bottom,
+        k,
+        stage,
+        stage,
+    )
+    actual = take_nth_layer_column(actual_da, 0)
+
+    np.testing.assert_equal(actual, expected)
+
+
+@parametrize_with_cases(
     argnames="active,top,bottom,elevation",
     prefix="ghb_",
 )


### PR DESCRIPTION
Fixes #1386

# Description
Fix bug where conductances were set to ``np.nan`` for cells where ``stage`` equals ``bottom_elevation`` in ``_compute_crosscut_thickness``.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
