### PR TITLE
Issue #1392 better default settings

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -31,10 +31,9 @@ Changed
   :meth:`imod.mf6.LayeredWell.from_imod5_data` now also accept the argument
   ``times = "steady-state"``, for the simulation is assumed to be "steady-state"
   and well timeseries are averaged.
-- The ``riv`` attribute of :class:`imod.prepare.SimulationAllocationOptions` has
-  the ``stage_to_riv_bot_drn_above`` of :func:`imod.prepare.ALLOCATION_OPTION`
-  now set as default. This means by default drainage cells are placed from the
-  first active cell to the river stage level when allocating rivers in
+- The ``drn`` attribute of :class:`imod.prepare.SimulationAllocationOptions` has
+  the ``at_elevation`` of :func:`imod.prepare.ALLOCATION_OPTION` option now set
+  as default. This means by default drainage cells are placed differently in
   :meth:`imod.mf6.Simulation.from_imod5_data`.
 
 Fixed

--- a/imod/prepare/topsystem/default_allocation_methods.py
+++ b/imod/prepare/topsystem/default_allocation_methods.py
@@ -15,10 +15,10 @@ class SimulationAllocationOptions:
     ----------
     drn: ALLOCATION_OPTION
         allocation option to be used for drainage packages, defaults to
-        ``first_active_to_elevation``.
+        ``at_elevation``.
     riv: ALLOCATION_OPTION
         allocation option to be used for river packages, defaults to
-        ``stage_to_riv_bot_drn_above``.
+        ``stage_to_riv_bot``.
     ghb: ALLOCATION_OPTION
         allocation option to be used for general head boundary packages,
         defaults to ``at_elevation``.
@@ -37,8 +37,8 @@ class SimulationAllocationOptions:
 
     """
 
-    drn: ALLOCATION_OPTION = ALLOCATION_OPTION.first_active_to_elevation
-    riv: ALLOCATION_OPTION = ALLOCATION_OPTION.stage_to_riv_bot_drn_above
+    drn: ALLOCATION_OPTION = ALLOCATION_OPTION.at_elevation
+    riv: ALLOCATION_OPTION = ALLOCATION_OPTION.stage_to_riv_bot
     ghb: ALLOCATION_OPTION = ALLOCATION_OPTION.at_elevation
 
 
@@ -53,7 +53,7 @@ class SimulationDistributingOptions:
     ----------
     drn: DISTRIBUTING_OPTION
         distribution option to be used for drainage packages, defaults to
-        ``by_corrected_transmissivity``.
+        ``by_layer_transmissivity``.
     riv: DISTRIBUTING_OPTION
         distribution option to be used for river packages, defaults to
         ``by_corrected_transmissivity``.
@@ -75,6 +75,6 @@ class SimulationDistributingOptions:
 
     """
 
-    drn: DISTRIBUTING_OPTION = DISTRIBUTING_OPTION.by_corrected_transmissivity
+    drn: DISTRIBUTING_OPTION = DISTRIBUTING_OPTION.by_layer_transmissivity
     riv: DISTRIBUTING_OPTION = DISTRIBUTING_OPTION.by_corrected_transmissivity
     ghb: DISTRIBUTING_OPTION = DISTRIBUTING_OPTION.by_layer_transmissivity

--- a/imod/tests/test_mf6/test_mf6_riv.py
+++ b/imod/tests/test_mf6/test_mf6_riv.py
@@ -642,7 +642,7 @@ def test_import_river_from_imod5__period_data(imod5_dataset_periods, tmp_path):
         target_npf,
         datetime(2002, 2, 2),
         datetime(2022, 2, 2),
-        SimulationAllocationOptions.riv,
+        ALLOCATION_OPTION.stage_to_riv_bot_drn_above,
         SimulationDistributingOptions.riv,
         regridder_types=None,
     )


### PR DESCRIPTION
Fixes #1392 

# Description
Changes default to better match iMOD5. 

- Reverted the default of ``SimulationAllocationOptions.riv`` back to what it was in the previous version, as this matches iMOD5's default setting.
- Set ``SimulationAllocationOptions.drn`` to ``ALLOCATION_OPTION.at_elevation``, to match iMOD5's default setting.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
