### PR TITLE
Issue #1399 imod5 min thickness k wells defaults

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -35,6 +35,9 @@ Changed
   the ``at_elevation`` of :func:`imod.prepare.ALLOCATION_OPTION` option now set
   as default. This means by default drainage cells are placed differently in
   :meth:`imod.mf6.Simulation.from_imod5_data`.
+- :meth:`imod.mf6.Well.from_imod5_data` and
+  :meth:`imod.mf6.LayeredWell.from_imod5_data` now have default values for
+  ``minimum_thickness`` and ``minimum_k`` set to 0.0. 
 
 Fixed
 ~~~~~

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -35,8 +35,9 @@ Changed
   the ``at_elevation`` of :func:`imod.prepare.ALLOCATION_OPTION` option now set
   as default. This means by default drainage cells are placed differently in
   :meth:`imod.mf6.Simulation.from_imod5_data`.
-- :meth:`imod.mf6.Well.from_imod5_data` and
-  :meth:`imod.mf6.LayeredWell.from_imod5_data` now have default values for
+- :class:`imod.mf6.Well`, :class:`imod.mf6.LayeredWell`,
+  :func:`imod.prepare.wells.assign_wells`, :meth:`imod.mf6.Well.from_imod5_data`
+  and :meth:`imod.mf6.LayeredWell.from_imod5_data` now have default values for
   ``minimum_thickness`` and ``minimum_k`` set to 0.0. 
 
 Fixed

--- a/examples/mf6/ex01_twri.py
+++ b/examples/mf6/ex01_twri.py
@@ -151,7 +151,6 @@ gwf_model["wel"] = imod.mf6.Well(
     screen_top=screen_top,
     screen_bottom=screen_bottom,
     rate=rate_wel,
-    minimum_k=0.0001,
 )
 
 # Attach it to a simulation

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -744,12 +744,11 @@ class Well(GridAgnosticWell):
         assign an identifier code to each well. if not provided, one will be generated
         Must be convertible to string, and unique entries.
     minimum_k: float, optional
-        on allocating well filters to the model, no filter segments will be
-        placed in cells with a lower horizontal conductivity than this. Defaults
-        to 0.0.
+        on allocating wells to the model, no filter segments will be placed in
+        cells with a smaller horizontal conductivity than this. Defaults to 0.0.
     minimum_thickness: float, optional
-        on allocating well filters to the model, no filter segments will be
-        placed in cells with a lower thickness than this. Defaults to 0.0
+        on allocating wells to the model, no filter segments will be placed in
+        cells with a smaller thickness than this. Defaults to 0.0
     print_input: ({True, False}, optional)
         keyword to indicate that the list of well information will be written to
         the listing file immediately after it is read.

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -744,9 +744,12 @@ class Well(GridAgnosticWell):
         assign an identifier code to each well. if not provided, one will be generated
         Must be convertible to string, and unique entries.
     minimum_k: float, optional
-        on creating point wells, no point wells will be placed in cells with a lower horizontal conductivity than this
+        on allocating well filters to the model, no filter segments will be
+        placed in cells with a lower horizontal conductivity than this. Defaults
+        to 0.0.
     minimum_thickness: float, optional
-        on creating point wells, no point wells will be placed in cells with a lower thickness than this
+        on allocating well filters to the model, no filter segments will be
+        placed in cells with a lower thickness than this. Defaults to 0.0
     print_input: ({True, False}, optional)
         keyword to indicate that the list of well information will be written to
         the listing file immediately after it is read.
@@ -839,8 +842,8 @@ class Well(GridAgnosticWell):
         concentration: Optional[list[float] | xr.DataArray] = None,
         concentration_boundary_type="aux",
         id: Optional[list[Any]] = None,
-        minimum_k: float = 0.1,
-        minimum_thickness: float = 0.05,
+        minimum_k: float = 0.0,
+        minimum_thickness: float = 0.0,
         print_input: bool = False,
         print_flows: bool = False,
         save_flows: bool = False,
@@ -1132,9 +1135,11 @@ class LayeredWell(GridAgnosticWell):
         assign an identifier code to each well. if not provided, one will be generated
         Must be convertible to string, and unique entries.
     minimum_k: float, optional
-        on creating point wells, no point wells will be placed in cells with a lower horizontal conductivity than this
+        on allocating wells to model cells, no wells will be placed in cells
+        with a lower horizontal conductivity than this. Defaults to 0.0.
     minimum_thickness: float, optional
-        on creating point wells, no point wells will be placed in cells with a lower thickness than this
+        on allocating wells to model cells, no wells will be placed in cells
+        with a lower thickness than this. Defaults to 0.0.
     print_input: ({True, False}, optional)
         keyword to indicate that the list of well information will be written to
         the listing file immediately after it is read.
@@ -1215,8 +1220,8 @@ class LayeredWell(GridAgnosticWell):
         concentration: Optional[list[float] | xr.DataArray] = None,
         concentration_boundary_type="aux",
         id: Optional[list[Any]] = None,
-        minimum_k: float = 0.1,
-        minimum_thickness: float = 1.0,
+        minimum_k: float = 0.0,
+        minimum_thickness: float = 0.0,
         print_input: bool = False,
         print_flows: bool = False,
         save_flows: bool = False,

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -582,8 +582,8 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
         key: str,
         imod5_data: dict[str, dict[str, GridDataArray]],
         times: StressPeriodTimesType,
-        minimum_k: float = 0.1,
-        minimum_thickness: float = 0.05,
+        minimum_k: float = 0.0,
+        minimum_thickness: float = 0.0,
     ) -> "GridAgnosticWell":
         """
         Convert wells to imod5 data, loaded with

--- a/imod/prepare/wells.py
+++ b/imod/prepare/wells.py
@@ -147,8 +147,8 @@ def assign_wells(
     top: GridDataArray,
     bottom: GridDataArray,
     k: Optional[GridDataArray] = None,
-    minimum_thickness: Optional[float] = 0.05,
-    minimum_k: Optional[float] = 1.0,
+    minimum_thickness: Optional[float] = 0.0,
+    minimum_k: Optional[float] = 0.0,
     validate: bool = True,
 ) -> pd.DataFrame:
     """
@@ -171,10 +171,10 @@ def assign_wells(
         Bottom of the model layers.
     k: xarray.DataArray or xugrid.UgridDataArray, optional
         Horizontal conductivity of the model layers.
-    minimum_thickness: float, optional, default: 0.01
+    minimum_thickness: float, optional, default: 0.0
         Minimum thickness, cells with thicknesses smaller than this value will
         be dropped.
-    minimum_k: float, optional, default: 1.0
+    minimum_k: float, optional, default: 0.0
         Minimum horizontal conductivity, cells with horizontal conductivities
         smaller than this value will be dropped.
     validate: bool

--- a/imod/prepare/wells.py
+++ b/imod/prepare/wells.py
@@ -172,8 +172,11 @@ def assign_wells(
     k: xarray.DataArray or xugrid.UgridDataArray, optional
         Horizontal conductivity of the model layers.
     minimum_thickness: float, optional, default: 0.01
+        Minimum thickness, cells with thicknesses smaller than this value will
+        be dropped.
     minimum_k: float, optional, default: 1.0
-        Minimum conductivity
+        Minimum horizontal conductivity, cells with horizontal conductivities
+        smaller than this value will be dropped.
     validate: bool
         raise an excpetion if one of the wells is not in the domain
     Returns
@@ -213,7 +216,7 @@ def assign_wells(
     #   -in very thin layers or when the wellbore penetrates the layer very little
     #   -in low conductivity layers
     df_factor = df_factor.loc[
-        (df_factor["overlap"] >= minimum_thickness) & (df_factor["k"] >= minimum_k)
+        (df_factor["overlap"] > minimum_thickness) & (df_factor["k"] > minimum_k)
     ]
     df_factor["rate"] = df_factor["transmissivity"] / df_factor.groupby("id")[
         "transmissivity"

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -377,7 +377,7 @@ def test_to_mf6_pkg__error_on_well_removal(
     Should throw error if error_on_well_removal = True"""
     idomain, top, bottom = basic_dis
 
-    wel = imod.mf6.Well(minimum_k=1.0, *well_high_lvl_test_data_transient)
+    wel = imod.mf6.Well(minimum_k=0.9, *well_high_lvl_test_data_transient)
     active = idomain == 1
     k = xr.ones_like(idomain)
     k.loc[{"x": 85.0}] = 1e-3

--- a/imod/tests/test_mf6/test_well_highlvl.py
+++ b/imod/tests/test_mf6/test_well_highlvl.py
@@ -152,12 +152,15 @@ def test_write_all_wells_filtered_out(
 ):
     # for this test, we leave the low conductivity of the twri model as is, so
     # all wells get filtered out
+    # set minimum_k and minimum_thickness to force filtering
     twri_simulation["GWF_1"]["well"] = imod.mf6.Well(
         x=[1.0, 6002.0],
         y=[3.0, 5004.0],
         screen_top=[0.0, 0.0],
         screen_bottom=[-10.0, -10.0],
         rate=[1.0, 3.0],
+        minimum_k=0.1,
+        minimum_thickness=0.05,
         print_flows=True,
         validate=True,
     )
@@ -173,12 +176,15 @@ def test_write_one_well_filtered_out(
     # one of the wells violates the thickness constraint (the second one) and
     # gets filtered out alltogether
     twri_simulation["GWF_1"]["npf"]["k"] *= 20000
+    # set minimum_k and minimum_thickness to force filtering
     twri_simulation["GWF_1"]["well"] = imod.mf6.Well(
         x=[1.0, 6002.0],
         y=[3.0, 5004.0],
         screen_top=[0.0, 0.0],
         screen_bottom=[-10.0, -0.01],
         rate=[1.0, 3.0],
+        minimum_k=0.1,
+        minimum_thickness=0.05,
         print_flows=True,
         validate=True,
     )
@@ -197,12 +203,15 @@ def test_write_one_layer_filtered_out(
     k.loc[{"layer": 3}] = 10.0
 
     # define 2 wells penetrating all layers
+    # set minimum_k and minimum_thickness to force filtering
     twri_simulation["GWF_1"]["well"] = imod.mf6.Well(
         x=[1.0, 6002.0],
         y=[3.0, 5004.0],
         screen_top=[0.0, 0.0],
         screen_bottom=[-400.0, -400],
         rate=[1.0, 3.0],
+        minimum_k=0.1,
+        minimum_thickness=0.05,
         print_flows=True,
         validate=True,
     )


### PR DESCRIPTION
Fixes #1399

# Description
This PR sets better defaults for ``minimum_k`` and ``minimum_thickness``. See linked issue.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
