### PR TITLE
Issue #1413 add missing arg rch from imod5 cap data

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -64,6 +64,8 @@ Fixed
   ``by_crosscut_transmissivity``, ``by_corrected_transmissivity``.
 - :meth:`imod.mf6.NodePropertyFlow.from_imod5_data` now defaults to 90 degrees
   for missing layers ``imod5_data`` instead of 0 degrees.
+- Bug in :meth:`imod.mf6.Modflow6Simulation.from_imod5_data` where an error was
+  raised in case the ``"CAP"`` package was present in the ``imod5_data``.
 
 [1.0.0rc1] - 2024-12-20
 -----------------------

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -336,7 +336,7 @@ class GroundwaterFlowModel(Modflow6Model):
 
         if "cap" in imod5_keys:
             result["msw-sprinkling"] = LayeredWell.from_imod5_cap_data(imod5_data)  # type: ignore
-            result["msw-rch"] = Recharge.from_imod5_cap_data(imod5_data)  # type: ignore
+            result["msw-rch"] = Recharge.from_imod5_cap_data(imod5_data, dis_pkg)  # type: ignore
 
         # import ghb's
         ghb_keys = [key for key in imod5_keys if key[0:3] == "ghb"]


### PR DESCRIPTION
Fixes #1413

# Description
Fix missing arg in call to ``imod.mf6.Rcharge.from_imod5_cap_data`` in ``imod.mf6.GroundwaterFlowModel.from_imod5_data`` and add test to verify if packages are generated.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
