### PR TITLE
Update pixi toml to stop pixi warning with pixi>=0.40.

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -142,19 +142,19 @@ pip = "*"
 pixi-diff-to-markdown = "*"
 
 [feature.py310.dependencies]
-python = "3.10.12"
+python = ">=3.10.12"
 pip = "*"
 
 [feature.py311.dependencies]
-python = "3.11"
+python = "3.11.*"
 pip = "*"
 
 [feature.py312.dependencies]
-python = "3.12"
+python = "3.12.*"
 pip = "*"
 
 [feature.py313.dependencies]
-python = "3.13"
+python = "3.13.*"
 pip = "*"
 
 [feature.pixi-update.tasks]


### PR DESCRIPTION
Update toml to stop warnings with pixi >=0.40.

```
 WARN Encountered ambiguous version specifier `3.10.12`, could be `3.10.12.*` but assuming you meant `==3.10.12`. In the future this will result in an error.
 WARN Encountered ambiguous version specifier `3.11`, could be `3.11.*` but assuming you meant `==3.11`. In the future this will result in an error.
 WARN Encountered ambiguous version specifier `3.12`, could be `3.12.*` but assuming you meant `==3.12`. In the future this will result in an error.
 WARN Encountered ambiguous version specifier `3.13`, could be `3.13.*` but assuming you meant `==3.13`. In the future this will result in an error.
```