### PR TITLE
Issue #1412 check hfb geometry type

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -44,6 +44,11 @@ Changed
   ``minimum_thickness`` and ``minimum_k`` set to 0.0. 
 - When intitating a MODFLOW6 package with a ``layer`` coordinate with 
   values <= 0, iMOD Python will throw an error.
+- :class:`imod.mf6.HorizontalFlowBarrierResistance`,
+  :class:`imod.mf6.HorizontalFlowBarrierSingleLayerResistance` and other HFB now
+  validate whether proper type of geometry is provided, respectively Polygon for
+  :class:`imod.mf6.HorizontalFlowBarrierResistance`, and LineString for
+  :class:`imod.mf6.HorizontalFlowBarrierSingleLayerResistance`.
 
 Fixed
 ~~~~~

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -31,7 +31,14 @@ from imod.mf6.utilities.hfb import (
     _prepare_index_names,
 )
 from imod.mf6.validation_context import ValidationContext
-from imod.schemata import EmptyIndexesSchema, MaxNUniqueValuesSchema, ValidationError
+from imod.schemata import (
+    DimsSchema,
+    DTypeSchema,
+    EmptyIndexesSchema,
+    GeometryTypeSchema,
+    MaxNUniqueValuesSchema,
+    ValidationError,
+)
 from imod.typing import GeoDataFrameType, GridDataArray, LineStringType
 from imod.typing.grid import as_ugrid_dataarray, ones_like
 from imod.util.imports import MissingOptionalModule
@@ -976,6 +983,17 @@ class HorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierBase):
 
     """
 
+    _init_schemata = {
+        "print_flows": [DTypeSchema(np.bool_), DimsSchema()],
+    }
+
+    _write_schemata = {
+        "geometry": [
+            EmptyIndexesSchema(),
+            GeometryTypeSchema(shapely.Polygon),
+        ],
+    }
+
     @init_log_decorator()
     def __init__(
         self,
@@ -1041,8 +1059,15 @@ class SingleLayerHorizontalFlowBarrierHydraulicCharacteristic(
 
     """
 
+    _init_schemata = {
+        "print_flows": [DTypeSchema(np.bool_), DimsSchema()],
+    }
+
     _write_schemata = {
-        "geometry": [EmptyIndexesSchema()],
+        "geometry": [
+            EmptyIndexesSchema(),
+            GeometryTypeSchema(shapely.LineString),
+        ],
         "layer": [MaxNUniqueValuesSchema(1)],
     }
 
@@ -1111,6 +1136,14 @@ class HorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
     >>> hfb = imod.mf6.HorizontalFlowBarrierMultiplier(barrier_gdf)
 
     """
+
+    _init_schemata = {
+        "print_flows": [DTypeSchema(np.bool_), DimsSchema()],
+    }
+
+    _write_schemata = {
+        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(shapely.Polygon)],
+    }
 
     @init_log_decorator()
     def __init__(
@@ -1182,8 +1215,12 @@ class SingleLayerHorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
 
     """
 
+    _init_schemata = {
+        "print_flows": [DTypeSchema(np.bool_), DimsSchema()],
+    }
+
     _write_schemata = {
-        "geometry": [EmptyIndexesSchema()],
+        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(shapely.LineString)],
         "layer": [MaxNUniqueValuesSchema(1)],
     }
 
@@ -1273,6 +1310,14 @@ class HorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
 
     """
 
+    _init_schemata = {
+        "print_flows": [DTypeSchema(np.bool_), DimsSchema()],
+    }
+
+    _write_schemata = {
+        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(shapely.Polygon)],
+    }
+
     @init_log_decorator()
     def __init__(
         self,
@@ -1336,8 +1381,12 @@ class SingleLayerHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
 
     """
 
+    _init_schemata = {
+        "print_flows": [DTypeSchema(np.bool_), DimsSchema()],
+    }
+
     _write_schemata = {
-        "geometry": [EmptyIndexesSchema()],
+        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(shapely.LineString)],
         "layer": [MaxNUniqueValuesSchema(1)],
     }
 

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -260,7 +260,7 @@ def _select_dataframe_with_snapped_line_index(
 def _extract_mean_hfb_bounds_from_dataframe(
     dataframe: GeoDataFrameType,
 ) -> Tuple[pd.Series, pd.Series]:
-    """
+    r"""
     Extract hfb bounds from dataframe. Requires dataframe geometry to be of type
     shapely "Z Polygon".
 

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -54,11 +54,13 @@ else:
 
 if TYPE_CHECKING:
     import shapely
+
     _POLYGON = shapely.geometry.Polygon
     _LINESTRING = shapely.geometry.LineString
 else:
     try:
         import shapely
+
         _POLYGON = shapely.geometry.Polygon
         _LINESTRING = shapely.geometry.LineString
     except ImportError:

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -54,11 +54,17 @@ else:
 
 if TYPE_CHECKING:
     import shapely
+    _POLYGON = shapely.geometry.Polygon
+    _LINESTRING = shapely.geometry.LineString
 else:
     try:
         import shapely
+        _POLYGON = shapely.geometry.Polygon
+        _LINESTRING = shapely.geometry.LineString
     except ImportError:
         shapely = MissingOptionalModule("shapely")
+        _POLYGON = ""
+        _LINESTRING = ""
 
 NO_BARRIER_MSG = textwrap.dedent(
     """
@@ -990,7 +996,7 @@ class HorizontalFlowBarrierHydraulicCharacteristic(HorizontalFlowBarrierBase):
     _write_schemata = {
         "geometry": [
             EmptyIndexesSchema(),
-            GeometryTypeSchema(shapely.Polygon),
+            GeometryTypeSchema(_POLYGON),
         ],
     }
 
@@ -1066,7 +1072,7 @@ class SingleLayerHorizontalFlowBarrierHydraulicCharacteristic(
     _write_schemata = {
         "geometry": [
             EmptyIndexesSchema(),
-            GeometryTypeSchema(shapely.LineString),
+            GeometryTypeSchema(_LINESTRING),
         ],
         "layer": [MaxNUniqueValuesSchema(1)],
     }
@@ -1142,7 +1148,7 @@ class HorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
     }
 
     _write_schemata = {
-        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(shapely.Polygon)],
+        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(_POLYGON)],
     }
 
     @init_log_decorator()
@@ -1220,7 +1226,7 @@ class SingleLayerHorizontalFlowBarrierMultiplier(HorizontalFlowBarrierBase):
     }
 
     _write_schemata = {
-        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(shapely.LineString)],
+        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(_LINESTRING)],
         "layer": [MaxNUniqueValuesSchema(1)],
     }
 
@@ -1315,7 +1321,7 @@ class HorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
     }
 
     _write_schemata = {
-        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(shapely.Polygon)],
+        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(_POLYGON)],
     }
 
     @init_log_decorator()
@@ -1386,7 +1392,7 @@ class SingleLayerHorizontalFlowBarrierResistance(HorizontalFlowBarrierBase):
     }
 
     _write_schemata = {
-        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(shapely.LineString)],
+        "geometry": [EmptyIndexesSchema(), GeometryTypeSchema(_LINESTRING)],
         "layer": [MaxNUniqueValuesSchema(1)],
     }
 

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -473,7 +473,7 @@ def test_to_mf6_layered_hfb(mf6_flow_barrier_mock, basic_dis, layer, expected_va
     assert_array_equal(barrier_layer, expected_layer)
 
 
-def test_to_mf6_layered_hfb__error():
+def test_to_mf6_layered_hfb__error_non_unique_layer():
     """Throws error because multiple layers attached to one object."""
     # Arrange.
     print_input = False
@@ -488,6 +488,34 @@ def test_to_mf6_layered_hfb__error():
         data={
             "resistance": [1e3, 1e3],
             "layer": [1, 2],
+        },
+    )
+
+    hfb = SingleLayerHorizontalFlowBarrierResistance(geometry, print_input)
+    errors = hfb._validate(hfb._write_schemata)
+
+    assert len(errors) > 0
+
+
+def test_to_mf6_layered_hfb__error_geometry_type():
+    """Throws error because wrong geometry type in object."""
+    # Arrange.
+    print_input = False
+
+    barrier_ztop = [0.0, 0.0]
+    barrier_zbottom = [-100.0, -100.0]
+    barrier_y = [5.5, 5.5, 5.5]
+    barrier_x = [82.0, 40.0, 0.0]
+
+    polygons = linestring_to_square_zpolygons(
+        barrier_x, barrier_y, barrier_ztop, barrier_zbottom
+    )
+
+    geometry = gpd.GeoDataFrame(
+        geometry=polygons,
+        data={
+            "resistance": [1e3, 1e3],
+            "layer": [1, 1],
         },
     )
 


### PR DESCRIPTION
Fixes #1412

# Description
- Adds validation for HFB geometry types 
- I had to create the ``_POLYGON`` and ``_LINESTRING`` variables to keep shapely an optional module. Otherwise iMOD Python breaks upon import.
- Convert docstring from regular string to rawstring, to avoid warning upon import about backslashes.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
