### PR TITLE
Issue #1170 avoid mangled path unsa dbase

### DIFF
--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -59,7 +59,7 @@ INITIAL_CONDITIONS_PACKAGES = (
     InitialConditionsSavedState,
 )
 
-DEFAULT_SETTINGS = {
+DEFAULT_SETTINGS: dict[str, Any] = {
     "vegetation_mdl": 1,
     "evapotranspiration_mdl": 1,
     "saltstress_mdl": 0,
@@ -222,7 +222,7 @@ class MetaSwapModel(Model):
         if not optional_package:
             raise KeyError(f"Could not find package of type: {pkg_type}")
 
-    def _write_simulation_settings(self, directory: Union[str, Path]):
+    def _write_simulation_settings(self, directory: Path) -> None:
         """
         Write simulation settings to para_sim.inp.
 

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -1,5 +1,5 @@
 import collections
-from copy import copy
+from copy import copy, deepcopy
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Tuple, Union, cast
@@ -122,9 +122,7 @@ class MetaSwapModel(Model):
         else:
             self.simulation_settings = settings
 
-        self.simulation_settings["unsa_svat_path"] = (
-            self._render_unsaturated_database_path(unsaturated_database)
-        )
+        self.simulation_settings["unsa_svat_path"] = unsaturated_database
 
     def _render_unsaturated_database_path(self, unsaturated_database: Union[str, Path]):
         # Force to Path object
@@ -224,6 +222,36 @@ class MetaSwapModel(Model):
         if not optional_package:
             raise KeyError(f"Could not find package of type: {pkg_type}")
 
+    def _write_simulation_settings(self, directory: Union[str, Path]):
+        """
+        Write simulation settings to para_sim.inp.
+
+        Parameters
+        ----------
+        directory: Path or str
+            directory to write model in.
+        """
+        simulation_settings = deepcopy(self.simulation_settings)
+
+        # Add time settings
+        year, time_since_start_year = self._get_starttime()
+
+        simulation_settings["iybg"] = year
+        simulation_settings["tdbg"] = time_since_start_year
+
+        # Add IdfMapping settings
+        idf_key = self._get_pkg_key(IdfMapping)
+        simulation_settings.update(self[idf_key].get_output_settings())
+
+        simulation_settings["unsa_svat_path"] = self._render_unsaturated_database_path(
+            simulation_settings["unsa_svat_path"]
+        )
+
+        filename = directory / self._file_name
+        with open(filename, "w") as f:
+            rendered = self._template.render(settings=simulation_settings)
+            f.write(rendered)
+
     def write(
         self,
         directory: Union[str, Path],
@@ -250,20 +278,8 @@ class MetaSwapModel(Model):
         directory = Path(directory)
         directory.mkdir(exist_ok=True, parents=True)
 
-        # Add time settings
-        year, time_since_start_year = self._get_starttime()
-
-        self.simulation_settings["iybg"] = year
-        self.simulation_settings["tdbg"] = time_since_start_year
-
-        # Add IdfMapping settings
-        idf_key = self._get_pkg_key(IdfMapping)
-        self.simulation_settings.update(self[idf_key].get_output_settings())
-
-        filename = directory / self._file_name
-        with open(filename, "w") as f:
-            rendered = self._template.render(settings=self.simulation_settings)
-            f.write(rendered)
+        # Write simulation settings
+        self._write_simulation_settings(directory)
 
         # Get index and svat
         grid_key = self._get_pkg_key(GridData)

--- a/imod/msw/utilities/parse.py
+++ b/imod/msw/utilities/parse.py
@@ -23,12 +23,15 @@ def _try_parsing_string_to_number(s: str) -> ScalarType:
     return s
 
 
-def correct_unsa_svat_path(unsa_path: Path | str) -> str:
+def correct_unsa_svat_path(unsa_path: ScalarType) -> str:
     """
     Correct the path to the UNSA SVAT executable in the parameter file. Drop any
     quotes and trailing backslashes, and replace any dollar signs. These could
     have been added by ``MetaSwapModel._render_unsaturated_database_path``.
     """
+    if not isinstance(unsa_path, str):
+        raise TypeError(f"Unexcepted type for unsa_path, expected str, got {unsa_path}")
+
     unsa_path = unsa_path.replace('"', "")
 
     if unsa_path.endswith("\\"):

--- a/imod/msw/utilities/parse.py
+++ b/imod/msw/utilities/parse.py
@@ -23,6 +23,23 @@ def _try_parsing_string_to_number(s: str) -> ScalarType:
     return s
 
 
+def correct_unsa_svat_path(unsa_path: Path | str) -> str:
+    """
+    Correct the path to the UNSA SVAT executable in the parameter file. Drop any
+    quotes and trailing backslashes, and replace any dollar signs. These could
+    have been added by ``MetaSwapModel._render_unsaturated_database_path``.
+    """
+    unsa_path = unsa_path.replace('"', "")
+
+    if unsa_path.endswith("\\"):
+        unsa_path = unsa_path[:-1]
+
+    if unsa_path.startswith("$"):
+        unsa_path = unsa_path.replace("$", "./")
+
+    return unsa_path
+
+
 def read_para_sim(file: Path | str) -> dict[str, ScalarType]:
     with open(file, "r") as f:
         lines = f.readlines()
@@ -35,4 +52,7 @@ def read_para_sim(file: Path | str) -> dict[str, ScalarType]:
                 key = key_values[0].strip()
                 value = _try_parsing_string_to_number(key_values[1].strip())
                 out[key] = value
+
+    out["unsa_svat_path"] = correct_unsa_svat_path(out["unsa_svat_path"])
+
     return out

--- a/imod/tests/test_msw/test_model.py
+++ b/imod/tests/test_msw/test_model.py
@@ -9,6 +9,7 @@ from pytest_cases import parametrize_with_cases
 from imod import mf6, msw
 from imod.mf6.utilities.regrid import RegridderWeightsCache
 from imod.msw.model import DEFAULT_SETTINGS
+from imod.msw.utilities.parse import read_para_sim
 from imod.typing import GridDataArray, Imod5DataDict
 
 
@@ -20,6 +21,33 @@ def test_msw_model_write(msw_model, coupled_mf6_model, coupled_mf6wel, tmp_path)
 
     assert len(list(output_dir.rglob(r"*.inp"))) == 16
     assert len(list(output_dir.rglob(r"*.asc"))) == 4
+
+
+def test_msw_model_write_settings_roundtrip(msw_model, tmp_path):
+    # Arrange
+    output_dir = tmp_path / "metaswap"
+    output_dir.mkdir()
+    keys_to_drop = [
+        "iybg",
+        "tdbg",
+        "simgro_opt",
+        "idf_per",
+        "idf_dx",
+        "idf_dy",
+        "idf_ncol",
+        "idf_nrow",
+        "idf_xmin",
+        "idf_ymin",
+        "idf_nodata",
+    ]
+    # Act
+    msw_model._write_simulation_settings(output_dir)
+    # Assert
+    parasim_settings = read_para_sim(output_dir / "para_sim.inp")
+    for key in keys_to_drop:
+        parasim_settings.pop(key)
+
+    assert msw_model.simulation_settings == parasim_settings
 
 
 def test_get_starttime(msw_model):

--- a/imod/tests/test_msw/test_utilities/test_parse.py
+++ b/imod/tests/test_msw/test_utilities/test_parse.py
@@ -1,6 +1,9 @@
 from pytest_cases import parametrize_with_cases
 
-from imod.msw.utilities.parse import _try_parsing_string_to_number
+from imod.msw.utilities.parse import (
+    _try_parsing_string_to_number,
+    correct_unsa_svat_path,
+)
 
 
 class ParseCases:
@@ -20,9 +23,34 @@ class ParseCases:
         return "!", str
 
 
+class UnsaSvatPathCases:
+    def case_relpath(self):
+        path = '"$unsat\\"'
+        path_expected = "./unsat"
+        return path, path_expected
+
+    def case_abspath(self):
+        path = '"C:\\Program Files\\MetaSWAP\\unsat\\"'
+        path_expected = "C:\\Program Files\\MetaSWAP\\unsat"
+        return path, path_expected
+
+    def case_quoted(self):
+        path = '"a/b/c"'
+        path_expected = "a/b/c"
+        return path, path_expected
+
+
 @parametrize_with_cases(["s", "expected_type"], cases=ParseCases)
 def test_try_parsing_string_to_value(s, expected_type):
     # Act
     parsed = _try_parsing_string_to_number(s)
     # Assert
     assert type(parsed) is expected_type
+
+
+@parametrize_with_cases(["path", "path_expected"], cases=UnsaSvatPathCases)
+def test_correct_unsa_svat_path(path, path_expected):
+    # Act
+    path_corrected = correct_unsa_svat_path(path)
+    # Assert
+    assert path_corrected == path_expected

--- a/imod/tests/test_msw/test_utilities/test_parse.py
+++ b/imod/tests/test_msw/test_utilities/test_parse.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest_cases import parametrize_with_cases
 
 from imod.msw.utilities.parse import (
@@ -54,3 +55,11 @@ def test_correct_unsa_svat_path(path, path_expected):
     path_corrected = correct_unsa_svat_path(path)
     # Assert
     assert path_corrected == path_expected
+
+
+def test_correct_unsa_svat_path__wrong_type():
+    with pytest.raises(TypeError):
+        correct_unsa_svat_path(1.0)
+
+    with pytest.raises(TypeError):
+        correct_unsa_svat_path(1)


### PR DESCRIPTION
Fixes #1170

# Description
Fixes a problem where the path to ``unsa_svat_path`` was mangled. Adds/changes the following things:

- Render ``"unsa_svat_path"`` upon writing ``para_sim.inp`` instead of upon initialization ``MetaSwapModel``.
- Add function to correct mangled ``"unsa_svat_path"`` upon reading ``para_sim.inp`` file.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
