### PR TITLE
Issue #1415 relax validation copy files

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -49,6 +49,8 @@ Changed
   validate whether proper type of geometry is provided, respectively Polygon for
   :class:`imod.mf6.HorizontalFlowBarrierResistance`, and LineString for
   :class:`imod.mf6.HorizontalFlowBarrierSingleLayerResistance`.
+- Relaxed validation for :class:`imod.msw.MetaSwapModel` if ``FileCopier``
+  package is present.
 
 Fixed
 ~~~~~
@@ -79,6 +81,8 @@ Fixed
 - :meth:`imod.mf6.LayeredWell.from_imod5_cap_data` will convert the
   ``max_abstraction_groundwater`` and ``max_abstraction_surfacewater`` capacity
   from mm/d to m3/d.
+- Models imported with :meth:`imod.msw.MetaSwapModel.from_imod5_data` can be
+  written with ``validate`` set to True.
 
 
 [1.0.0rc1] - 2024-12-20

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -137,7 +137,7 @@ class MetaSwapModel(Model):
             # TODO: Test if this is how MetaSWAP accepts relative paths
             return f'"${unsaturated_database}\\"'
 
-    def _check_required_packages(self):
+    def _check_required_packages(self) -> None:
         pkg_types_included = {type(pkg) for pkg in self.values()}
         missing_packages = set(REQUIRED_PACKAGES) - pkg_types_included
         if len(missing_packages) > 0:
@@ -193,6 +193,10 @@ class MetaSwapModel(Model):
                 f"which were not in AnnualCropGrowth: {missing_indices}"
             )
 
+    def has_file_copier(self) -> bool:
+        pkg_types_included = {type(pkg) for pkg in self.values()}
+        return FileCopier in pkg_types_included
+
     def _get_starttime(self):
         """
         Loop over all packages to get the minimum time.
@@ -224,6 +228,12 @@ class MetaSwapModel(Model):
         if not optional_package:
             raise KeyError(f"Could not find package of type: {pkg_type}")
 
+    def _model_checks(self, validate: bool):
+        if validate and not self.has_file_copier():
+            self._check_required_packages()
+            self._check_vegetation_indices_in_annual_crop_factors()
+            self._check_landuse_indices_in_lookup_options()
+
     def write(
         self,
         directory: Union[str, Path],
@@ -241,10 +251,7 @@ class MetaSwapModel(Model):
         """
 
         # Model checks
-        if validate:
-            self._check_required_packages()
-            self._check_vegetation_indices_in_annual_crop_factors()
-            self._check_landuse_indices_in_lookup_options()
+        self._model_checks(validate)
 
         # Force to Path
         directory = Path(directory)

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -139,7 +139,8 @@ class MetaSwapModel(Model):
 
     def _check_required_packages(self) -> None:
         pkg_types_included = {type(pkg) for pkg in self.values()}
-        missing_packages = set(REQUIRED_PACKAGES) - pkg_types_included
+        required_packages_set = cast(set[type[Any]], set(REQUIRED_PACKAGES))
+        missing_packages = required_packages_set - pkg_types_included
         if len(missing_packages) > 0:
             raise ValueError(
                 f"Missing the following required packages: {missing_packages}"

--- a/imod/tests/test_msw/test_model.py
+++ b/imod/tests/test_msw/test_model.py
@@ -8,6 +8,7 @@ from pytest_cases import parametrize_with_cases
 
 from imod import mf6, msw
 from imod.mf6.utilities.regrid import RegridderWeightsCache
+from imod.msw.copy_files import FileCopier
 from imod.msw.model import DEFAULT_SETTINGS
 from imod.typing import GridDataArray, Imod5DataDict
 
@@ -68,6 +69,22 @@ def test_check_landuse_indices_in_lookup_options(msw_model):
 
     with pytest.raises(ValueError):
         msw_model._check_landuse_indices_in_lookup_options()
+
+
+def test_check_model(msw_model):
+    """
+    Test _model_checks method. Should raise error if validate = True and
+    FileCopier not present, else not.
+    """
+    msw_model.pop("grid")
+
+    msw_model._model_checks(validate=False)
+
+    with pytest.raises(ValueError):
+        msw_model._model_checks(validate=True)
+
+    msw_model["copy_files"] = FileCopier(["./test.txt"])
+    msw_model._model_checks(validate=True)
 
 
 def test_render_unsat_database_path(msw_model, tmp_path):
@@ -288,7 +305,7 @@ def test_import_from_imod5_and_write(
     mf6_wel_pkg = well_pkg.to_mf6_pkg(
         active, dis_pkg["top"], dis_pkg["bottom"], npf_pkg["k"]
     )
-    model.write(modeldir, dis_pkg, mf6_wel_pkg, validate=False)
+    model.write(modeldir, dis_pkg, mf6_wel_pkg)
 
     # Assert
     expected_n_files = 13


### PR DESCRIPTION
Fixes #1415

# Description
Relax validation when ``FileCopier`` is included to ``MetaSwapModel``. Otherwise models imported from imod5_data could not be written without turning off the validation.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
