### PR TITLE
Issue #1416 0-based TimeOutputControl

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -79,6 +79,8 @@ Fixed
 - :meth:`imod.mf6.LayeredWell.from_imod5_cap_data` will convert the
   ``max_abstraction_groundwater`` and ``max_abstraction_surfacewater`` capacity
   from mm/d to m3/d.
+- :class:`imod.msw.TimeOutputControl` now starts counting at 0.0 instead of 1.0,
+  like MetaSWAP expects.
 
 
 [1.0.0rc1] - 2024-12-20

--- a/imod/msw/output_control.py
+++ b/imod/msw/output_control.py
@@ -132,7 +132,6 @@ class TimeOutputControl(MetaSwapPackage, IRegridPackage):
             data={"time_since_start_year": time_since_start_year, "year": year}
         )
 
-        dataframe["time_since_start_year"] += 1
         dataframe["option"] = 7
 
         self._check_range(dataframe)

--- a/imod/tests/test_msw/test_output_control.py
+++ b/imod/tests/test_msw/test_output_control.py
@@ -88,7 +88,7 @@ def test_time_oc(fixed_format_parser):
             output_dir / TimeOutputControl._file_name, TimeOutputControl._metadata_dict
         )
 
-    assert_almost_equal(results["time_since_start_year"], np.array([1.0, 2.0, 3.0]))
+    assert_almost_equal(results["time_since_start_year"], np.array([0.0, 1.0, 2.0]))
     assert_equal(results["year"], [1971, 1971, 1971])
     assert_equal(results["option"], [7, 7, 7])
 


### PR DESCRIPTION
Fixes #1416

# Description
Make start time variables consistently 0-based. For ``mete_grid.inp`` and ``tdbg`` in ``para_sim.inp`` this was already the case. But this was not the case for ``tiop_sim.inp``. This makes that consistent.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
