### PR TITLE
Test resample_timesries forward filling

### DIFF
--- a/imod/tests/test_mf6/test_utilities/test_resampling.py
+++ b/imod/tests/test_mf6/test_utilities/test_resampling.py
@@ -124,6 +124,27 @@ def test_timeseries_resampling_5():
     )
 
 
+def test_timeseries_resampling_6():
+    # In this test, we resample a timeseries after the last timestep of
+    # timeseries, should be forward filled.
+    original_times = [datetime(1899, 1, 1), datetime(1909, 1, 1)] + [
+        datetime(1989, 1, i) for i in [1, 3, 5, 7, 9]
+    ]
+    original_rates = [0.0, 0.0, 200.0, 200.0, 300.0, 400.0, 500.0]
+    original_timeseries = initialize_timeseries(original_times, original_rates)
+
+    new_dates = [datetime(2000, 1, 2), datetime(2000, 1, 3), datetime(2000, 1, 4)]
+    new_timeseries = resample_timeseries(original_timeseries, new_dates)
+
+    expected_times = [datetime(2000, 1, 2), datetime(2000, 1, 3), datetime(2000, 1, 4)]
+    expected_rates = [500.0, 500.0, 500.0]
+    expected_timeseries = initialize_timeseries(expected_times, expected_rates)
+
+    pd.testing.assert_frame_equal(
+        new_timeseries, expected_timeseries, check_dtype=False
+    )
+
+
 def test_timeseries_resampling_coarsen_and_refine():
     # In this test, we resample a timeseries for a coarser output discretization.
     # Then we refine it again to the original discretization.


### PR DESCRIPTION
Fixes #1427 

# Description
I got a an issue from a user that iMOD Python wasn't incorrectly forward filling well timeseries, but it turned out it was doing the right thing. I saw we didn't explicitly test for this so I added a test.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
