### PR TITLE
Issue #1235 Update dead links

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -166,7 +166,7 @@ Changed
   regridder to regrid individual grids instead.
   <https://deltares.github.io/xugrid/examples/regridder_overview.html>`_ To
   regrid entire MODFLOW6 packages or simulations, `see the user guide here.
-  <https://deltares.github.io/imod-python/user_guide/regridding.html>`_.
+  <https://deltares.github.io/imod-python/user-guide/08-regridding.html>`_.
 
 [0.18.1] - 2024-11-20
 ---------------------

--- a/docs/api/mf6.rst
+++ b/docs/api/mf6.rst
@@ -135,7 +135,6 @@ Flow Packages
     River.regrid_like
     River.cleanup
     River.clip_box
-    River.split_conductance
     SingleLayerHorizontalFlowBarrierHydraulicCharacteristic
     SingleLayerHorizontalFlowBarrierHydraulicCharacteristic.to_mf6_pkg
     SingleLayerHorizontalFlowBarrierHydraulicCharacteristic.clip_box

--- a/examples/imod-wq/Elder.py
+++ b/examples/imod-wq/Elder.py
@@ -15,7 +15,7 @@ Simpson, J., & Clement, P. (2003).
 Theoretical analysis of the worthiness of Henry and Elder
 problems as benchmark of density-dependent groundwater flow models.
 `Advances in Water Resources, 1708` (02).
-Retrieved from http://www.eng.auburn.edu/~clemept/publsihed_pdf/awrmat.pdf
+Retrieved from https://www.sciencedirect.com/science/article/abs/pii/S0309170802000854
 """
 
 # %%

--- a/examples/mf6/ex01_twri.py
+++ b/examples/mf6/ex01_twri.py
@@ -215,7 +215,7 @@ head.isel(layer=0, time=0).plot.contourf()
 # %%
 # .. _MODFLOW6 example problems: https://github.com/MODFLOW-USGS/modflow6-examples
 # .. _description: https://modflow6-examples.readthedocs.io/en/master/_examples/ex-gwf-twri.html
-# .. _notebook: https://github.com/MODFLOW-USGS/modflow6-examples/tree/master/notebooks/ex-gwf-twri.ipynb
+# .. _notebook: https://github.com/MODFLOW-USGS/modflow6-examples/blob/develop/scripts/ex-gwf-twri.py
 # .. _Techniques of Water-Resources Investigation: https://pubs.usgs.gov/twri/twri7-c1/
 # .. _McDonald & Harbaugh, 1988: https://pubs.er.usgs.gov/publication/twri06A1
 # .. _Harbaugh & McDonald, 1996: https://pubs.er.usgs.gov/publication/ofr96485

--- a/imod/select/cross_sections.py
+++ b/imod/select/cross_sections.py
@@ -349,7 +349,7 @@ def cross_section_line(data, start, end):
     `xarray.DataArray` so that we can utilize its coordinate data.
 
     Adapted from Metpy:
-    https://github.com/Unidata/MetPy/blob/master/metpy/interpolate/slices.py
+    https://github.com/Unidata/MetPy/blob/main/src/metpy/interpolate/slices.py
 
     Parameters
     ----------
@@ -391,7 +391,7 @@ def cross_section_linestring(data, linestring):
     we can utilize its coordinate data.
 
     Adapted from Metpy:
-    https://github.com/Unidata/MetPy/blob/master/metpy/interpolate/slices.py
+    https://github.com/Unidata/MetPy/blob/main/src/metpy/interpolate/slices.py
 
     Parameters
     ----------


### PR DESCRIPTION
Fixes #1235

# Description
Fixes some of the faulty links scanned with [lychee](https://github.com/lycheeverse/lychee/)
I fixed the dead links that gave 404 errors. Some of the links to scientific papers give 403 errors when running lychee.  But manually clicking on them opens these. I guess lychee needs to be authorized to scan these or something. Same holds for the 401 errors. I resorted to just fixing the 404 errors.

It now throws:

```
[html\examples\imod-wq\Elder.html]:
     [403] https://www.sciencedirect.com/science/article/abs/pii/S0309170802000854

[html\api\generated\prepare\imod.prepare.split_conductance_with_infiltration_factor.html]:
     [403] https://ngwa.onlinelibrary.wiley.com/doi/10.1111/j.1745-6584.2009.00582.x

[html\examples\imod-wq\Hydrocoin.html]:
     [403] https://doi.org/10.1029/97WR01926

[html\_static\webpack-macros.html]:
   [ERROR] file:///C:/src/imod-python/docs/_build/html/_static/%7B%7B%20pathto('_static/scripts/bootstrap.js',%201)%20%7D%7D
   [ERROR] file:///C:/src/imod-python/docs/_build/html/_static/%7B%7B%20pathto('_static/styles/theme.css',%201)%20%7D%7D
   [ERROR] file:///C:/src/imod-python/docs/_build/html/_static/%7B%7B%20pathto('_static/scripts/pydata-sphinx-theme.js',%201)%20%7D%7D
   [ERROR] file:///C:/src/imod-python/docs/_build/html/_static/%7B%7B%20pathto('_static/styles/pydata-sphinx-theme.css',%201)%20%7D%7D

[html\developing\releasing.html]:
     [401] https://dpcbuild.deltares.nl/buildConfiguration/iMOD6_IMODPython_Windows_DeployAll?mode=builds
     [401] https://dpcbuild.deltares.nl/
```

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
