### PR TITLE
Issue #1182 Add extra documentation on required columnnames ipf save

### DIFF
--- a/docs/faq/imod5_backwards_compatibility.rst
+++ b/docs/faq/imod5_backwards_compatibility.rst
@@ -130,7 +130,7 @@ Here an overview of iMOD5 MODFLOW6 features:
     DRN,Align iMOD5 input grids ,:meth:`imod.mf6.Drainage.from_imod5_data`
     DRN,Regrid,:meth:`imod.mf6.Drainage.regrid_like`
     DRN,Clip,:meth:`imod.mf6.Drainage.clip_box`
-    RIV,Infiltration factors (IFF),":meth:`imod.mf6.River.from_imod5_data`, :meth:`imod.mf6.River.split_conductance`"
+    RIV,Infiltration factors (IFF),":meth:`imod.mf6.River.from_imod5_data`, :meth:`imod.prepare.split_conductance_with_infiltration_factor`"
     RIV,Auto placement (IDEFLAYER),":meth:`imod.mf6.River.from_imod5_data`, :func:`imod.prepare.allocate_riv_cells`"
     RIV,Distribute conductances (DISTRCOND),":meth:`imod.mf6.River.from_imod5_data`, :func:`imod.prepare.distribute_riv_conductance`"
     RIV,Cleanup,":meth:`imod.mf6.River.cleanup`, :func:`imod.prepare.cleanup_riv`"

--- a/imod/formats/ipf.py
+++ b/imod/formats/ipf.py
@@ -394,10 +394,11 @@ def write_assoc(path, df, itype=1, nodata=1.0e20, assoc_columns=None):
         IPF type.
         Possible values, either integer or string:
 
-        1 : "timeseries"
-        2 : "borehole1d"
-        3 : "cpt"
-        4 : "borehole3d"
+        * ``1`` : ``"timeseries"``, a column named ``"time"`` is required.        
+        * ``2`` : ``"borehole1d"``, a column named ``"top"`` is required.
+        * ``3`` : ``"cpt"``, a column named ``"top"`` is required.
+        * ``4`` : ``"borehole3d"``, columns named ``"x_offset"``,
+          ``"y_offset"``, and ``"top"`` are required.
     nodata : float
         The value given to nodata values. These are generally NaN (Not-a-Number)
         in pandas, but this leads to errors in iMOD(FLOW) for IDFs.
@@ -622,10 +623,11 @@ def save(path, df, itype=None, assoc_ext="txt", nodata=1.0e20, assoc_columns=Non
         IPF type. Defaults to ``None``, in which case no associated files are
         created. Possible other values, either integer or string:
 
-        * ``1`` or ``"timeseries"``
-        * ``2`` or ``"borehole1d"``
-        * ``3`` or ``"cpt"``
-        * ``4`` or ``"borehole3d"``
+        * ``1`` or ``"timeseries"``, a column named ``"time"`` is required.
+        * ``2`` or ``"borehole1d"``, a column named ``"top"`` is required.
+        * ``3`` or ``"cpt"``, a column named ``"top"`` is required.
+        * ``4`` or ``"borehole3d"``, columns named ``"x_offset"``,
+          ``"y_offset"``, and ``"top"`` are required.
     assoc_ext : str
         Extension of the associated files. Defaults to "txt".
     nodata : float

--- a/imod/formats/ipf.py
+++ b/imod/formats/ipf.py
@@ -394,7 +394,7 @@ def write_assoc(path, df, itype=1, nodata=1.0e20, assoc_columns=None):
         IPF type.
         Possible values, either integer or string:
 
-        * ``1`` : ``"timeseries"``, a column named ``"time"`` is required.        
+        * ``1`` : ``"timeseries"``, a column named ``"time"`` is required.
         * ``2`` : ``"borehole1d"``, a column named ``"top"`` is required.
         * ``3`` : ``"cpt"``, a column named ``"top"`` is required.
         * ``4`` : ``"borehole3d"``, columns named ``"x_offset"``,

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -605,21 +605,20 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
         *Associated wells*
 
         Wells with timeseries in an associated textfile are processed as
-        follows:
+        follows.
 
-        - Wells are validated if the following requirements are met
-            * Associated well entries in projectfile are defined on either all
+        - Wells are validated if the following requirements are met:
+            - Associated well entries in projectfile are defined on either all
               timestamps or just the first
-            * Multiplication and addition factors need to remain constant through time
-            * Same associated well cannot be assigned to multiple layers
+            - Multiplication and addition factors need to remain constant through time
+            - Same associated well cannot be assigned to multiple layers
         - The dataframe of the first projectfile timestamp is selected
-        - Timeseries are processed based on the ``times`` argument of this
-          method:
-            * If ``times`` is a list of datetimes, rate timeseries are resampled
+        - Timeseries are processed based on the ``times`` argument of this method:
+            - If ``times`` is a list of datetimes, rate timeseries are resampled
               with a time weighted mean to the simulation times. When simulation
               times fall outside well timeseries range, the last rate is forward
               filled.
-            * If ``times = "steady-state"``, the simulation is assumed to be
+            - If ``times = "steady-state"``, the simulation is assumed to be
               "steady-state" and an average rate is computed from the
               timeseries.
         - Projectfile timestamps are not used. Even if assigned to a

--- a/imod/prepare/topsystem/conductance.py
+++ b/imod/prepare/topsystem/conductance.py
@@ -592,18 +592,22 @@ def split_conductance_with_infiltration_factor(
     Note
     ----
     Derivation of the formulas from Zaadnoordijk (2009):
-    [1] cond_RIV = A/ci
-    [2] cond_DRN = A * (ci-cd) / (ci*cd)
+    
+    * [1] cond_RIV = A/ci
+    * [2] cond_DRN = A * (ci-cd) / (ci*cd)
+
     Where cond_RIV and cond_DRN repsectively are the River and Drainage conductance [L^2/T],
     A is the cell area [L^2] and ci and cd respectively are the infiltration and exfiltration resistance [T]
 
     Taking f as the infiltration factor and cond_d as the exfiltration conductance, we can write (iMOD manual):
-    [3] ci = cd * (1/f)
-    [4] cond_d = A/cd
+
+    * [3] ci = cd * (1/f)
+    * [4] cond_d = A/cd
 
     We can then rewrite equations 1 and 2 to:
-    [5] cond_RIV = f * cond_d
-    [6] cond_DRN = (1-f) * cond_d
+
+    * [5] cond_RIV = f * cond_d
+    * [6] cond_DRN = (1-f) * cond_d
 
     References
     ----------

--- a/imod/prepare/topsystem/conductance.py
+++ b/imod/prepare/topsystem/conductance.py
@@ -589,9 +589,9 @@ def split_conductance_with_infiltration_factor(
     river_conductance : xr.DataArray
         conductance for the river package
 
-    Derivation
-    ----------
-    From Zaadnoordijk (2009):
+    Note
+    ----
+    Derivation of the formulas from Zaadnoordijk (2009):
     [1] cond_RIV = A/ci
     [2] cond_DRN = A * (ci-cd) / (ci*cd)
     Where cond_RIV and cond_DRN repsectively are the River and Drainage conductance [L^2/T],

--- a/imod/prepare/topsystem/conductance.py
+++ b/imod/prepare/topsystem/conductance.py
@@ -592,7 +592,7 @@ def split_conductance_with_infiltration_factor(
     Note
     ----
     Derivation of the formulas from Zaadnoordijk (2009):
-    
+
     * [1] cond_RIV = A/ci
     * [2] cond_DRN = A * (ci-cd) / (ci*cd)
 


### PR DESCRIPTION
Fixes #1182 

# Description
- Add some extra docs on required columnames upon ipf.save
- Boyscouting: Also fix some formatting issues in the ``split_conductance_with_infiltration_factor``
- Boyscouting: Fix broken crossref to ``split_conductance_with_infiltration_factor`` that caused an error.
- Boyscouting: Avoid error in rendering Well docstrings

# Checklist

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
