### PR TITLE
Issue #1441 reduce warnings

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -91,6 +91,8 @@ Fixed
   like MetaSWAP expects.
 - Models imported with :meth:`imod.msw.MetaSwapModel.from_imod5_data` can be
   written with ``validate`` set to True.
+- Fixed part of the code that made Pandas, Geopands, and xarray throw a lot of
+  ``FutureWarning``s and ``DeprecationWarning``s.
 
 
 [1.0.0rc1] - 2024-12-20

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -91,7 +91,7 @@ Fixed
   like MetaSWAP expects.
 - Models imported with :meth:`imod.msw.MetaSwapModel.from_imod5_data` can be
   written with ``validate`` set to True.
-- Fixed part of the code that made Pandas, Geopands, and xarray throw a lot of
+- Fixed part of the code that made Pandas, Geopandas, and xarray throw a lot of
   ``FutureWarning``s and ``DeprecationWarning``s.
 
 

--- a/imod/flow/cap.py
+++ b/imod/flow/cap.py
@@ -296,7 +296,7 @@ class MetaSwap(Package):
         # Frozen(SortedKeysDict).keys() does not preserve ordering in keys
         # Therefore convert to set and check for symmetric difference,
         # to see if any dimensions are missing or unexpected dimensions are included.
-        dims = set(self.dataset.dims.keys())
+        dims = set(self.dataset.sizes.keys())
 
         if len(dims.symmetric_difference(("y", "x"))) > 0:
             raise ValueError(f'Dataset dims not ("y", "x"), instead got {dims}')

--- a/imod/formats/gen/gen.py
+++ b/imod/formats/gen/gen.py
@@ -53,7 +53,7 @@ def parse_ascii_segments(lines: List[str]):
 
     first_coord = features[0][1:][0]
     has_whitespace = _infer_delimwhitespace(first_coord, 2)
-    sep='\s+' if has_whitespace else ','
+    sep = "\s+" if has_whitespace else ","
 
     vertex_coords = []
     for i, feature in enumerate(features):
@@ -61,9 +61,7 @@ def parse_ascii_segments(lines: List[str]):
         # Use pd.read_csv instead of np.loadtxt, since it supports files
         # delimited with multiple whitespace characters.
         feature_buffer = io.StringIO(initial_value="\n".join(feature[1:]))
-        coords_df = pd.read_csv(
-            feature_buffer, sep=sep, header=None
-        )
+        coords_df = pd.read_csv(feature_buffer, sep=sep, header=None)
         coords = coords_df.values
         is_polygon[i] = (coords[0] == coords[-1]).all()
         vertex_coords.append(coords)

--- a/imod/formats/gen/gen.py
+++ b/imod/formats/gen/gen.py
@@ -53,7 +53,7 @@ def parse_ascii_segments(lines: List[str]):
 
     first_coord = features[0][1:][0]
     has_whitespace = _infer_delimwhitespace(first_coord, 2)
-    sep = "\s+" if has_whitespace else ","
+    sep = r"\s+" if has_whitespace else ","
 
     vertex_coords = []
     for i, feature in enumerate(features):

--- a/imod/formats/gen/gen.py
+++ b/imod/formats/gen/gen.py
@@ -53,6 +53,7 @@ def parse_ascii_segments(lines: List[str]):
 
     first_coord = features[0][1:][0]
     has_whitespace = _infer_delimwhitespace(first_coord, 2)
+    sep='\s+' if has_whitespace else ','
 
     vertex_coords = []
     for i, feature in enumerate(features):
@@ -61,7 +62,7 @@ def parse_ascii_segments(lines: List[str]):
         # delimited with multiple whitespace characters.
         feature_buffer = io.StringIO(initial_value="\n".join(feature[1:]))
         coords_df = pd.read_csv(
-            feature_buffer, delim_whitespace=has_whitespace, header=None
+            feature_buffer, sep=sep, header=None
         )
         coords = coords_df.values
         is_polygon[i] = (coords[0] == coords[-1]).all()

--- a/imod/formats/ipf.py
+++ b/imod/formats/ipf.py
@@ -54,9 +54,10 @@ def _read_ipf(path, kwargs=None) -> Tuple[pd.DataFrame, int, str]:
         line = f.readline()
         delim_whitespace = _infer_delimwhitespace(line, ncol)
         f.seek(position)
+        sep='\s+' if delim_whitespace else ','
 
         ipf_kwargs = {
-            "delim_whitespace": delim_whitespace,
+            "sep": sep,
             "header": None,
             "names": colnames,
             "nrows": nrow,
@@ -78,10 +79,10 @@ def _read(path, kwargs=None, assoc_kwargs=None):
         globpath for IPF files to read.
     kwargs : dict
         Dictionary containing the ``pandas.read_csv()`` keyword arguments for the
-        IPF files (e.g. `{"delim_whitespace": True}`)
+        IPF files (e.g. `{"sep": "\s+"}`)
     assoc_kwargs: dict
         Dictionary containing the ``pandas.read_csv()`` keyword arguments for the
-        associated (TXT) files (e.g. `{"delim_whitespace": True}`)
+        associated (TXT) files (e.g. `{"sep": "\s+"}`)
 
     Returns
     -------
@@ -131,7 +132,7 @@ def read_associated(path, kwargs={}):
         Path to associated file.
     kwargs : dict
         Dictionary containing the ``pandas.read_csv()`` keyword arguments for the
-        associated (TXT) file (e.g. `{"delim_whitespace": True}`).
+        associated (TXT) file (e.g. `{"sep": "\s+"}`).
 
     Returns
     -------
@@ -263,10 +264,10 @@ def read(path, kwargs={}, assoc_kwargs={}):
         be combined in a single pd.DataFrame.
     kwargs : dict
         Dictionary containing the ``pandas.read_csv()`` keyword arguments for the
-        IPF files (e.g. `{"delim_whitespace": True}`)
+        IPF files (e.g. `{"sep": "\s+"}`)
     assoc_kwargs: dict
         Dictionary containing the ``pandas.read_csv()`` keyword arguments for the
-        associated (TXT) files (e.g. `{"delim_whitespace": True}`)
+        associated (TXT) files (e.g. `{"sep": "\s+"}`)
 
     Returns
     -------

--- a/imod/formats/ipf.py
+++ b/imod/formats/ipf.py
@@ -200,15 +200,16 @@ def read_associated(path, kwargs={}):
         line = f.readline()
         f.seek(position)
         delim_whitespace = _infer_delimwhitespace(line, ncol)
+        sep = "\s+" if delim_whitespace else ","
 
         itype_kwargs = {
-            "delim_whitespace": delim_whitespace,
             "header": None,
             "names": colnames,
             "usecols": usecols,
             "nrows": nrow,
             "na_values": na_values,
             "skipinitialspace": True,
+            "sep": sep,
         }
         if itype == 1:  # Timevariant information: timeseries
             # check if first column is time in [yyyymmdd] or [yyyymmddhhmmss]

--- a/imod/formats/ipf.py
+++ b/imod/formats/ipf.py
@@ -54,7 +54,7 @@ def _read_ipf(path, kwargs=None) -> Tuple[pd.DataFrame, int, str]:
         line = f.readline()
         delim_whitespace = _infer_delimwhitespace(line, ncol)
         f.seek(position)
-        sep = "\s+" if delim_whitespace else ","
+        sep = r"\s+" if delim_whitespace else ","
 
         ipf_kwargs = {
             "sep": sep,
@@ -164,6 +164,7 @@ def read_associated(path, kwargs={}):
         # https://github.com/pandas-dev/pandas/issues/19827#issuecomment-398649163
         lines = [f.readline() for _ in range(ncol)]
         delim_whitespace = _infer_delimwhitespace(lines[0], 2)
+        sep = r"\s+" if delim_whitespace else ","
         # Normally, this ought to work:
         # metadata = pd.read_csv(f, header=None, nrows=ncol).values
         # TODO: replace when bugfix is released
@@ -175,7 +176,7 @@ def read_associated(path, kwargs={}):
         # the challenge lies in replacing the pd.notnull for nodata values.
         # is otherwise quite a bit faster for such a header block.
         metadata_kwargs = {
-            "delim_whitespace": delim_whitespace,
+            "sep": sep,
             "header": None,
             "nrows": ncol,
             "skipinitialspace": True,
@@ -201,7 +202,7 @@ def read_associated(path, kwargs={}):
         line = f.readline()
         f.seek(position)
         delim_whitespace = _infer_delimwhitespace(line, ncol)
-        sep = "\s+" if delim_whitespace else ","
+        sep = r"\s+" if delim_whitespace else ","
 
         itype_kwargs = {
             "header": None,

--- a/imod/formats/ipf.py
+++ b/imod/formats/ipf.py
@@ -54,7 +54,7 @@ def _read_ipf(path, kwargs=None) -> Tuple[pd.DataFrame, int, str]:
         line = f.readline()
         delim_whitespace = _infer_delimwhitespace(line, ncol)
         f.seek(position)
-        sep='\s+' if delim_whitespace else ','
+        sep = "\s+" if delim_whitespace else ","
 
         ipf_kwargs = {
             "sep": sep,

--- a/imod/mf6/evt.py
+++ b/imod/mf6/evt.py
@@ -227,7 +227,7 @@ class Evapotranspiration(BoundaryCondition, IRegridPackage):
         options = super()._get_options(predefined_options, not_options=not_options)
         # Add amount of segments
         if "segment" in self.dataset.dims:
-            options["nseg"] = self.dataset.dims["segment"] + 1
+            options["nseg"] = self.dataset.sizes["segment"] + 1
         else:
             options["nseg"] = 1
         return options

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -400,7 +400,7 @@ def _prepare_barrier_dataset_for_mf6_adapter(dataset: xr.Dataset) -> xr.Dataset:
     # removes the layer as well.
     layer = dataset.coords["layer"].values
     # Drop leftover coordinate and reset cell_id.
-    dataset = dataset.drop_vars("edge_index").reset_coords()
+    dataset = dataset.drop_vars(("edge_index", "layer", "cell_id")).reset_coords()
     # Attach layer again
     dataset["layer"] = ("cell_id", layer)
     return dataset

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -951,8 +951,8 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
         ]
 
         return values.where(
-            (connected_cells_left.drop(face_dimension) > 0)
-            & (connected_cells_right.drop(face_dimension) > 0)
+            (connected_cells_left.drop_vars(face_dimension) > 0)
+            & (connected_cells_right.drop_vars(face_dimension) > 0)
         )
 
 

--- a/imod/mf6/multimodel/exchange_creator.py
+++ b/imod/mf6/multimodel/exchange_creator.py
@@ -293,8 +293,7 @@ class ExchangeCreator(abc.ABC):
         colnames = ["cell_idx1", "cell_idx2", "cell_label1", "cell_label2"]
         colnames_reversed = ["cell_idx2", "cell_idx1", "cell_label2", "cell_label1"]
 
-        decreasing_connections = df.loc[label_decreasing, colnames].values.astype(int)
-
+        decreasing_connections = df.loc[label_decreasing, colnames].values
         df.loc[label_decreasing, colnames_reversed] = decreasing_connections
 
         self._connected_cells = df

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -875,7 +875,7 @@ class Well(GridAgnosticWell):
         }
         super().__init__(dict_dataset)
         # Set index as coordinate
-        index_coord = np.arange(self.dataset.dims["index"])
+        index_coord = np.arange(self.dataset.sizes["index"])
         self.dataset = self.dataset.assign_coords(index=index_coord)
         self._validate_init_schemata(validate)
 
@@ -952,7 +952,7 @@ class Well(GridAgnosticWell):
 
         # Initiate array of True with right shape to deal with case no spatial
         # selection needs to be done.
-        in_bounds = np.full(ds.dims["index"], True)
+        in_bounds = np.full(ds.sizes["index"], True)
         # Select all variables along "index" dimension
         in_bounds &= values_within_range(ds["x"], x_min, x_max)
         in_bounds &= values_within_range(ds["y"], y_min, y_max)
@@ -1252,7 +1252,7 @@ class LayeredWell(GridAgnosticWell):
         }
         super().__init__(dict_dataset)
         # Set index as coordinate
-        index_coord = np.arange(self.dataset.dims["index"])
+        index_coord = np.arange(self.dataset.sizes["index"])
         self.dataset = self.dataset.assign_coords(index=index_coord)
         self._validate_init_schemata(validate)
 
@@ -1305,7 +1305,7 @@ class LayeredWell(GridAgnosticWell):
 
         # Initiate array of True with right shape to deal with case no spatial
         # selection needs to be done.
-        in_bounds = np.full(ds.dims["index"], True)
+        in_bounds = np.full(ds.sizes["index"], True)
         # Select all variables along "index" dimension
         in_bounds &= values_within_range(ds["x"], x_min, x_max)
         in_bounds &= values_within_range(ds["y"], y_min, y_max)

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -237,7 +237,7 @@ class GeometryTypeSchema(BaseSchema):
         if not all(is_geometry_type):
             is_wrong_type = ~np.array(is_geometry_type)
             wrong_type_index = np.argwhere(is_wrong_type).ravel()
-            wrong_types = [o.type for o in obj.data.ravel()[is_wrong_type]]
+            wrong_types = [o.geom_type for o in obj.data.ravel()[is_wrong_type]]
             raise ValidationError(
                 f"Geometry not of expected type '{self.dtype}'. "
                 f"Got wrong types for geometry number {wrong_type_index}, namely {wrong_types}"

--- a/imod/tests/test_formats/test_ipf.py
+++ b/imod/tests/test_formats/test_ipf.py
@@ -102,7 +102,7 @@ def test_read_associated__itype1implicit(tmp_path):
     delim = " "
     with open(path, "w") as f:
         f.write(assoc_string.format(delim=delim))
-    df = ipf.read_associated(path, {"delim_whitespace": True})
+    df = ipf.read_associated(path, {"sep": "\s+"})
     assert df.shape == (2, 2)
 
 
@@ -120,7 +120,7 @@ def test_read__comma(write_basic_ipf, tmp_path):
 def test_read__space(write_basic_ipf, tmp_path):
     path = tmp_path / "basic_space.ipf"
     write_basic_ipf(path, " ")
-    df = ipf.read(path, {"delim_whitespace": True})
+    df = ipf.read(path, {"sep": "\s+"})
     assert isinstance(df, pd.DataFrame)
     assert list(df) == ["X", "Y", "Z", "City of Holland"]
     assert len(df) == 2

--- a/imod/tests/test_formats/test_ipf.py
+++ b/imod/tests/test_formats/test_ipf.py
@@ -102,7 +102,7 @@ def test_read_associated__itype1implicit(tmp_path):
     delim = " "
     with open(path, "w") as f:
         f.write(assoc_string.format(delim=delim))
-    df = ipf.read_associated(path, {"sep": "\s+"})
+    df = ipf.read_associated(path, {"sep": r"\s+"})
     assert df.shape == (2, 2)
 
 
@@ -120,7 +120,7 @@ def test_read__comma(write_basic_ipf, tmp_path):
 def test_read__space(write_basic_ipf, tmp_path):
     path = tmp_path / "basic_space.ipf"
     write_basic_ipf(path, " ")
-    df = ipf.read(path, {"sep": "\s+"})
+    df = ipf.read(path, {"sep": r"\s+"})
     assert isinstance(df, pd.DataFrame)
     assert list(df) == ["X", "Y", "Z", "City of Holland"]
     assert len(df) == 2

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -603,7 +603,7 @@ def test_clip_box__well_stationary(
         ds = wel.clip_box(**clip_box_args).dataset
 
         # Assert
-        assert dict(ds.dims) == expected_dims
+        assert dict(ds.sizes) == expected_dims
 
 
 @pytest.mark.parametrize(
@@ -637,7 +637,7 @@ def test_clip_box__layered_well_stationary(
         ds = wel.clip_box(**clip_box_args).dataset
 
         # Assert
-        assert dict(ds.dims) == expected_dims
+        assert dict(ds.sizes) == expected_dims
 
 
 @pytest.mark.parametrize(
@@ -655,28 +655,28 @@ def test_clip_box__high_lvl_transient(
     # Act & Assert
     # Test clipping x & y without specified time
     ds = wel.clip_box(x_min=52.0, x_max=76.0, y_max=67.0).dataset
-    assert dict(ds.dims) == {"index": 3, "time": 5, "species": 2}
+    assert dict(ds.sizes) == {"index": 3, "time": 5, "species": 2}
 
     # Test clipping with z
     ds = wel.clip_box(layer_max=2, top=top, bottom=bottom).dataset
-    assert dict(ds.dims) == {"index": 4, "time": 5, "species": 2}
+    assert dict(ds.sizes) == {"index": 4, "time": 5, "species": 2}
     ds = wel.clip_box(layer_min=5, top=top, bottom=bottom).dataset
-    assert dict(ds.dims) == {"index": 4, "time": 5, "species": 2}
+    assert dict(ds.sizes) == {"index": 4, "time": 5, "species": 2}
 
     # Test clipping with specified time
     timestr = "2000-01-03"
     ds = wel.clip_box(time_min=timestr).dataset
-    assert dict(ds.dims) == {"index": 8, "time": 3, "species": 2}
+    assert dict(ds.sizes) == {"index": 8, "time": 3, "species": 2}
 
     # Test clipping with specified time and spatial dimensions
     timestr = "2000-01-03"
     ds = wel.clip_box(x_min=52.0, x_max=76.0, y_max=67.0, time_min=timestr).dataset
-    assert dict(ds.dims) == {"index": 3, "time": 3, "species": 2}
+    assert dict(ds.sizes) == {"index": 3, "time": 3, "species": 2}
 
     # Test clipping with specified time inbetween timesteps
     timestr = "2000-01-03 18:00:00"
     ds = wel.clip_box(x_min=52.0, x_max=76.0, y_max=67.0, time_min=timestr).dataset
-    assert dict(ds.dims) == {"index": 3, "time": 3, "species": 2}
+    assert dict(ds.sizes) == {"index": 3, "time": 3, "species": 2}
     ds_first_time = ds.isel(time=0)
     assert ds_first_time.coords["time"] == np.datetime64(timestr)
     np.testing.assert_allclose(ds_first_time["rate"].values, np.array([3.0, 3.0, 3.0]))

--- a/imod/tests/test_mf6/test_mf6_wel_lowlvl.py
+++ b/imod/tests/test_mf6/test_mf6_wel_lowlvl.py
@@ -185,7 +185,7 @@ def test_remove_inactive__stationary(basic_dis, mf6wel_test_data_stationary):
     ds_removed = imod.mf6.utilities.dataset.remove_inactive(ds, active)
 
     # Assert
-    assert dict(ds_removed.dims) == {"ncellid": 6, "dim_cellid": 3}
+    assert dict(ds_removed.sizes) == {"ncellid": 6, "dim_cellid": 3}
 
 
 def test_remove_inactive__transient(basic_dis, mf6wel_test_data_transient):
@@ -203,4 +203,4 @@ def test_remove_inactive__transient(basic_dis, mf6wel_test_data_transient):
     ds_removed = imod.mf6.utilities.dataset.remove_inactive(ds, active)
 
     # Assert
-    assert dict(ds_removed.dims) == {"ncellid": 6, "time": 5, "dim_cellid": 3}
+    assert dict(ds_removed.sizes) == {"ncellid": 6, "time": 5, "dim_cellid": 3}

--- a/imod/tests/test_msw/test_model.py
+++ b/imod/tests/test_msw/test_model.py
@@ -305,9 +305,9 @@ def test_import_from_imod5(
     assert not missing_keys
     for pkgname in grid_packages:
         # Test if all grid packages broadcasted to grid.
-        missing_dims = {"y", "x"} - set(model[pkgname].dataset.dims.keys())
+        missing_dims = {"y", "x"} - set(model[pkgname].dataset.sizes.keys())
         assert not missing_dims
-    assert "time" in model["time_oc"].dataset.dims.keys()
+    assert "time" in model["time_oc"].dataset.sizes.keys()
     assert len(model["meteo_grid"].dataset.dims) == 0
     assert ("scaling_factor" in model.keys()) == has_scaling_factor
 

--- a/imod/util/expand_repetitions.py
+++ b/imod/util/expand_repetitions.py
@@ -92,7 +92,7 @@ def resample_timeseries(
         how="outer",
         on="time",
         validate="m:m",
-    ).fillna(method="ffill")
+    ).ffill()
     # Catch case where multiple well rates precede first timestep on multiple
     # occasions, these have to be clipped to avoid including them in the
     # computation of weighted averages later in the function. We only want to

--- a/imod/visualize/spatial.py
+++ b/imod/visualize/spatial.py
@@ -45,7 +45,7 @@ def read_imod_legend(path):
     try:
         legend = _read(sep=",")
     except ValueError:
-        legend = _read(sep="\s+")
+        legend = _read(sep=r"\s+")
 
     # The colors in iMOD are formatted in RGB. Format to hexadecimal.
     red = legend["red"]

--- a/imod/visualize/spatial.py
+++ b/imod/visualize/spatial.py
@@ -31,11 +31,11 @@ def read_imod_legend(path):
     """
 
     # Read file. Do not rely the headers in the leg file.
-    def _read(delim_whitespace):
+    def _read(sep):
         return pd.read_csv(
             path,
             header=1,
-            delim_whitespace=delim_whitespace,
+            sep=sep,
             index_col=False,
             usecols=[0, 1, 2, 3, 4],
             names=["upper", "lower", "red", "green", "blue"],
@@ -43,9 +43,9 @@ def read_imod_legend(path):
 
     # Try both comma and whitespace separated
     try:
-        legend = _read(delim_whitespace=False)
+        legend = _read(sep=",")
     except ValueError:
-        legend = _read(delim_whitespace=True)
+        legend = _read(sep="\s+")
 
     # The colors in iMOD are formatted in RGB. Format to hexadecimal.
     red = legend["red"]


### PR DESCRIPTION
Fixes #1441

# Description
Fix a lot of DeprecationWarnings and FutureWarnings, which could overwhelm users. Things like:

```
..\mf6\wel.py:878: 16 warnings
imod/tests/test_mf6/test_mf6_simulation.py: 1 warning
  C:\src\imod-python\imod\mf6\wel.py:878: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
    index_coord = np.arange(self.dataset.dims["index"])

imod/tests/test_mf6/test_mf6_chd.py: 7826 warnings
imod/tests/test_mf6/test_mf6_simulation.py: 27391 warnings
  C:\src\imod-python\imod\formats\gen\gen.py:63: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\s+'`` instead
    coords_df = pd.read_csv(

imod/tests/test_mf6/test_mf6_chd.py: 6 warnings
imod/tests/test_mf6/test_mf6_simulation.py: 21 warnings
  C:\src\imod-python\imod\formats\ipf.py:66: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\s+'`` instead
    df = pd.read_csv(f, **ipf_kwargs)

imod/tests/test_mf6/test_mf6_chd.py: 6 warnings
imod/tests/test_mf6/test_mf6_simulation.py: 21 warnings
  C:\src\imod-python\imod\formats\ipf.py:183: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\s+'`` instead
    metadata = pd.read_csv(io.StringIO(lines), **metadata_kwargs)

imod/tests/test_mf6/test_mf6_chd.py: 6 warnings
imod/tests/test_mf6/test_mf6_simulation.py: 21 warnings
  C:\src\imod-python\imod\formats\ipf.py:230: FutureWarning: The 'delim_whitespace' keyword in pd.read_csv is deprecated and will be removed in a future version. Use ``sep='\s+'`` instead
    df = pd.read_csv(f, **itype_kwargs)

imod/tests/test_mf6/test_mf6_simulation.py: 15 warnings
  C:\src\imod-python\imod\util\expand_repetitions.py:95: FutureWarning: DataFrame.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.
    ).fillna(method="ffill")

imod/tests/test_mf6/test_mf6_simulation.py: 21 warnings
  C:\src\imod-python\imod\mf6\wel.py:1255: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
    index_coord = np.arange(self.dataset.dims["index"])

imod/tests/test_mf6/test_mf6_simulation.py: 72 warnings
  C:\src\imod-python\imod\mf6\hfb.py:954: DeprecationWarning: dropping variables using `drop` is deprecated; use drop_vars.
    (connected_cells_left.drop(face_dimension) > 0)

imod/tests/test_mf6/test_mf6_simulation.py: 72 warnings
  C:\src\imod-python\imod\mf6\hfb.py:955: DeprecationWarning: dropping variables using `drop` is deprecated; use drop_vars.
    & (connected_cells_right.drop(face_dimension) > 0)

imod/tests/test_mf6/test_mf6_simulation.py::test_import_from_imod5_no_storage_no_recharge
imod/tests/test_mf6/test_mf6_simulation.py::test_import_from_imod5__nonstandard_regridding
  C:\src\imod-python\imod\mf6\hfb.py:403: DeprecationWarning: Deleting a single level of a MultiIndex is deprecated. Previously, this deleted all levels of a MultiIndex. Please also drop the following variables: {'layer', 'cell_id'} to avoid an error in the future.
    dataset = dataset.drop_vars("edge_index").reset_coords()

imod/tests/test_mf6/test_mf6_simulation.py::test_import_from_imod5
  C:\src\imod-python\imod\mf6\hfb.py:403: DeprecationWarning: Deleting a single level of a MultiIndex is deprecated. Previously, this deleted all levels of a MultiIndex. Please also drop the following variables: {'cell_id', 'layer'} to avoid an error in the future.
    dataset = dataset.drop_vars("edge_index").reset_coords()
```


# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
