### PR TITLE
Add sonarcloud python information

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,4 @@
 sonar.projectKey=Deltares_imod-python
 sonar.organization=deltares
 sonar.exclusions=examples/**/*, imod/tests/**/*
+sonar.python.version=3.10, 3.11, 3.12, 3.13


### PR DESCRIPTION
Like in pyproject.toml, support 3.10 and up.
I don't know if this will change the quality gates, but it seems to be something that can be set, so let's try it out.