### PR TITLE
Issue #1437 fix recharge from imod5 cap data 2d

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -91,6 +91,9 @@ Fixed
   like MetaSWAP expects.
 - Models imported with :meth:`imod.msw.MetaSwapModel.from_imod5_data` can be
   written with ``validate`` set to True.
+- :meth:`imod.mf6.Recharge.from_imod5_cap_data` now returns a 2D array with a
+  ``"layer"`` coordinate of ``1`` as otherwise ``primod`` throws an error when
+  trying to derive recharge-svat mappings.
 
 
 [1.0.0rc1] - 2024-12-20

--- a/imod/mf6/rch.py
+++ b/imod/mf6/rch.py
@@ -279,11 +279,8 @@ class Recharge(BoundaryCondition, IRegridPackage):
         active = msw_active.all
 
         data = {}
-        layer_da = xr.full_like(
-            target_dis.dataset.coords["layer"], np.nan, dtype=np.float64
-        )
-        layer_da.loc[{"layer": 1}] = 0.0
-        data["rate"] = layer_da.where(active)
+        zero_scalar = xr.DataArray(0.0, coords={"layer": 1})
+        data["rate"] = zero_scalar.where(active)
 
         return cls(**data, validate=True, fixed_cell=False)
 

--- a/imod/tests/test_mf6/test_mf6_rch.py
+++ b/imod/tests/test_mf6/test_mf6_rch.py
@@ -477,8 +477,8 @@ def test_from_imod5_cap_data(imod5_dataset):
     # Assert
     np.testing.assert_array_equal(np.unique(rate), np.array([0.0, np.nan]))
     # Boundaries inactive in MetaSWAP
-    assert np.isnan(rate[0, :, 0]).all()
-    assert np.isnan(rate[0, :, -1]).all()
-    assert np.isnan(rate[0, 0, :]).all()
-    assert np.isnan(rate[0, -1, :]).all()
-    assert np.isnan(rate[:, 100, 100]).all()
+    assert np.isnan(rate[:, 0]).all()
+    assert np.isnan(rate[:, -1]).all()
+    assert np.isnan(rate[0, :]).all()
+    assert np.isnan(rate[-1, :]).all()
+    assert np.isnan(rate[100, 100]).all()

--- a/imod/tests/test_mf6/test_mf6_rch.py
+++ b/imod/tests/test_mf6/test_mf6_rch.py
@@ -10,10 +10,11 @@ import xarray as xr
 
 import imod
 from imod.mf6.dis import StructuredDiscretization
+from imod.mf6.utilities.regrid import RegridderWeightsCache
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.typing.grid import is_planar_grid, is_transient_data_grid, nan_like
-from imod.mf6.utilities.regrid import RegridderWeightsCache
+
 
 @pytest.fixture(scope="function")
 def rch_dict():
@@ -502,7 +503,7 @@ def test_from_imod5_cap_data__regrid(imod5_dataset):
     like = imod.util.empty_2d(*expected_spatial_ref)
     # Act
     rch = imod.mf6.Recharge.from_imod5_cap_data(data, target_discretization)
-    rch_coarse = rch.regrid_like(like, regrid_cache = RegridderWeightsCache())
+    rch_coarse = rch.regrid_like(like, regrid_cache=RegridderWeightsCache())
     # Assert
     actual_spatial_ref = imod.util.spatial_reference(rch_coarse.dataset["rate"])
     assert actual_spatial_ref == expected_spatial_ref
@@ -521,11 +522,10 @@ def test_from_imod5_cap_data__clip_box(imod5_dataset):
     # Setup template grid
     dx, xmin, xmax, dy, ymin, ymax = imod.util.spatial_reference(msw_bound)
     xmin_to_clip = xmin + 10 * dx
-    expected_spatial_ref = dx, xmin_to_clip, xmax, dy, ymin, ymax 
+    expected_spatial_ref = dx, xmin_to_clip, xmax, dy, ymin, ymax
     # Act
     rch = imod.mf6.Recharge.from_imod5_cap_data(data, target_discretization)
-    rch_clipped = rch.clip_box(x_min = xmin_to_clip)
+    rch_clipped = rch.clip_box(x_min=xmin_to_clip)
     # Assert
     actual_spatial_ref = imod.util.spatial_reference(rch_clipped.dataset["rate"])
     assert actual_spatial_ref == expected_spatial_ref
-


### PR DESCRIPTION
Fixes #1437 

# Description
``primod`` expects a 2D rate array or single layer array for the dummy MODFLOW6 package, as otherwise the ``squeeze("layer")`` it does returns an error. I think the safest for iMOD Python is to return a 2D array with extra layer coordinate. I added some extra tests to test if this RCH package could be clipped and regridded, as in most/all fixtures for clipping/regridding I added packages with layer dimension. Luckily these two extra tests turned out to be mostly for my own peace of mind, as they ran without problems.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
