### PR TITLE
Issue #1436 work around dask issue

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -93,10 +93,13 @@ Fixed
   written with ``validate`` set to True.
 - Fixed part of the code that made Pandas, Geopandas, and xarray throw a lot of
   ``FutureWarning``s and ``DeprecationWarning``s.
-- Fixed performance issue when coverting very large wells (>10k) with
+- Fixed performance issue when converting very large wells (>10k) with
   :meth:`imod.mf6.Well.to_mf6_pkg` and :meth:`imod.mf6.LayeredWell.to_mf6_pkg`,
   such as those created with :meth:`imod.mf6.LayeredWell.from_imod5_cap_data`
   for a large grid.
+- Fixed issue where an error was thrown when deriving couplings for
+  :class:`imod.msw.CouplerMapping` and computing svats in
+  :class:`imod.msw.GridData` with ``dask>=2025.2.0``.
 
 
 [1.0.0rc1] - 2024-12-20

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -115,6 +115,9 @@ class CouplerMapping(MetaSwapPackage):
         well_row = well_cellid.sel(dim_cellid="row").data - 1
         well_column = well_cellid.sel(dim_cellid="column").data - 1
 
+        # Load into memory to avoid dask issue
+        # https://github.com/dask/dask/issues/11753
+        idomain_active.load()
         n_mod = idomain_active.sum()
         mod_id = xr.full_like(idomain_active, 0, dtype=np.int64)
         mod_id.data[idomain_active.data] = np.arange(1, n_mod + 1)

--- a/imod/msw/grid_data.py
+++ b/imod/msw/grid_data.py
@@ -91,11 +91,14 @@ class GridData(MetaSwapPackage, IRegridPackage):
         active = self.dataset["active"]
 
         isactive = area.where(active).notnull()
-
-        index = isactive.values.ravel()
-
         svat = xr.full_like(area, fill_value=0, dtype=np.int64).rename("svat")
-        svat.values[isactive.values] = np.arange(1, index.sum() + 1)
+        # Load into memory to avoid dask issue
+        # https://github.com/dask/dask/issues/11753
+        isactive.load()
+        svat.load()
+        
+        index = isactive.values.ravel()
+        svat.data[isactive.data] = np.arange(1, index.sum() + 1)
 
         return index, svat
 

--- a/imod/msw/grid_data.py
+++ b/imod/msw/grid_data.py
@@ -96,7 +96,7 @@ class GridData(MetaSwapPackage, IRegridPackage):
         # https://github.com/dask/dask/issues/11753
         isactive.load()
         svat.load()
-        
+
         index = isactive.values.ravel()
         svat.data[isactive.data] = np.arange(1, index.sum() + 1)
 

--- a/imod/tests/test_msw/test_coupler_mapping.py
+++ b/imod/tests/test_msw/test_coupler_mapping.py
@@ -1,11 +1,10 @@
 import tempfile
 from pathlib import Path
-import pytest
-from pytest_cases import parametrize_with_cases
 
 import numpy as np
 import xarray as xr
 from numpy.testing import assert_equal
+from pytest_cases import parametrize_with_cases
 
 from imod import mf6, msw
 from imod.mf6.mf6_wel_adapter import Mf6Wel
@@ -37,6 +36,7 @@ def case_svat_data():
     # fmt: on
     return svat
 
+
 def case_svat_data__dask():
     return case_svat_data().chunk({"x": 3, "y": 3, "subunit": 1})
 
@@ -51,14 +51,15 @@ def get_mf6_wel(svat_data):
 
 
 def get_mf6_dis(svat_data):
-    like = xr.full_like(svat_data.isel(subunit=0, drop=True), 1.0, dtype=float).expand_dims(
-        layer=[1, 2, 3]
-    )
+    like = xr.full_like(
+        svat_data.isel(subunit=0, drop=True), 1.0, dtype=float
+    ).expand_dims(layer=[1, 2, 3])
     return mf6.StructuredDiscretization(
         top=1.0,
         bottom=xr.full_like(like, 0.0),
         idomain=xr.full_like(like, 1, dtype=np.int32),
     )
+
 
 def get_index(svat_data):
     return (svat_data != 0).data.ravel()
@@ -92,7 +93,7 @@ def test_simple_model_with_sprinkling_1_subunit(fixed_format_parser, svat_data):
     index = get_index(svat_data)
     mf6_dis = get_mf6_dis(svat_data)
     mf6_wel = get_mf6_wel(svat_data)
-    #mf6_wel.dataset = mf6_wel.dataset.sel()
+    # mf6_wel.dataset = mf6_wel.dataset.sel()
 
     coupler_mapping = msw.CouplerMapping()
 

--- a/imod/tests/test_msw/test_coupler_mapping.py
+++ b/imod/tests/test_msw/test_coupler_mapping.py
@@ -93,7 +93,6 @@ def test_simple_model_with_sprinkling_1_subunit(fixed_format_parser, svat_data):
     index = get_index(svat_data)
     mf6_dis = get_mf6_dis(svat_data)
     mf6_wel = get_mf6_wel(svat_data)
-    # mf6_wel.dataset = mf6_wel.dataset.sel()
 
     coupler_mapping = msw.CouplerMapping()
 
@@ -106,9 +105,9 @@ def test_simple_model_with_sprinkling_1_subunit(fixed_format_parser, svat_data):
             msw.CouplerMapping._metadata_dict,
         )
 
-    assert_equal(results["mod_id"], np.array([20, 17, 2, 8]))
+    assert_equal(results["mod_id"], np.array([20, 8, 2, 8]))
     assert_equal(results["svat"], np.array([1, 2, 1, 2]))
-    assert_equal(results["layer"], np.array([3, 2, 1, 1]))
+    assert_equal(results["layer"], np.array([3, 1, 1, 1]))
 
 
 @parametrize_with_cases("svat_data", cases=[case_svat_data, case_svat_data__dask])

--- a/imod/tests/test_msw/test_grid_data.py
+++ b/imod/tests/test_msw/test_grid_data.py
@@ -281,6 +281,15 @@ def case_grid_data_two_subunits(
     # fmt: on
     return data
 
+@case(tags="two_subunit")
+def case_grid_data_two_subunits__dask(
+    coords_two_subunit: dict, coords_planar: dict
+) -> dict[str, xr.DataArray]:
+    data = case_grid_data_two_subunits(coords_two_subunit, coords_planar)
+    for key, values in data.items():
+        data[key] = values.chunk({"x": 3, "y": 1})
+    return data
+
 
 @parametrize_with_cases("grid_data_dict", cases=".", has_tag="two_subunit")
 def test_generate_index_array(

--- a/imod/tests/test_msw/test_grid_data.py
+++ b/imod/tests/test_msw/test_grid_data.py
@@ -281,6 +281,7 @@ def case_grid_data_two_subunits(
     # fmt: on
     return data
 
+
 @case(tags="two_subunit")
 def case_grid_data_two_subunits__dask(
     coords_two_subunit: dict, coords_planar: dict


### PR DESCRIPTION
Fixes #1436 

# Description
Work around Dask issue by forcing a load of idomain and svat into memory. These grids will never be as large as the boundary condition grids with a time axis, so I think it is acceptable. At least for the LHM it is. I couldn't get it to work with a ``where``: numpy only accepts 1D arrays on a boolean indexed 3D as long as the 1D array has the length of one of the dimensions, it then does what we want to do here. However when this is not the case, which is 95% of the time, numpy throws an error. I therefore had to resort to loading arrays into memory.

Furthermore I refactored ``test_coupler_mapping.py`` to be able to reduce some code duplication and add a test case with a dask array.

Furthermore

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
