### PR TITLE
Issue #1133 Remove mention of the imod.idf.write function

### DIFF
--- a/imod/formats/idf.py
+++ b/imod/formats/idf.py
@@ -554,10 +554,10 @@ def save(path, a, nodata=1.0e20, pattern=None, dtype=np.float32):
     Write a xarray.DataArray to one or more IDF files
 
     If the DataArray only has ``y`` and ``x`` dimensions, a single IDF file is
-    written, like the ``imod.idf.write`` function. This function is more general
-    and also supports ``time`` and ``layer`` dimensions. It will split these up,
-    give them their own filename according to the conventions in
-    ``imod.util.path.compose``, and write them each.
+    written. This function is more general and also supports ``time`` and
+    ``layer`` dimensions. It will split these up, give them their own filename
+    according to the conventions in ``imod.util.path.compose``, and write them
+    each.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixes #1133

# Description
Remove mention of the ``imod.idf.write`` function, which is not really part of the public API. ``imod.idf.save`` pretty much covers everything for a user.

# Checklist
- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
