### PR TITLE
#1480 Disable pulling the docker image team a build is started

### DIFF
--- a/.teamcity/Deploy/DeployProject.kt
+++ b/.teamcity/Deploy/DeployProject.kt
@@ -51,7 +51,7 @@ object BuildPackage : BuildType({
             dockerImage = "%DockerContainer%:%DockerVersion%"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
             dockerRunParameters = """--cpus=4 --memory=16g"""
-            dockerPull = true
+            dockerPull = false
         }
     }
 
@@ -94,7 +94,7 @@ object BuildPages : BuildType({
             dockerImage = "%DockerContainer%:%DockerVersion%"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
             dockerRunParameters = """--cpus=8 --memory=32g"""
-            dockerPull = true
+            dockerPull = false
         }
     }
 
@@ -170,7 +170,7 @@ object CreateGitHubRelease : BuildType({
                 """.trimIndent()
             }
             param("plugin.docker.imagePlatform", "windows")
-            param("plugin.docker.pull.enabled", "true")
+            param("plugin.docker.pull.enabled", "false")
             param("plugin.docker.imageId", "%DockerContainer%:%DockerVersion%")
             param("plugin.docker.run.parameters", "--cpus=4 --memory=16g")
         }
@@ -221,7 +221,7 @@ object DeployPackage : BuildType({
             dockerImage = "%DockerContainer%:%DockerVersion%"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
             dockerRunParameters = """--cpus=4 --memory=16g"""
-            dockerPull = true
+            dockerPull = false
         }
     }
 
@@ -305,7 +305,7 @@ object DeployPages : BuildType({
             dockerImage = "%DockerContainer%:%DockerVersion%"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
             dockerRunParameters = """--cpus=4 --memory=16g"""
-            dockerPull = true
+            dockerPull = false
         }
     }
 

--- a/.teamcity/Pixi/PixiProject.kt
+++ b/.teamcity/Pixi/PixiProject.kt
@@ -74,7 +74,7 @@ object UpdateDependencies : BuildType({
             }
             noProfile = false
             param("plugin.docker.imagePlatform", "windows")
-            param("plugin.docker.pull.enabled", "true")
+            param("plugin.docker.pull.enabled", "false")
             param("plugin.docker.imageId", "%DockerContainer%:%DockerVersion%")
             param("plugin.docker.run.parameters", "--cpus=4 --memory=16g")
         }

--- a/.teamcity/Templates/ExamplesTemplate.kt
+++ b/.teamcity/Templates/ExamplesTemplate.kt
@@ -34,7 +34,7 @@ object ExamplesTemplate : Template({
             dockerImage = "%DockerContainer%:%DockerVersion%"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
             dockerRunParameters = """--cpus=8 --memory=32g"""
-            dockerPull = true
+            dockerPull = false
         }
     }
 

--- a/.teamcity/Templates/LintTemplate.kt
+++ b/.teamcity/Templates/LintTemplate.kt
@@ -29,7 +29,7 @@ object LintTemplate : Template({
             dockerImage = "%DockerContainer%:%DockerVersion%"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
             dockerRunParameters = """--cpus=4 --memory=16g"""
-            dockerPull = true
+            dockerPull = false
         }
     }
 

--- a/.teamcity/Templates/MyPyTemplate.kt
+++ b/.teamcity/Templates/MyPyTemplate.kt
@@ -34,7 +34,7 @@ object MyPyTemplate : Template({
             dockerImage = "%DockerContainer%:%DockerVersion%"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
             dockerRunParameters = """--cpus=4 --memory=16g"""
-            dockerPull = true
+            dockerPull = false
         }
     }
 

--- a/.teamcity/Templates/PipPythonTemplate.kt
+++ b/.teamcity/Templates/PipPythonTemplate.kt
@@ -30,7 +30,7 @@ object PipPythonTemplate : Template({
             dockerImage = "%DockerContainer%:%DockerVersion%"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
             dockerRunParameters = """--cpus=4 --memory=16g"""
-            dockerPull = true
+            dockerPull = false
         }
     }
 

--- a/.teamcity/Templates/UnitTestsTemplate.kt
+++ b/.teamcity/Templates/UnitTestsTemplate.kt
@@ -37,7 +37,7 @@ object UnitTestsTemplate : Template({
             dockerImage = "%DockerContainer%:%DockerVersion%"
             dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
             dockerRunParameters = """--cpus=8 --memory=32g"""
-            dockerPull = true
+            dockerPull = false
         }
         powerShell {
             name = "Extract coverage statistics"
@@ -59,7 +59,7 @@ object UnitTestsTemplate : Template({
             }
             param("plugin.docker.imagePlatform", "windows")
             param("plugin.docker.imageId", "%DockerContainer%:%DockerVersion%")
-            param("plugin.docker.pull.enabled", "true")
+            param("plugin.docker.pull.enabled", "false")
         }
     }
 


### PR DESCRIPTION
Fixes #1480

# Description
We are experiencing flaky builds on the TeamCity build server.

A theory is that the builds are failing due to pull collisions when the docker images are pulled at the start of a build.
By disabling the 'explicit pull' option this might happen less frequent

With this change an image will only be pulled when its not present on the agent. If the image is overwritten on the registry the old image has to be manually removed from the agents
# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
