### PR TITLE
Quell xugrid warnings

### DIFF
--- a/imod/common/utilities/value_filters.py
+++ b/imod/common/utilities/value_filters.py
@@ -35,3 +35,10 @@ def is_empty_dataarray(da: Any) -> bool:
 def get_scalar_variables(ds: GridDataset) -> list[str]:
     """Returns scalar variables in a dataset."""
     return [var for var, arr in ds.variables.items() if is_scalar(arr)]
+
+
+def enforce_scalar(a: np.ndarray) -> np.ndarray:
+    """Enforce scalar value from array."""
+    if a.size == 1:
+        return a.item()
+    return ValueError(f"Array has size {a.size}, expected size 1.")

--- a/imod/formats/array_io/reading.py
+++ b/imod/formats/array_io/reading.py
@@ -7,6 +7,7 @@ import dask
 import numpy as np
 import xarray as xr
 
+from imod.common.utilities.value_filters import enforce_scalar
 from imod.util import nested_dict, spatial, time
 
 
@@ -107,20 +108,14 @@ def _array_z_coord(coords, tops, bots, unique_indices):
     return coords
 
 
-def _enforce_scalar(a):
-    if a.ndim > 0:
-        return a[0]
-    return a
-
-
 def _scalar_z_coord(coords, tops, bots):
     # They must be all the same to be used, as they cannot be assigned
     # to layer.
     top = np.unique(tops)
     bot = np.unique(bots)
     if top.size == bot.size == 1:
-        top = _enforce_scalar(top)
-        bot = _enforce_scalar(bot)
+        top = enforce_scalar(top)
+        bot = enforce_scalar(bot)
         dz = top - bot
         z = top - 0.5 * dz
         coords["dz"] = float(dz)  # cast from array

--- a/imod/formats/array_io/reading.py
+++ b/imod/formats/array_io/reading.py
@@ -107,12 +107,20 @@ def _array_z_coord(coords, tops, bots, unique_indices):
     return coords
 
 
+def _enforce_scalar(a):
+    if a.ndim > 0:
+        return a[0]
+    return a
+
+
 def _scalar_z_coord(coords, tops, bots):
     # They must be all the same to be used, as they cannot be assigned
     # to layer.
     top = np.unique(tops)
     bot = np.unique(bots)
     if top.size == bot.size == 1:
+        top = _enforce_scalar(top)
+        bot = _enforce_scalar(bot)
         dz = top - bot
         z = top - 0.5 * dz
         coords["dz"] = float(dz)  # cast from array

--- a/imod/mf6/drn.py
+++ b/imod/mf6/drn.py
@@ -14,6 +14,7 @@ from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.disv import VerticesDiscretization
 from imod.mf6.npf import NodePropertyFlow
 from imod.mf6.regrid.regrid_schemes import DrainageRegridMethod
+from imod.mf6.utilities.package import get_repeat_stress
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA, CONC_DIMS_SCHEMA
 from imod.prepare.cleanup import cleanup_drn
 from imod.prepare.topsystem.allocation import ALLOCATION_OPTION, allocate_drn_cells
@@ -341,7 +342,8 @@ class Drainage(BoundaryCondition, IRegridPackage):
         drn = Drainage(**regridded_package_data, validate=True)
         repeat = period_data.get(key)
         if repeat is not None:
-            drn.set_repeat_stress(expand_repetitions(repeat, time_min, time_max))
+            times = expand_repetitions(repeat, time_min, time_max)
+            drn.dataset["repeat_stress"] = get_repeat_stress(times)
         return drn
 
     @classmethod

--- a/imod/mf6/ghb.py
+++ b/imod/mf6/ghb.py
@@ -15,6 +15,7 @@ from imod.mf6.npf import NodePropertyFlow
 from imod.mf6.regrid.regrid_schemes import (
     GeneralHeadBoundaryRegridMethod,
 )
+from imod.mf6.utilities.package import get_repeat_stress
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA, CONC_DIMS_SCHEMA
 from imod.prepare.cleanup import cleanup_ghb
 from imod.prepare.topsystem.allocation import ALLOCATION_OPTION, allocate_ghb_cells
@@ -341,7 +342,8 @@ class GeneralHeadBoundary(BoundaryCondition, IRegridPackage):
         ghb = GeneralHeadBoundary(**regridded_package_data, validate=True)
         repeat = period_data.get(key)
         if repeat is not None:
-            ghb.set_repeat_stress(expand_repetitions(repeat, time_min, time_max))
+            times = expand_repetitions(repeat, time_min, time_max)
+            ghb.dataset["repeat_stress"] = get_repeat_stress(times)
         return ghb
 
     @classmethod

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -14,6 +14,7 @@ from imod.mf6.drn import Drainage
 from imod.mf6.npf import NodePropertyFlow
 from imod.mf6.regrid.regrid_schemes import RiverRegridMethod
 from imod.mf6.utilities.imod5_converter import regrid_imod5_pkg_data
+from imod.mf6.utilities.package import get_repeat_stress
 from imod.mf6.validation import BOUNDARY_DIMS_SCHEMA, CONC_DIMS_SCHEMA
 from imod.prepare.cleanup import AlignLevelsMode, align_interface_levels, cleanup_riv
 from imod.prepare.topsystem.allocation import ALLOCATION_OPTION, allocate_riv_cells
@@ -57,9 +58,8 @@ def set_repeat_stress_if_available(
     """Set repeat stress for optional package if repeat is not None."""
     if repeat is not None:
         if optional_package is not None:
-            optional_package.set_repeat_stress(
-                expand_repetitions(repeat, time_min, time_max)
-            )
+            times = expand_repetitions(repeat, time_min, time_max)
+            optional_package.dataset["repeat_stress"] = get_repeat_stress(times)
 
 
 def mask_package__drop_if_empty(

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -8,6 +8,7 @@ import jinja2
 import numpy as np
 import xarray as xr
 
+from imod.common.utilities.value_filters import enforce_scalar
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.mf6_wel_adapter import Mf6Wel
 from imod.msw.copy_files import FileCopier
@@ -213,8 +214,8 @@ class MetaSwapModel(Model):
 
         year, time_since_start_year = to_metaswap_timeformat([starttime])
 
-        year = int(year.values)
-        time_since_start_year = float(time_since_start_year.values)
+        year = int(enforce_scalar(year.values))
+        time_since_start_year = float(enforce_scalar(time_since_start_year.values))
 
         return year, time_since_start_year
 

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -299,7 +299,7 @@ class EmptyIndexesSchema(BaseSchema):
         # Remove face dim from list to validate, as it has no ``indexes``
         # attribute.
         if isinstance(obj, xu.UgridDataArray):
-            ugrid_dims = obj.ugrid.grid.dimensions
+            ugrid_dims = obj.ugrid.grid.sizes.keys()
             dims_to_validate = [
                 dim for dim in dims_to_validate if dim not in ugrid_dims
             ]

--- a/imod/tests/fixtures/flow_basic_unstructured_fixture.py
+++ b/imod/tests/fixtures/flow_basic_unstructured_fixture.py
@@ -9,7 +9,7 @@ import imod
 @pytest.fixture(scope="function")
 def basic_unstructured_dis(basic_dis):
     idomain, top, bottom = basic_dis
-    idomain_ugrid = xu.UgridDataArray.from_structured(idomain)
+    idomain_ugrid = xu.UgridDataArray.from_structured2d(idomain)
     top_mf6 = top.sel(layer=1)  # Top for modlfow 6 shouldn't contain layer dim
 
     return idomain_ugrid, top_mf6, bottom
@@ -18,7 +18,7 @@ def basic_unstructured_dis(basic_dis):
 @pytest.fixture(scope="function")
 def basic_disv__topsystem(basic_dis__topsystem):
     ibound, top, bottom = basic_dis__topsystem
-    idomain_ugrid = xu.UgridDataArray.from_structured(ibound)
+    idomain_ugrid = xu.UgridDataArray.from_structured2d(ibound)
 
     return idomain_ugrid, top, bottom
 

--- a/imod/tests/fixtures/mf6_circle_fixture.py
+++ b/imod/tests/fixtures/mf6_circle_fixture.py
@@ -167,7 +167,6 @@ def circle_model():
     return make_circle_model()
 
 
-@pytest.mark.usefixtures("circle_model")
 @pytest.fixture(scope="session")
 def circle_result(tmpdir_factory):
     # Using a tmpdir_factory is the canonical way of sharing a tempory pytest
@@ -218,7 +217,6 @@ def circle_model_evt():
     return make_circle_model_evt()
 
 
-@pytest.mark.usefixtures("circle_model_evt")
 @pytest.fixture(scope="session")
 def circle_result_evt(tmpdir_factory):
     # Using a tmpdir_factory is the canonical way of sharing a tempory pytest
@@ -252,7 +250,6 @@ def circle_result_sto(tmpdir_factory):
     return modeldir
 
 
-@pytest.mark.usefixtures("circle_model_evt")
 @pytest.fixture(scope="function")
 def circle_partitioned():
     simulation = make_circle_model_evt()

--- a/imod/tests/fixtures/mf6_flow_with_transport_fixture.py
+++ b/imod/tests/fixtures/mf6_flow_with_transport_fixture.py
@@ -173,7 +173,6 @@ def sp2_fc():
 
 
 @pytest.fixture(scope="function")
-@pytest.mark.usefixtures("concentration_fc")
 def flow_model_with_concentration(concentration_fc):
     idomain = get_data_array(grid_dimensions(), globaltimes)
     cellType = xr.full_like(idomain.isel(time=0), 1, dtype=np.int32)

--- a/imod/tests/fixtures/mf6_small_models_fixture.py
+++ b/imod/tests/fixtures/mf6_small_models_fixture.py
@@ -56,7 +56,7 @@ def grid_data_unstructured(
     This function creates a dataarray with scalar values for a grid of configurable cell size.
     First a regular grid is constructed and then this is converted to an ugrid dataarray.
     """
-    return xu.UgridDataArray.from_structured(
+    return xu.UgridDataArray.from_structured2d(
         grid_data_structured(dtype, value, cellsize)
     )
 
@@ -68,7 +68,7 @@ def grid_data_unstructured_layered(
     This function creates a dataarray with scalar values for a grid of configurable cell size. The values are
     multiplied with the layer index. First a regular grid is constructed and then this is converted to an ugrid dataarray.
     """
-    return xu.UgridDataArray.from_structured(
+    return xu.UgridDataArray.from_structured2d(
         grid_data_structured_layered(dtype, value, cellsize)
     )
 

--- a/imod/tests/fixtures/mf6_twri_fixture.py
+++ b/imod/tests/fixtures/mf6_twri_fixture.py
@@ -287,7 +287,6 @@ def transient_unconfined_twri_model():
     return simulation
 
 
-@pytest.mark.usefixtures("twri_model")
 @pytest.fixture(scope="function")
 def twri_result(tmpdir_factory):
     # Using a tmpdir_factory is the canonical way of sharing a tempory pytest
@@ -345,7 +344,6 @@ def twri_result_9_drn_in_1_cell(tmpdir_factory):
     return modeldir
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @pytest.fixture(scope="function")
 def transient_twri_result(tmpdir_factory, transient_twri_model):
     # Using a tmpdir_factory is the canonical way of sharing a tempory pytest
@@ -357,7 +355,6 @@ def transient_twri_result(tmpdir_factory, transient_twri_model):
     return modeldir
 
 
-@pytest.mark.usefixtures("transient_unconfined_twri_model")
 @pytest.fixture(scope="function")
 def transient_unconfined_twri_result(tmpdir_factory, transient_unconfined_twri_model):
     # Using a tmpdir_factory is the canonical way of sharing a tempory pytest
@@ -369,7 +366,6 @@ def transient_unconfined_twri_result(tmpdir_factory, transient_unconfined_twri_m
     return modeldir
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @pytest.fixture(scope="function")
 def split_transient_twri_model(transient_twri_model):
     active = transient_twri_model["GWF_1"].domain.sel(layer=1)

--- a/imod/tests/test_common/test_utilities/test_clip.py
+++ b/imod/tests/test_common/test_utilities/test_clip.py
@@ -147,7 +147,7 @@ def test_clip_by_grid_with_line_data_package__unstructured(
     # Arrange
     idomain, _, _ = basic_dis
     active = idomain.sel(layer=1, drop=True)
-    active_uda = xu.UgridDataArray.from_structured(active)
+    active_uda = xu.UgridDataArray.from_structured2d(active)
 
     # Act
     hfb_clipped = clip_by_grid(horizontal_flow_barrier, active_uda)
@@ -212,7 +212,7 @@ def test_clip_by_grid__unstructured_grid_full(
     idomain, _, _ = basic_dis
     active = idomain.sel(layer=1, drop=True)
     wel = imod.mf6.Well(*well_high_lvl_test_data_stationary, print_flows=True)
-    active_ugrid = xu.UgridDataArray.from_structured(active)
+    active_ugrid = xu.UgridDataArray.from_structured2d(active)
 
     # Act
     wel_clipped = clip_by_grid(wel, active_ugrid)
@@ -234,7 +234,7 @@ def test_clip_by_grid__unstructured_grid_clipped(
     wel = imod.mf6.Well(*well_high_lvl_test_data_stationary, print_flows=True)
     # Clip grid so that xmax is set to 70.0 instead of 90.0
     active_selected = active.sel(x=slice(None, 70.0))
-    active_ugrid = xu.UgridDataArray.from_structured(active_selected)
+    active_ugrid = xu.UgridDataArray.from_structured2d(active_selected)
 
     # Act
     wel_clipped = clip_by_grid(wel, active_ugrid)

--- a/imod/tests/test_mf6/test_circle.py
+++ b/imod/tests/test_mf6/test_circle.py
@@ -13,7 +13,6 @@ from imod.mf6.validation_context import ValidationContext
 from imod.mf6.write_context import WriteContext
 
 
-@pytest.mark.usefixtures("circle_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_simulation_write_and_run(circle_model, tmp_path):
     imod.logging.configure(
@@ -53,7 +52,6 @@ def test_simulation_write_and_run(circle_model, tmp_path):
     assert head.shape == (52, 2, 216)
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_gwfmodel_render(circle_model, tmp_path):
     simulation = circle_model
     globaltimes = simulation["time_discretization"]["time"].values
@@ -85,7 +83,6 @@ def test_gwfmodel_render(circle_model, tmp_path):
     assert (tmp_path / "GWF_1").is_dir()
 
 
-@pytest.mark.usefixtures("circle_model_evt")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_simulation_write_and_run_evt(circle_model_evt, tmp_path):
     simulation = circle_model_evt
@@ -107,7 +104,6 @@ def test_simulation_write_and_run_evt(circle_model_evt, tmp_path):
     assert head.shape == (52, 2, 216)
 
 
-@pytest.mark.usefixtures("circle_model_evt")
 def test_gwfmodel_render_evt(circle_model_evt, tmp_path):
     simulation = circle_model_evt
     globaltimes = simulation["time_discretization"]["time"].values

--- a/imod/tests/test_mf6/test_ex01_twri.py
+++ b/imod/tests/test_mf6/test_ex01_twri.py
@@ -14,7 +14,6 @@ from imod.schemata import ValidationError
 from imod.typing.grid import ones_like
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_dis_render(twri_model, tmp_path):
     simulation = twri_model
     dis = simulation["GWF_1"]["dis"]
@@ -63,7 +62,6 @@ def test_dis_render(twri_model, tmp_path):
     assert (tmp_path / "dis" / "idomain.bin").is_file()
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_chd_render(twri_model, tmp_path):
     simulation = twri_model
     globaltimes = simulation["time_discretization"]["time"].values
@@ -100,7 +98,6 @@ def test_chd_render(twri_model, tmp_path):
     assert (tmp_path / "chd" / "chd.bin").is_file()
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_drn_render(twri_model, tmp_path):
     simulation = twri_model
     globaltimes = simulation["time_discretization"]["time"].values
@@ -137,7 +134,6 @@ def test_drn_render(twri_model, tmp_path):
     assert (tmp_path / "drn" / "drn.bin").is_file()
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_ic_render(twri_model, tmp_path):
     simulation = twri_model
     ic = simulation["GWF_1"]["ic"]
@@ -164,7 +160,6 @@ def test_ic_render(twri_model, tmp_path):
     assert (tmp_path / "ic.ic").is_file()
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_npf_render(twri_model, tmp_path):
     simulation = twri_model
     npf = simulation["GWF_1"]["npf"]
@@ -201,7 +196,6 @@ def test_npf_render(twri_model, tmp_path):
     assert (tmp_path / "npf.npf").is_file()
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_oc_render(twri_model, tmp_path):
     simulation = twri_model
     globaltimes = simulation["time_discretization"]["time"].values
@@ -247,7 +241,6 @@ def test_oc_render(twri_model, tmp_path):
     assert actual == expected
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_rch_render(twri_model, tmp_path):
     simulation = twri_model
     globaltimes = simulation["time_discretization"]["time"].values
@@ -310,7 +303,6 @@ def test_wel_render(twri_model, tmp_path):
     assert (tmp_path / "GWF_1/wel" / "wel.bin").is_file()
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_solver_render(twri_model, tmp_path):
     simulation = twri_model
     solver = simulation["solver"]
@@ -346,7 +338,6 @@ def test_solver_render(twri_model, tmp_path):
     assert (tmp_path / "solver.ims").is_file()
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_gwfmodel_render(twri_model, tmp_path):
     simulation = twri_model
     globaltimes = simulation["time_discretization"]["time"].values
@@ -380,7 +371,6 @@ def test_gwfmodel_render(twri_model, tmp_path):
     assert (tmp_path / "GWF_1").is_dir()
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_simulation_render(twri_model):
     simulation = twri_model
     write_context = WriteContext(".")
@@ -411,7 +401,6 @@ def test_simulation_render(twri_model):
     assert actual == expected
 
 
-@pytest.mark.usefixtures("twri_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_simulation_write_and_run(twri_model, tmp_path):
     simulation = twri_model
@@ -446,7 +435,6 @@ def test_simulation_write_and_run(twri_model, tmp_path):
     assert np.allclose(meanhead_layer, mean_answer)
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_simulation_write_storage(transient_twri_model, tmp_path):
     simulation = transient_twri_model
@@ -471,7 +459,6 @@ def test_simulation_write_storage(transient_twri_model, tmp_path):
     np.testing.assert_allclose(meanflux_layer.values, mean_answer, rtol=2e-7)
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_simulation_wrong_dtype(transient_twri_model, tmp_path):
     simulation = transient_twri_model
@@ -487,7 +474,6 @@ def test_simulation_wrong_dtype(transient_twri_model, tmp_path):
         simulation.write(modeldir, binary=True)
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_simulation_validate_false(transient_twri_model, tmp_path):
     simulation = transient_twri_model
@@ -501,7 +487,6 @@ def test_simulation_validate_false(transient_twri_model, tmp_path):
     simulation.write(modeldir, binary=True, validate=False)
 
 
-@pytest.mark.usefixtures("twri_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_simulation_write_errors(twri_model, tmp_path):
     simulation = twri_model
@@ -514,7 +499,6 @@ def test_simulation_write_errors(twri_model, tmp_path):
         simulation.write(modeldir, binary=True)
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_slice_and_run(transient_twri_model, tmp_path):
     # TODO: bring back well once slicing is implemented...
@@ -534,7 +518,6 @@ def test_slice_and_run(transient_twri_model, tmp_path):
     simulation.run()
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_slice_and_run_with_state(transient_twri_model, tmp_path):
     # TODO: bring back well once slicing is implemented...
@@ -565,7 +548,6 @@ def test_slice_and_run_with_state(transient_twri_model, tmp_path):
     assert (np_array == 1.23).sum() == 33
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_slice_and_run_purge_empty_package(transient_twri_model, tmp_path):
     # TODO: bring back well once slicing is implemented...

--- a/imod/tests/test_mf6/test_ex01_twri_disv.py
+++ b/imod/tests/test_mf6/test_ex01_twri_disv.py
@@ -7,7 +7,6 @@ import xugrid as xu
 import imod
 
 
-@pytest.mark.usefixtures("twri_disv_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_simulation_write_and_run(twri_disv_model, tmp_path):
     simulation = twri_disv_model
@@ -32,7 +31,6 @@ def test_simulation_write_and_run(twri_disv_model, tmp_path):
     assert np.allclose(meanhead_layer, mean_answer)
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="capture_output added in 3.7")
 def test_slice_and_run(twri_disv_model, tmp_path):
     # TODO: bring back well once slicing is implemented...

--- a/imod/tests/test_mf6/test_mf6_absolute_paths.py
+++ b/imod/tests/test_mf6/test_mf6_absolute_paths.py
@@ -47,7 +47,6 @@ def uzf_test_data():
     return d
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_simulation_writes_full_paths_if_requested(circle_model, tmp_path):
     simulation = circle_model
     sim_dir = tmp_path / "circle"

--- a/imod/tests/test_mf6/test_mf6_absolute_paths.py
+++ b/imod/tests/test_mf6/test_mf6_absolute_paths.py
@@ -19,7 +19,7 @@ def uzf_test_data():
     dims = ("layer", "y", "x")
 
     nper = 4
-    time = pd.date_range("2018-01-01", periods=nper, freq="H")
+    time = pd.date_range("2018-01-01", periods=nper, freq="h")
     layer = np.arange(1, nlay + 1)
     y = np.arange(ymax, ymin, dy) + 0.5 * dy
     x = np.arange(xmin, xmax, dx) + 0.5 * dx

--- a/imod/tests/test_mf6/test_mf6_chd.py
+++ b/imod/tests/test_mf6/test_mf6_chd.py
@@ -195,7 +195,6 @@ def test_write_concentration_period_data(head_fc, concentration_fc):
             )  # the number 2 is in the concentration data, and in the cell indices.
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5(imod5_dataset, tmp_path):
     imod5_data = imod5_dataset[0]
 
@@ -216,7 +215,6 @@ def test_from_imod5(imod5_dataset, tmp_path):
     chd3.write("chd3", [1], tmp_path, use_binary=False)
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5_shd(imod5_dataset, tmp_path):
     imod5_data = imod5_dataset[0]
 
@@ -236,7 +234,6 @@ def test_from_imod5_shd(imod5_dataset, tmp_path):
 
 @pytest.mark.unittest_jit
 @pytest.mark.parametrize("remove_merged_packages", [True, False])
-@pytest.mark.usefixtures("imod5_dataset")
 def test_concatenate_chd(imod5_dataset, tmp_path, remove_merged_packages):
     # Arrange
     imod5_data = imod5_dataset[0]

--- a/imod/tests/test_mf6/test_mf6_dis.py
+++ b/imod/tests/test_mf6/test_mf6_dis.py
@@ -237,7 +237,6 @@ def test_write_ascii_griddata_2d_3d(idomain_and_bottom, tmp_path):
     assert len(bottom_content) == 1
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5_data__idomain_values(imod5_dataset):
     imod5_data = imod5_dataset[0]
 
@@ -251,7 +250,6 @@ def test_from_imod5_data__idomain_values(imod5_dataset):
     assert (dis["idomain"] == 2).sum() == 688329
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5_data__grid_extent(imod5_dataset):
     imod5_data = imod5_dataset[0]
 
@@ -270,7 +268,6 @@ def test_from_imod5_data__grid_extent(imod5_dataset):
     assert dis.dataset.coords["x"].max() == 199287.5
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5_data__write(imod5_dataset, tmp_path):
     directory = tmp_path / "dis_griddata"
     directory.mkdir()

--- a/imod/tests/test_mf6/test_mf6_disv.py
+++ b/imod/tests/test_mf6/test_mf6_disv.py
@@ -32,7 +32,7 @@ def idomain_and_bottom():
     coords = {"layer": layer, "y": y, "x": x}
     idomain = xr.DataArray(np.ones(shape, dtype=np.int8), coords=coords, dims=dims)
     bottom = xr.DataArray([-200.0, -350.0, -450.0], {"layer": layer}, ("layer",))
-    idomain = xu.UgridDataArray.from_structured(idomain)
+    idomain = xu.UgridDataArray.from_structured2d(idomain)
 
     return idomain, bottom
 

--- a/imod/tests/test_mf6/test_mf6_drn.py
+++ b/imod/tests/test_mf6/test_mf6_drn.py
@@ -237,7 +237,6 @@ def test_3d_singelayer():
     assert isinstance(struct_array, np.ndarray)
 
 
-@pytest.mark.usefixtures("concentration_fc", "elevation_fc", "conductance_fc")
 def test_render_concentration(
     concentration_fc,
     elevation_fc,
@@ -286,7 +285,6 @@ def test_render_concentration(
     assert actual == expected
 
 
-@pytest.mark.usefixtures("elevation_fc", "conductance_fc")
 def test_repeat_stress(
     elevation_fc,
     conductance_fc,
@@ -360,7 +358,6 @@ def test_repeat_stress(
     assert actual == expected
 
 
-@pytest.mark.usefixtures("elevation_fc", "conductance_fc")
 def test_repeat_stress_old_style(
     elevation_fc,
     conductance_fc,

--- a/imod/tests/test_mf6/test_mf6_evt.py
+++ b/imod/tests/test_mf6/test_mf6_evt.py
@@ -130,7 +130,7 @@ def test_get_bin_ds__no_segments(
     bin_ds = evt._get_bin_ds()
 
     # Assert
-    expected_dims = {"time": 3, "layer": 3, "y": 15, "x": 15}
+    expected_sizes = {"time": 3, "layer": 3, "y": 15, "x": 15}
     expected_variables = [
         "surface",
         "rate",
@@ -139,7 +139,7 @@ def test_get_bin_ds__no_segments(
         "proportion_rate",
     ]
 
-    assert bin_ds.dims == expected_dims
+    assert bin_ds.sizes == expected_sizes
     assert list(bin_ds.keys()) == expected_variables
 
 
@@ -168,7 +168,7 @@ def test_get_bin_ds__with_segments(
     bin_ds = evt._get_bin_ds()
 
     # Assert
-    expected_dims = {"time": 3, "layer": 3, "y": 15, "x": 15}
+    expected_sizes = {"time": 3, "layer": 3, "y": 15, "x": 15}
     expected_variables = [
         "surface",
         "rate",
@@ -181,7 +181,7 @@ def test_get_bin_ds__with_segments(
         "proportion_rate_segment_3",
     ]
 
-    assert bin_ds.dims == expected_dims
+    assert bin_ds.sizes == expected_sizes
     assert list(bin_ds.keys()) == expected_variables
 
 

--- a/imod/tests/test_mf6/test_mf6_evt.py
+++ b/imod/tests/test_mf6/test_mf6_evt.py
@@ -9,13 +9,6 @@ import imod
 from imod.schemata import ValidationError
 
 
-@pytest.mark.usefixtures(
-    "rate_fc",
-    "elevation_fc",
-    "concentration_fc",
-    "proportion_rate_fc",
-    "proportion_depth_fc",
-)
 def test_render(
     rate_fc, elevation_fc, concentration_fc, proportion_rate_fc, proportion_depth_fc
 ):
@@ -68,12 +61,6 @@ def test_render(
     assert actual == expected
 
 
-@pytest.mark.usefixtures(
-    "rate_fc",
-    "elevation_fc",
-    "proportion_rate_fc",
-    "proportion_depth_fc",
-)
 def test_get_options__no_segments(
     rate_fc, elevation_fc, proportion_rate_fc, proportion_depth_fc
 ):
@@ -96,12 +83,6 @@ def test_get_options__no_segments(
     assert options["nseg"] == 1
 
 
-@pytest.mark.usefixtures(
-    "rate_fc",
-    "elevation_fc",
-    "proportion_rate_fc",
-    "proportion_depth_fc",
-)
 def test_get_options__with_segments(
     rate_fc, elevation_fc, proportion_rate_fc, proportion_depth_fc
 ):
@@ -133,12 +114,6 @@ def test_get_options__with_segments(
     assert options["nseg"] == 4
 
 
-@pytest.mark.usefixtures(
-    "rate_fc",
-    "elevation_fc",
-    "proportion_rate_fc",
-    "proportion_depth_fc",
-)
 def test_get_bin_ds__no_segments(
     rate_fc, elevation_fc, proportion_rate_fc, proportion_depth_fc
 ):
@@ -168,12 +143,6 @@ def test_get_bin_ds__no_segments(
     assert list(bin_ds.keys()) == expected_variables
 
 
-@pytest.mark.usefixtures(
-    "rate_fc",
-    "elevation_fc",
-    "proportion_rate_fc",
-    "proportion_depth_fc",
-)
 def test_get_bin_ds__with_segments(
     rate_fc, elevation_fc, proportion_rate_fc, proportion_depth_fc
 ):
@@ -216,12 +185,6 @@ def test_get_bin_ds__with_segments(
     assert list(bin_ds.keys()) == expected_variables
 
 
-@pytest.mark.usefixtures(
-    "rate_fc",
-    "elevation_fc",
-    "proportion_rate_fc",
-    "proportion_depth_fc",
-)
 def test_wrong_dim_order(
     rate_fc, elevation_fc, proportion_rate_fc, proportion_depth_fc
 ):

--- a/imod/tests/test_mf6/test_mf6_flopy_compatibility.py
+++ b/imod/tests/test_mf6/test_mf6_flopy_compatibility.py
@@ -6,7 +6,6 @@ import pytest
 from imod.mf6 import Modflow6Simulation
 
 
-@pytest.mark.usefixtures("twri_model")
 @pytest.mark.parametrize("absolute_paths", [True])
 def test_readable_by_flopy(
     twri_model: Modflow6Simulation, tmp_path: Path, absolute_paths
@@ -31,7 +30,6 @@ def test_readable_by_flopy(
     assert len(flopy_sim_result) == 2
 
 
-@pytest.mark.usefixtures("twri_model")
 @pytest.mark.parametrize("absolute_paths", [True, False])
 def test_readable_by_mf6(
     twri_model: Modflow6Simulation, tmp_path: Path, absolute_paths

--- a/imod/tests/test_mf6/test_mf6_gwfgwf.py
+++ b/imod/tests/test_mf6/test_mf6_gwfgwf.py
@@ -64,7 +64,6 @@ def sample_gwfgwf_unstructured():
 
 
 class TestGwfgwf:
-    @pytest.mark.usefixtures("sample_gwfgwf_structured")
     def test_render_exchange_file_structured(
         self, sample_gwfgwf_structured: imod.mf6.GWFGWF, tmp_path: Path
     ):
@@ -98,7 +97,6 @@ class TestGwfgwf:
         actual = remove_comment_lines(actual)
         assert actual == expected
 
-    @pytest.mark.usefixtures("sample_gwfgwf_unstructured")
     def test_render_exchange_file_unstructured(
         self, sample_gwfgwf_unstructured: imod.mf6.GWFGWF, tmp_path: Path
     ):
@@ -133,7 +131,6 @@ class TestGwfgwf:
         actual = remove_comment_lines(actual)
         assert actual == expected
 
-    @pytest.mark.usefixtures("sample_gwfgwf_structured")
     def test_error_clip(self, sample_gwfgwf_structured: imod.mf6.GWFGWF):
         # test error
         with pytest.raises(NotImplementedError):

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -99,7 +99,7 @@ def test_to_mf6_creates_mf6_adapter_init(
     grid = (
         idomain.ugrid.grid
         if isinstance(idomain, xu.UgridDataArray)
-        else xu.UgridDataArray.from_structured(idomain).ugrid.grid
+        else xu.UgridDataArray.from_structured2d(idomain).ugrid.grid
     )
 
     expected_barrier_values = xr.DataArray(
@@ -228,7 +228,7 @@ def test_to_mf6_creates_mf6_adapter_layered(
     grid = (
         idomain.ugrid.grid
         if isinstance(idomain, xu.UgridDataArray)
-        else xu.UgridDataArray.from_structured(idomain).ugrid.grid
+        else xu.UgridDataArray.from_structured2d(idomain).ugrid.grid
     )
 
     data = np.full((idomain.coords["layer"].size, edge_index.size), fill_value=np.nan)

--- a/imod/tests/test_mf6/test_mf6_hfb.py
+++ b/imod/tests/test_mf6/test_mf6_hfb.py
@@ -714,7 +714,6 @@ def test_set_options(print_input, parameterizable_basic_dis):
     assert mf6_package.dataset["print_input"].values[()] == print_input
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_hfb_from_imod5(imod5_dataset, tmp_path):
     imod5_data = imod5_dataset[0]
     target_dis = StructuredDiscretization.from_imod5_data(imod5_data)
@@ -731,7 +730,6 @@ def test_hfb_from_imod5(imod5_dataset, tmp_path):
     assert list(np.unique(hfb_package["layer"].values)) == [7]
 
 
-@pytest.mark.usefixtures("structured_flow_model")
 def test_snap_to_grid_and_aggregate(structured_flow_model):
     idomain = structured_flow_model["dis"]["idomain"]
     grid2d = xu.Ugrid2d.from_structured(idomain)
@@ -766,7 +764,6 @@ def test_snap_to_grid_and_aggregate(structured_flow_model):
     np.testing.assert_array_equal(edge_index, argwhere_summed_expected)
 
 
-@pytest.mark.usefixtures("structured_flow_model")
 def test_combine_linestrings(structured_flow_model):
     dis = structured_flow_model["dis"]
     top, bottom, idomain = (
@@ -802,7 +799,6 @@ def test_combine_linestrings(structured_flow_model):
     xr.testing.assert_equal(mf6_hfb_single.dataset, mf6_hfb_triple.dataset)
 
 
-@pytest.mark.usefixtures("structured_flow_model")
 def test_run_multiple_hfbs(tmp_path, structured_flow_model):
     # Single layered model
     structured_flow_model = structured_flow_model.clip_box(layer_max=1)

--- a/imod/tests/test_mf6/test_mf6_ic.py
+++ b/imod/tests/test_mf6/test_mf6_ic.py
@@ -43,7 +43,6 @@ def test_wrong_arguments():
         imod.mf6.InitialConditions(head=0.0, start=1.0)
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5(imod5_dataset, tmp_path):
     data = deepcopy(imod5_dataset[0])
 

--- a/imod/tests/test_mf6/test_mf6_lak.py
+++ b/imod/tests/test_mf6/test_mf6_lak.py
@@ -2,7 +2,6 @@ import textwrap
 
 import numpy as np
 import pandas as pd
-import pytest
 import xarray as xr
 import xugrid as xu
 
@@ -17,7 +16,6 @@ from imod.mf6.lak import (
 )
 
 
-@pytest.mark.usefixtures("naardermeer", "ijsselmeer")
 def test_alternative_constructor(naardermeer, ijsselmeer):
     outlet1 = OutletManning("Naardermeer", "IJsselmeer", 23.0, 24.0, 25.0, 26.0)
     outlet2 = OutletManning("IJsselmeer", "Naardermeer", 27.0, 28.0, 29.0, 30.0)

--- a/imod/tests/test_mf6/test_mf6_lake_table.py
+++ b/imod/tests/test_mf6/test_mf6_lake_table.py
@@ -1,12 +1,9 @@
 import textwrap
 
-import pytest
-
 import imod.tests.fixtures.mf6_lake_package_fixture as mf_lake
 from imod.mf6.lak import Lake
 
 
-@pytest.mark.usefixtures("naardermeer", "ijsselmeer")
 def test_mf6_write_number_tables(naardermeer, ijsselmeer, tmp_path):
     lake_package_2lakes = Lake.from_lakes_and_outlets(
         [naardermeer(has_lake_table=True), ijsselmeer(has_lake_table=True)]

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -95,7 +95,6 @@ def roundtrip(model, tmp_path):
     assert isinstance(back, type(model))
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_circle_roundtrip(circle_model, tmp_path):
     roundtrip(circle_model["GWF_1"], tmp_path)
 

--- a/imod/tests/test_mf6/test_mf6_mst.py
+++ b/imod/tests/test_mf6/test_mf6_mst.py
@@ -25,14 +25,6 @@ def test_render_simple():
     assert actual == expected
 
 
-@pytest.mark.usefixtures(
-    "porosity_fc",
-    "decay_fc",
-    "decay_sorbed_fc",
-    "bulk_density_fc",
-    "distcoef_fc",
-    "sp2_fc",
-)
 def test_render_first_order_decay(
     porosity_fc, decay_fc, decay_sorbed_fc, bulk_density_fc, distcoef_fc, sp2_fc
 ):

--- a/imod/tests/test_mf6/test_mf6_npf.py
+++ b/imod/tests/test_mf6/test_mf6_npf.py
@@ -212,7 +212,6 @@ def test_configure_xt3d(tmp_path):
     assert not npf.get_xt3d_option()
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_npf_from_imod5_isotropic(imod5_dataset, tmp_path):
     data = deepcopy(imod5_dataset[0])
     # throw out kva (=vertical anisotropy array) and ani (=horizontal anisotropy array)
@@ -234,7 +233,6 @@ def test_npf_from_imod5_isotropic(imod5_dataset, tmp_path):
     assert "angle3" not in rendered_npf
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_npf_from_imod5_horizontal_anisotropy(imod5_dataset, tmp_path):
     data = deepcopy(imod5_dataset[0])
     # throw out kva (=vertical anisotropy array)
@@ -268,7 +266,6 @@ def test_npf_from_imod5_horizontal_anisotropy(imod5_dataset, tmp_path):
     assert "angle3" not in rendered_npf
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_npf_from_imod5_vertical_anisotropy(imod5_dataset, tmp_path):
     data = deepcopy(imod5_dataset[0])
     # throw out ani (=horizontal anisotropy array)
@@ -296,7 +293,6 @@ def test_npf_from_imod5_vertical_anisotropy(imod5_dataset, tmp_path):
     assert "angle3" not in rendered_npf
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_npf_from_imod5_settings(imod5_dataset, tmp_path):
     data = deepcopy(imod5_dataset[0])
 

--- a/imod/tests/test_mf6/test_mf6_out.py
+++ b/imod/tests/test_mf6/test_mf6_out.py
@@ -1,13 +1,11 @@
 import dask
 import numpy as np
-import pytest
 import xarray as xr
 import xugrid as xu
 
 import imod
 
 
-@pytest.mark.usefixtures("twri_result")
 def test_read_disgrb(twri_result):
     modeldir = twri_result
     with imod.util.cd(modeldir):
@@ -43,7 +41,6 @@ def test_read_disgrb(twri_result):
         assert isinstance(grb["top"], xr.DataArray)
 
 
-@pytest.mark.usefixtures("twri_result", "twri_model")
 def test_open_hds(twri_result, twri_model):
     model = twri_model["GWF_1"]
     modeldir = twri_result
@@ -57,7 +54,6 @@ def test_open_hds(twri_result, twri_model):
         assert isinstance(head.data, dask.array.Array)  # rather than numpy array
 
 
-@pytest.mark.usefixtures("twri_result")
 def test_read_cbc_headers(twri_result):
     modeldir = twri_result
     with imod.util.cd(modeldir):
@@ -74,7 +70,6 @@ def test_read_cbc_headers(twri_result):
         assert isinstance(headers["chd_chd"][0], imod.mf6.out.cbc.Imeth6Header)
 
 
-@pytest.mark.usefixtures("transient_twri_result")
 def test_read_cbc_headers__transient(transient_twri_result):
     modeldir = transient_twri_result
     with imod.util.cd(modeldir):
@@ -353,7 +348,6 @@ def test_disv_indices():
     np.testing.assert_array_equal(horizontal, expected_horizontal)
 
 
-@pytest.mark.usefixtures("twri_result")
 def test_open_cbc__dis(twri_result):
     modeldir = twri_result
     with imod.util.cd(modeldir):
@@ -406,7 +400,6 @@ def test_open_cbc__dis_multi_drn_1_cell(twri_result_9_drn_in_1_cell):
         np.testing.assert_approx_equal(actual_value, -24.7, significant=1)
 
 
-@pytest.mark.usefixtures("transient_twri_result")
 def test_open_cbc__dis_transient(transient_twri_result):
     modeldir = transient_twri_result
     with imod.util.cd(modeldir):
@@ -430,7 +423,6 @@ def test_open_cbc__dis_transient(transient_twri_result):
             array.load()
 
 
-@pytest.mark.usefixtures("transient_twri_result")
 def test_open_cbc__dis_datetime(transient_twri_result):
     modeldir = transient_twri_result
     with imod.util.cd(modeldir):
@@ -445,7 +437,6 @@ def test_open_cbc__dis_datetime(transient_twri_result):
         assert array.coords["time"].dtype == np.dtype("datetime64[ns]")
 
 
-@pytest.mark.usefixtures("transient_unconfined_twri_result")
 def test_open_cbc__dis_transient_unconfined(transient_unconfined_twri_result):
     modeldir = transient_unconfined_twri_result
     with imod.util.cd(modeldir):
@@ -474,7 +465,6 @@ def test_open_cbc__dis_transient_unconfined(transient_unconfined_twri_result):
             array.load()
 
 
-@pytest.mark.usefixtures("circle_result")
 def test_open_cbc__disv(circle_result):
     modeldir = circle_result
     with imod.util.cd(modeldir):
@@ -501,7 +491,6 @@ def test_open_cbc__disv(circle_result):
             array.load()
 
 
-@pytest.mark.usefixtures("circle_result")
 def test_open_cbc__disv_datetime(circle_result):
     modeldir = circle_result
     with imod.util.cd(modeldir):
@@ -516,7 +505,6 @@ def test_open_cbc__disv_datetime(circle_result):
         assert array.coords["time"].dtype == np.dtype("datetime64[ns]")
 
 
-@pytest.mark.usefixtures("circle_result_sto")
 def test_open_cbc__disv_sto(circle_result_sto):
     """With saved storage fluxes, which are saved as METH1"""
     modeldir = circle_result_sto

--- a/imod/tests/test_mf6/test_mf6_rch.py
+++ b/imod/tests/test_mf6/test_mf6_rch.py
@@ -198,7 +198,6 @@ def test_transient_no_layer_dim(rch_dict_transient):
     assert actual == expected
 
 
-@pytest.mark.usefixtures("concentration_fc", "rate_fc")
 def test_render_concentration(concentration_fc, rate_fc):
     rch = imod.mf6.Recharge(
         rate=rate_fc,
@@ -280,7 +279,6 @@ def test_validate_false():
     imod.mf6.Recharge(rate=0.001, validate=False)
 
 
-@pytest.mark.usefixtures("rate_fc", "concentration_fc")
 def test_write_concentration_period_data(rate_fc, concentration_fc):
     globaltimes = np.array(
         [
@@ -330,7 +328,6 @@ def test_clip_box(rch_dict):
     assert selection["rate"].shape == (1, 1)
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_planar_rch_from_imod5_constant(imod5_dataset, tmp_path):
     data = deepcopy(imod5_dataset[0])
     target_discretization = StructuredDiscretization.from_imod5_data(data)
@@ -356,7 +353,6 @@ def test_planar_rch_from_imod5_constant(imod5_dataset, tmp_path):
     data["rch"]["rate"]["layer"].values[0] = 1
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_planar_rch_from_imod5_transient(imod5_dataset, tmp_path):
     data = deepcopy(imod5_dataset[0])
     target_discretization = StructuredDiscretization.from_imod5_data(data)
@@ -387,7 +383,6 @@ def test_planar_rch_from_imod5_transient(imod5_dataset, tmp_path):
     assert "maxbound 33856" in rendered_rch
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_non_planar_rch_from_imod5_constant(imod5_dataset, tmp_path):
     data = deepcopy(imod5_dataset[0])
     target_discretization = StructuredDiscretization.from_imod5_data(data)
@@ -425,7 +420,6 @@ def test_non_planar_rch_from_imod5_constant(imod5_dataset, tmp_path):
     data["rch"]["rate"] = original_rch
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_non_planar_rch_from_imod5_transient(imod5_dataset, tmp_path):
     data = deepcopy(imod5_dataset[0])
     target_discretization = StructuredDiscretization.from_imod5_data(data)
@@ -458,7 +452,6 @@ def test_non_planar_rch_from_imod5_transient(imod5_dataset, tmp_path):
     assert "maxbound 33856" in rendered_rch
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5_cap_data(imod5_dataset):
     # Arrange
     data = deepcopy(imod5_dataset[0])

--- a/imod/tests/test_mf6/test_mf6_regrid_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_regrid_simulation.py
@@ -81,7 +81,6 @@ def test_regridded_simulation_has_required_packages(
     assert isinstance(new_simulation["flow"], imod.mf6.GroundwaterFlowModel)
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_regrid_with_custom_method(circle_model):
     simulation = circle_model
     idomain = circle_model["GWF_1"].domain

--- a/imod/tests/test_mf6/test_mf6_riv.py
+++ b/imod/tests/test_mf6/test_mf6_riv.py
@@ -401,7 +401,6 @@ def test_validate_false():
     imod.mf6.River(validate=False, **riv_ds.sel(layer=slice(None, None, -1)))
 
 
-@pytest.mark.usefixtures("concentration_fc")
 def test_render_concentration(concentration_fc):
     riv_ds = xr.merge([riv_dict()])
 
@@ -434,7 +433,6 @@ def test_render_concentration(concentration_fc):
     assert actual == expected
 
 
-@pytest.mark.usefixtures("concentration_fc")
 def test_write_concentration_period_data(concentration_fc):
     globaltimes = [np.datetime64("2000-01-01")]
     concentration_fc[:] = 2
@@ -458,7 +456,6 @@ def test_write_concentration_period_data(concentration_fc):
             )  # the number 2 is in the concentration data, and in the cell indices.
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_import_river_from_imod5(imod5_dataset, tmp_path):
     imod5_data = imod5_dataset[0]
     period_data = imod5_dataset[1]
@@ -499,7 +496,6 @@ def test_import_river_from_imod5(imod5_dataset, tmp_path):
     assert len(errors) == 0
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_import_river_from_imod5__negative_layer(imod5_dataset, tmp_path):
     # Arrange
     imod5_data = imod5_dataset[0]
@@ -572,7 +568,6 @@ def test_import_river_from_imod5__negative_layer(imod5_dataset, tmp_path):
     imod5_data["riv-1"] = original_riv_1
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_import_river_from_imod5__infiltration_factors(imod5_dataset):
     imod5_data = imod5_dataset[0]
     period_data = imod5_dataset[1]
@@ -622,7 +617,6 @@ def test_import_river_from_imod5__infiltration_factors(imod5_dataset):
     imod5_data["riv-1"]["infiltration_factor"] = original_infiltration_factor
 
 
-@pytest.mark.usefixtures("imod5_dataset_periods")
 def test_import_river_from_imod5__period_data(imod5_dataset_periods, tmp_path):
     imod5_data = imod5_dataset_periods[0]
     imod5_periods = imod5_dataset_periods[1]

--- a/imod/tests/test_mf6/test_mf6_riv.py
+++ b/imod/tests/test_mf6/test_mf6_riv.py
@@ -66,7 +66,7 @@ def riv_dict():
 
 
 def make_dict_unstructured(d):
-    return {key: xu.UgridDataArray.from_structured(value) for key, value in d.items()}
+    return {key: xu.UgridDataArray.from_structured2d(value) for key, value in d.items()}
 
 
 class RivCases:

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -50,32 +50,26 @@ def roundtrip(simulation, tmpdir_factory, name):
     assert isinstance(back, imod.mf6.Modflow6Simulation)
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_twri_roundtrip(twri_model, tmpdir_factory):
     roundtrip(twri_model, tmpdir_factory, "twri")
 
 
-@pytest.mark.usefixtures("twri_model_hfb")
 def test_twri_hfb_roundtrip(twri_model_hfb, tmpdir_factory):
     roundtrip(twri_model_hfb, tmpdir_factory, "twri")
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 def test_twri_transient_roundtrip(transient_twri_model, tmpdir_factory):
     roundtrip(transient_twri_model, tmpdir_factory, "twri_transient")
 
 
-@pytest.mark.usefixtures("twri_disv_model")
 def test_twri_disv_roundtrip(twri_disv_model, tmpdir_factory):
     roundtrip(twri_disv_model, tmpdir_factory, "twri_disv")
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_circle_roundtrip(circle_model, tmpdir_factory):
     roundtrip(circle_model, tmpdir_factory, "circle")
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_dump_version_number__version_written(twri_model, tmpdir_factory):
     # Arrange
     tmp_path = tmpdir_factory.mktemp("twri")
@@ -88,7 +82,6 @@ def test_dump_version_number__version_written(twri_model, tmpdir_factory):
     assert toml_content["version"]["imod-python"] == imod.__version__
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_from_file_version_logged__version_in_dumped(twri_model, tmpdir_factory):
     """
     Tested if a warning is thrown when there is a mismatch between version
@@ -123,7 +116,6 @@ def test_from_file_version_logged__version_in_dumped(twri_model, tmpdir_factory)
         assert "iMOD Python version in dumped simulation: 0.0.0" in log
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_from_file_version_logged__no_version_in_dumped(twri_model, tmpdir_factory):
     """
     Tested if a warning is thrown when there is a mismatch between version
@@ -158,7 +150,6 @@ def test_from_file_version_logged__no_version_in_dumped(twri_model, tmpdir_facto
         assert "No iMOD Python version information found in dumped simulation." in log
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_twri_gdal(twri_model, tmpdir_factory):
     """
     Test of dumping a structured model with a CRS results in the necessary
@@ -174,7 +165,6 @@ def test_twri_gdal(twri_model, tmpdir_factory):
     assert crs == "EPSG:28992"
 
 
-@pytest.mark.usefixtures("twri_disv_model")
 def test_twri_disv_mdal_compliant_semi_roundtrip(twri_disv_model, tmpdir_factory):
     """
     Test if dumping an unstructured model with mdal_compliant=True also results
@@ -192,7 +182,6 @@ def test_twri_disv_mdal_compliant_semi_roundtrip(twri_disv_model, tmpdir_factory
     assert len(ds.data_vars) == 3
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_simulation_open_head(circle_model, tmp_path):
     simulation = circle_model
 
@@ -220,7 +209,6 @@ def test_simulation_open_head(circle_model, tmp_path):
     assert str(head.coords["time"].values[()][0]) == "2013-04-29T22:00:00.000000000"
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_simulation_open_head_relative_path(circle_model, tmp_path):
     simulation = circle_model
 
@@ -240,7 +228,6 @@ def test_simulation_open_head_relative_path(circle_model, tmp_path):
     assert head.shape == (52, 2, 216)
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_simulation_open_flow_budget(circle_model, tmp_path):
     simulation = circle_model
 
@@ -279,7 +266,6 @@ def test_write_circle_model_twice(circle_model, tmp_path):
     assert len(diff.right_only) == 0
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_simulation_open_concentration_fail(circle_model, tmp_path):
     """No transport model is assigned, so should throw error when opening concentrations"""
     simulation = circle_model
@@ -331,7 +317,6 @@ def setup_simulation():
     return simulation
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @pytest.fixture(scope="function")
 def split_transient_twri_model(transient_twri_model):
     active = transient_twri_model["GWF_1"].domain.sel(layer=1)
@@ -465,7 +450,6 @@ class TestModflow6Simulation:
                 y_min=grid_y_min, y_max=grid_y_max / 2
             )
 
-    @pytest.mark.usefixtures("transient_twri_model")
     def test_exchanges_in_simulation_file(self, transient_twri_model, tmp_path):
         # Arrange
         active = transient_twri_model["GWF_1"].domain.sel(layer=1)
@@ -502,7 +486,6 @@ class TestModflow6Simulation:
             namfile_content = mfsim_nam.read()
         assert expected_exchanges_block in namfile_content
 
-    @pytest.mark.usefixtures("transient_twri_model")
     def test_write_exchanges(
         self, transient_twri_model, sample_gwfgwf_structured, tmp_path
     ):
@@ -516,7 +499,6 @@ class TestModflow6Simulation:
         _, filename, _, _ = sample_gwfgwf_structured.get_specification()
         assert Path.exists(tmp_path / filename)
 
-    @pytest.mark.usefixtures("split_transient_twri_model")
     def test_prevent_split_after_split(
         self,
         split_transient_twri_model,
@@ -528,7 +510,6 @@ class TestModflow6Simulation:
         with pytest.raises(RuntimeError):
             _ = split_simulation.split(None)
 
-    @pytest.mark.usefixtures("split_transient_twri_model")
     def test_prevent_clip_box_after_split(
         self,
         split_transient_twri_model,
@@ -544,7 +525,6 @@ class TestModflow6Simulation:
         # test  making a deepcopy will not crash
         _ = deepcopy(split_transient_twri_model)
 
-    @pytest.mark.usefixtures("split_transient_twri_model")
     def test_prevent_regrid_like_after_split(
         self,
         split_transient_twri_model,
@@ -566,7 +546,6 @@ def compare_submodel_partition_info(first: PartitionInfo, second: PartitionInfo)
 
 
 @pytest.mark.unittest_jit
-@pytest.mark.usefixtures("imod5_dataset")
 def test_import_from_imod5(imod5_dataset, tmp_path):
     imod5_data = imod5_dataset[0]
     period_data = imod5_dataset[1]
@@ -600,7 +579,6 @@ def test_import_from_imod5(imod5_dataset, tmp_path):
 
 
 @pytest.mark.unittest_jit
-@pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5__has_cap_data(imod5_dataset):
     imod5_data = deepcopy(imod5_dataset[0])
     period_data = imod5_dataset[1]
@@ -631,7 +609,6 @@ def test_from_imod5__has_cap_data(imod5_dataset):
 
 
 @pytest.mark.unittest_jit
-@pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5__strict_well_validation_set(imod5_dataset):
     imod5_data = imod5_dataset[0]
     period_data = imod5_dataset[1]
@@ -650,7 +627,6 @@ def test_from_imod5__strict_well_validation_set(imod5_dataset):
 
 
 @pytest.mark.unittest_jit
-@pytest.mark.usefixtures("imod5_dataset")
 def test_import_from_imod5__correct_well_type(imod5_dataset):
     # Unpack
     imod5_data = imod5_dataset[0]
@@ -681,7 +657,6 @@ def test_import_from_imod5__correct_well_type(imod5_dataset):
 
 
 @pytest.mark.unittest_jit
-@pytest.mark.usefixtures("imod5_dataset")
 def test_import_from_imod5__well_steady_state(imod5_dataset):
     # Unpack
     imod5_data = imod5_dataset[0]
@@ -713,7 +688,6 @@ def test_import_from_imod5__well_steady_state(imod5_dataset):
 
 
 @pytest.mark.unittest_jit
-@pytest.mark.usefixtures("imod5_dataset")
 def test_import_from_imod5__nonstandard_regridding(imod5_dataset, tmp_path):
     imod5_data = imod5_dataset[0]
     period_data = imod5_dataset[1]
@@ -749,7 +723,6 @@ def test_import_from_imod5__nonstandard_regridding(imod5_dataset, tmp_path):
 
 
 @pytest.mark.unittest_jit
-@pytest.mark.usefixtures("imod5_dataset")
 def test_import_from_imod5_no_storage_no_recharge(imod5_dataset, tmp_path):
     # this test imports an imod5 simulation, but it has no recharge and no storage package.
     imod5_data = imod5_dataset[0]

--- a/imod/tests/test_mf6/test_mf6_ssm.py
+++ b/imod/tests/test_mf6/test_mf6_ssm.py
@@ -9,7 +9,6 @@ from imod.mf6.ssm import SourceSinkMixing
 from imod.schemata import ValidationError
 
 
-@pytest.mark.usefixtures("flow_model_with_concentration")
 def test_transport_model_rendering(flow_model_with_concentration):
     directory = pathlib.Path("mymodel")
     globaltimes = np.array(["2000-01-01"], dtype="datetime64[ns]")
@@ -28,7 +27,6 @@ def test_transport_model_rendering(flow_model_with_concentration):
     assert actual == expected
 
 
-@pytest.mark.usefixtures("flow_model_with_concentration")
 def test_transport_model_multi_bcs_rendering(flow_model_with_concentration):
     directory = pathlib.Path("mymodel")
     globaltimes = np.array(["2000-01-01"], dtype="datetime64[ns]")
@@ -51,7 +49,6 @@ def test_transport_model_multi_bcs_rendering(flow_model_with_concentration):
     assert actual == expected
 
 
-@pytest.mark.usefixtures("flow_model_with_concentration")
 def test_transport_model_rendering_settings(flow_model_with_concentration):
     directory = pathlib.Path("mymodel")
     globaltimes = np.array(["2000-01-01"], dtype="datetime64[ns]")

--- a/imod/tests/test_mf6/test_mf6_sto.py
+++ b/imod/tests/test_mf6/test_mf6_sto.py
@@ -430,7 +430,6 @@ def test_check_nan_in_active_cell(sy_layered, convertible, dis):
         assert var == "storage_coefficient"
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5(imod5_dataset, tmp_path):
     data = imod5_dataset[0]
 
@@ -448,7 +447,6 @@ def test_from_imod5(imod5_dataset, tmp_path):
     assert "ss" in rendered_sto
 
 
-@pytest.mark.usefixtures("imod5_dataset")
 def test_from_imod5_steady_state(imod5_dataset):
     data = imod5_dataset[0]
 

--- a/imod/tests/test_mf6/test_mf6_transport_model.py
+++ b/imod/tests/test_mf6/test_mf6_transport_model.py
@@ -80,7 +80,6 @@ def test_assign_flow_discretization(basic_dis, concentration_fc):
     assert isinstance(tpt_model["dis"], imod.mf6.StructuredDiscretization)
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_flowmodel_validation(twri_model):
     # initialize transport with a flow model without concentration data
     flow_model = twri_model["GWF_1"]
@@ -88,7 +87,6 @@ def test_flowmodel_validation(twri_model):
         imod.mf6.SourceSinkMixing.from_flow_model(flow_model, "salinity")
 
 
-@pytest.mark.usefixtures("flow_transport_simulation")
 def test_transport_concentration_loading(tmp_path, flow_transport_simulation):
     flow_transport_simulation.write(tmp_path)
     flow_transport_simulation.run()
@@ -106,7 +104,6 @@ def test_transport_concentration_loading(tmp_path, flow_transport_simulation):
     assert conc_time.coords["time"].dtype == np.dtype("datetime64[ns]")
 
 
-@pytest.mark.usefixtures("flow_transport_simulation")
 def test_transport_balance_loading(tmp_path, flow_transport_simulation):
     flow_transport_simulation.write(tmp_path)
     flow_transport_simulation.run()
@@ -132,7 +129,6 @@ def test_transport_balance_loading(tmp_path, flow_transport_simulation):
     )
 
 
-@pytest.mark.usefixtures("flow_transport_simulation")
 def test_transport_output_wrong_species(tmp_path, flow_transport_simulation):
     flow_transport_simulation.write(tmp_path)
     flow_transport_simulation.run()

--- a/imod/tests/test_mf6/test_mf6_unsupported_grid_operations.py
+++ b/imod/tests/test_mf6/test_mf6_unsupported_grid_operations.py
@@ -21,7 +21,6 @@ def finer_grid(grid):
     )
 
 
-@pytest.mark.usefixtures("rectangle_with_lakes")
 def test_mf6_simulation_partition_with_lakes(rectangle_with_lakes, tmp_path):
     simulation = rectangle_with_lakes
 
@@ -32,7 +31,6 @@ def test_mf6_simulation_partition_with_lakes(rectangle_with_lakes, tmp_path):
         _ = simulation.split(label_array)
 
 
-@pytest.mark.usefixtures("rectangle_with_lakes")
 def test_mf6_simulation_regrid_with_lakes(rectangle_with_lakes, tmp_path):
     simulation = rectangle_with_lakes
 
@@ -42,7 +40,6 @@ def test_mf6_simulation_regrid_with_lakes(rectangle_with_lakes, tmp_path):
         _ = simulation.regrid_like("regridded_simulation", new_grid, True)
 
 
-@pytest.mark.usefixtures("rectangle_with_lakes")
 def test_mf6_model_regrid_with_lakes(rectangle_with_lakes, tmp_path):
     simulation = rectangle_with_lakes
     model = simulation["GWF_1"]
@@ -52,7 +49,6 @@ def test_mf6_model_regrid_with_lakes(rectangle_with_lakes, tmp_path):
         _ = model.regrid_like(new_grid, True)
 
 
-@pytest.mark.usefixtures("rectangle_with_lakes")
 def test_mf6_package_regrid_with_lakes(rectangle_with_lakes, tmp_path):
     simulation = rectangle_with_lakes
     package = simulation["GWF_1"]["lake"]
@@ -62,7 +58,6 @@ def test_mf6_package_regrid_with_lakes(rectangle_with_lakes, tmp_path):
         _ = package.regrid_like(new_grid, regrid_cache)
 
 
-@pytest.mark.usefixtures("rectangle_with_lakes")
 def test_mf6_simulation_clip_with_lakes(rectangle_with_lakes, tmp_path):
     simulation = rectangle_with_lakes
 
@@ -70,7 +65,6 @@ def test_mf6_simulation_clip_with_lakes(rectangle_with_lakes, tmp_path):
         _ = simulation.clip_box(x_min=200, y_min=200, x_max=1000, y_max=1000)
 
 
-@pytest.mark.usefixtures("rectangle_with_lakes")
 def test_mf6_model_clip_with_lakes(rectangle_with_lakes, tmp_path):
     model = rectangle_with_lakes["GWF_1"]
 
@@ -78,7 +72,6 @@ def test_mf6_model_clip_with_lakes(rectangle_with_lakes, tmp_path):
         _ = model.clip_box(x_min=200, y_min=200, x_max=1000, y_max=1000)
 
 
-@pytest.mark.usefixtures("rectangle_with_lakes")
 def test_mf6_package_clip_with_lakes(rectangle_with_lakes, tmp_path):
     simulation = rectangle_with_lakes
     package = simulation["GWF_1"]["lake"]

--- a/imod/tests/test_mf6/test_mf6_uzf.py
+++ b/imod/tests/test_mf6/test_mf6_uzf.py
@@ -21,7 +21,7 @@ def test_data():
     dims = ("layer", "y", "x")
 
     nper = 4
-    time = pd.date_range("2018-01-01", periods=nper, freq="H")
+    time = pd.date_range("2018-01-01", periods=nper, freq="h")
     layer = np.arange(1, nlay + 1)
     y = np.arange(ymax, ymin, dy) + 0.5 * dy
     x = np.arange(xmin, xmax, dx) + 0.5 * dx
@@ -119,7 +119,7 @@ def test_packagedata(test_data):
 def test_render(test_data):
     uzf = imod.mf6.UnsaturatedZoneFlow(**test_data)
     directory = pathlib.Path("mymodel")
-    globaltimes = pd.date_range("2018-01-01", periods=4, freq="H")
+    globaltimes = pd.date_range("2018-01-01", periods=4, freq="h")
     actual = uzf.render(directory, "uzf", globaltimes, True)
 
     expected = textwrap.dedent(

--- a/imod/tests/test_mf6/test_mf6_uzf_model.py
+++ b/imod/tests/test_mf6/test_mf6_uzf_model.py
@@ -17,7 +17,7 @@ def uzf_model():
     # Create discretication
     shape = nlay, nrow, ncol = 7, 9, 9
     nper = 48
-    time = pd.date_range("2018-01-01", periods=nper, freq="H")
+    time = pd.date_range("2018-01-01", periods=nper, freq="h")
 
     dx = 1000.0
     dy = -1000.0

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -988,7 +988,6 @@ def test_render__concentration_dis_vertices_transient(well_test_data_transient):
 
 
 @parametrize("wel_class", [Well, LayeredWell])
-@pytest.mark.usefixtures("imod5_dataset")
 def test_import_and_convert_to_mf6(imod5_dataset, tmp_path, wel_class):
     data = imod5_dataset[0]
     target_dis = StructuredDiscretization.from_imod5_data(data)
@@ -1020,7 +1019,6 @@ def test_import_and_convert_to_mf6(imod5_dataset, tmp_path, wel_class):
 
 
 @parametrize("wel_class", [Well, LayeredWell])
-@pytest.mark.usefixtures("imod5_dataset")
 def test_import__as_steady_state(imod5_dataset, wel_class):
     data = imod5_dataset[0]
     times = "steady-state"
@@ -1033,7 +1031,6 @@ def test_import__as_steady_state(imod5_dataset, wel_class):
 
 
 @parametrize("wel_class", [Well])
-@pytest.mark.usefixtures("imod5_dataset")
 def test_import_and_cleanup(imod5_dataset, wel_class: Well):
     data = imod5_dataset[0]
     target_dis = StructuredDiscretization.from_imod5_data(data)
@@ -1053,7 +1050,6 @@ def test_import_and_cleanup(imod5_dataset, wel_class: Well):
 
 
 @parametrize("wel_class", [Well, LayeredWell])
-@pytest.mark.usefixtures("well_simple_import_prj__steady_state")
 def test_import_simple_wells__steady_state(
     well_simple_import_prj__steady_state, wel_class
 ):
@@ -1074,7 +1070,6 @@ def test_import_simple_wells__steady_state(
 
 
 @parametrize("wel_class", [Well, LayeredWell])
-@pytest.mark.usefixtures("well_simple_import_prj__transient")
 def test_import_simple_wells__transient(well_simple_import_prj__transient, wel_class):
     imod5dict, _ = open_projectfile_data(well_simple_import_prj__transient)
     # Set layer to 1, to avoid validation error.
@@ -1100,7 +1095,6 @@ def test_import_simple_wells__transient(well_simple_import_prj__transient, wel_c
 
 
 @parametrize("wel_class", [Well, LayeredWell])
-@pytest.mark.usefixtures("well_regular_import_prj")
 def test_import_multiple_wells(well_regular_import_prj, wel_class):
     imod5dict, _ = open_projectfile_data(well_regular_import_prj)
     times = [
@@ -1126,7 +1120,6 @@ def test_import_multiple_wells(well_regular_import_prj, wel_class):
 
 
 @parametrize("wel_class", [Well, LayeredWell])
-@pytest.mark.usefixtures("well_duplication_import_prj")
 def test_import_from_imod5_with_duplication(well_duplication_import_prj, wel_class):
     imod5dict, _ = open_projectfile_data(well_duplication_import_prj)
     times = [
@@ -1152,7 +1145,6 @@ def test_import_from_imod5_with_duplication(well_duplication_import_prj, wel_cla
 
 
 @pytest.mark.parametrize("layer", [0, 1])
-@pytest.mark.usefixtures("well_regular_import_prj")
 def test_logmessage_for_layer_assignment_import_imod5(
     tmp_path, well_regular_import_prj, layer
 ):
@@ -1193,7 +1185,6 @@ def test_logmessage_for_layer_assignment_import_imod5(
 
 
 @pytest.mark.parametrize("remove", ["filt_top", "filt_bot", None])
-@pytest.mark.usefixtures("well_regular_import_prj")
 def test_logmessage_for_missing_filter_settings(
     tmp_path, well_regular_import_prj, remove
 ):

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -524,8 +524,8 @@ class ClipBoxCases:
     def case_clip_top_is_non_layered_unstructuredgrid(parameterizable_basic_dis):
         idomain, top, bottom = parameterizable_basic_dis
         top, bottom = broadcast_to_full_domain(idomain, top, bottom)
-        top = xu.UgridDataArray.from_structured(top)
-        bottom = xu.UgridDataArray.from_structured(bottom)
+        top = xu.UgridDataArray.from_structured2d(top)
+        bottom = xu.UgridDataArray.from_structured2d(bottom)
 
         top = top.isel(layer=0).drop_vars("layer")
 
@@ -538,8 +538,8 @@ class ClipBoxCases:
     def case_clip_top_is_layered_unstructuredgrid(parameterizable_basic_dis):
         idomain, top, bottom = parameterizable_basic_dis
         top, bottom = broadcast_to_full_domain(idomain, top, bottom)
-        top = xu.UgridDataArray.from_structured(top)
-        bottom = xu.UgridDataArray.from_structured(bottom)
+        top = xu.UgridDataArray.from_structured2d(top)
+        bottom = xu.UgridDataArray.from_structured2d(bottom)
 
         clip_arguments = {"layer_max": 2, "bottom": bottom, "top": top}
 

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter.py
@@ -1,12 +1,10 @@
 import numpy as np
-import pytest
 
 from imod.mf6.multimodel.modelsplitter import create_partition_info, slice_model
 from imod.tests.fixtures.mf6_modelrun_fixture import assert_simulation_can_run
 from imod.typing.grid import zeros_like
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_slice_model_structured(twri_model):
     """
     Create a sub model array for the twri model.
@@ -42,7 +40,6 @@ def test_slice_model_structured(twri_model):
         assert label_counts[submodel_label] == active_count.values
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_slice_model_unstructured(circle_model):
     """
     Create a sub model array for the circle model.
@@ -74,7 +71,6 @@ def test_slice_model_unstructured(circle_model):
         assert label_counts[submodel_label] == active_count.values
 
 
-@pytest.mark.usefixtures("flow_transport_simulation")
 def test_slice_model_with_auxiliary_variables(tmp_path, flow_transport_simulation):
     flow_simulation = flow_transport_simulation
     flow_simulation.pop("tpt_a")

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_modelsplitter_transport.py
@@ -33,7 +33,6 @@ def test_slice_model_structured(flow_transport_simulation: Modflow6Simulation):
             assert package_name in list(submodel.keys())
 
 
-@pytest.mark.usefixtures("flow_transport_simulation")
 def test_split_dump(
     tmp_path: Path,
     flow_transport_simulation: Modflow6Simulation,
@@ -62,7 +61,6 @@ def test_split_dump(
     assert len(diff.right_only) == 0
 
 
-@pytest.mark.usefixtures("flow_transport_simulation")
 def test_split_flow_and_transport_model(
     tmp_path: Path, flow_transport_simulation: Modflow6Simulation
 ):
@@ -118,7 +116,6 @@ def test_split_flow_and_transport_model(
     assert_simulation_can_run(new_simulation, tmp_path)
 
 
-@pytest.mark.usefixtures("flow_transport_simulation")
 def test_split_flow_and_transport_model_evaluate_output(
     tmp_path: Path, flow_transport_simulation: Modflow6Simulation
 ):
@@ -161,7 +158,6 @@ def test_split_flow_and_transport_model_evaluate_output(
     )
 
 
-@pytest.mark.usefixtures("flow_transport_simulation")
 def test_split_flow_and_transport_model_evaluate_output_with_species(
     tmp_path: Path, flow_transport_simulation: Modflow6Simulation
 ):
@@ -200,7 +196,6 @@ def test_split_flow_and_transport_model_evaluate_output_with_species(
     )
 
 
-@pytest.mark.usefixtures("flow_transport_simulation")
 @pytest.mark.parametrize("advection_scheme", ["TVD", "upstream", "central"])
 @pytest.mark.parametrize("dsp_xt3d_off", [True, False])
 def test_split_flow_and_transport_settings(

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partition_generation.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partition_generation.py
@@ -36,7 +36,6 @@ def test_partition_1d_happy_flow():
     ]
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_partition_2d_unstructured(circle_model):
     for nr_partitions in range(1, 20):
         label_array = get_label_array(circle_model, nr_partitions)
@@ -51,7 +50,6 @@ def test_partition_2d_unstructured(circle_model):
         assert min(unique) == 0
 
 
-@pytest.mark.usefixtures("twri_model")
 def test_partition_2d_structured(twri_model):
     # We skip a few partition numbers which would give an error. This would
     # happen if the number of partitions in the x or y direction would result in

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioned_simulation_postprocessing.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioned_simulation_postprocessing.py
@@ -1,12 +1,10 @@
 from pathlib import Path
 
 import numpy as np
-import pytest
 
 from imod.mf6.simulation import Modflow6Simulation
 
 
-@pytest.mark.usefixtures("split_transient_twri_model")
 def test_import_heads_structured(
     tmp_path: Path, split_transient_twri_model: Modflow6Simulation
 ):
@@ -97,7 +95,6 @@ def test_import_heads_structured(
     )
 
 
-@pytest.mark.usefixtures("circle_partitioned")
 def test_import_heads_unstructured(tmp_path, circle_partitioned):
     # Arrange
 
@@ -115,7 +112,6 @@ def test_import_heads_unstructured(tmp_path, circle_partitioned):
     assert np.allclose(merged_heads.coords["mesh2d_nFaces"].values, list(range(216)))
 
 
-@pytest.mark.usefixtures("split_transient_twri_model")
 def test_import_balances_structured(
     tmp_path: Path, split_transient_twri_model: Modflow6Simulation
 ):
@@ -150,7 +146,6 @@ def test_import_balances_structured(
             assert dim in merged_balances[key].dims
 
 
-@pytest.mark.usefixtures("circle_partitioned")
 def test_import_balances_unstructured(
     tmp_path: Path, circle_partitioned: Modflow6Simulation
 ):

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -18,7 +18,6 @@ from imod.prepare.hfb import (
 from imod.typing.grid import zeros_like
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @pytest.fixture(scope="function")
 def idomain_top(transient_twri_model):
     idomain = transient_twri_model["GWF_1"].domain
@@ -203,7 +202,6 @@ class HorizontalFlowBarrierCases:
         )
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_structured(
     tmp_path: Path,
@@ -239,7 +237,6 @@ def test_partitioning_structured(
     )
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases(
     "partition_array", cases=PartitionArrayCases, glob="*four_squares"
 )
@@ -264,7 +261,6 @@ def test_split_dump(
     assert len(diff.right_only) == 0
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases.case_four_squares)
 def test_partitioning_write_after_split(
     tmp_path: Path,
@@ -287,7 +283,6 @@ def test_partitioning_write_after_split(
     assert len(diff.right_only) == 0
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_structured_with_inactive_cells(
     tmp_path: Path,
@@ -337,7 +332,6 @@ def test_partitioning_structured_with_inactive_cells(
     )
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_structured_with_vpt_cells(
     tmp_path: Path,
@@ -389,7 +383,6 @@ def test_partitioning_structured_with_vpt_cells(
     )
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases(
     "partition_array", cases=PartitionArrayCases, has_tag="intrusion"
 )
@@ -464,7 +457,6 @@ def test_partitioning_structured_geometry_auxiliary_variables(
     )
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 @parametrize_with_cases("well", cases=WellCases)
 def test_partitioning_structured_one_high_level_well(
@@ -526,7 +518,6 @@ def is_expected_hfb_partition_combination_fail(current_cases):
     return False
 
 
-@pytest.mark.usefixtures("transient_twri_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 @parametrize_with_cases("hfb", cases=HorizontalFlowBarrierCases)
 def test_partitioning_structured_hfb(

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured.py
@@ -14,7 +14,6 @@ from imod.prepare.hfb import linestring_to_square_zpolygons
 from imod.typing.grid import ones_like, zeros_like
 
 
-@pytest.mark.usefixtures("circle_model")
 @pytest.fixture(scope="function")
 def idomain_top(circle_model):
     idomain = circle_model["GWF_1"].domain
@@ -157,7 +156,6 @@ def is_expected_hfb_partition_combination_fail(current_cases):
     return False
 
 
-@pytest.mark.usefixtures("circle_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_unstructured(
     tmp_path: Path, circle_model: Modflow6Simulation, partition_array: xu.UgridDataArray
@@ -197,7 +195,6 @@ def test_partitioning_unstructured(
         )
 
 
-@pytest.mark.usefixtures("circle_model")
 @pytest.mark.parametrize("inactivity_marker", [0, -1])
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_unstructured_with_inactive_cells(
@@ -250,7 +247,6 @@ def test_partitioning_unstructured_with_inactive_cells(
     )
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_partitioning_unstructured_voronoi_conversion(
     tmp_path: Path,
     circle_model: Modflow6Simulation,
@@ -307,7 +303,6 @@ def test_partitioning_unstructured_voronoi_conversion(
     )
 
 
-@pytest.mark.usefixtures("circle_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 @parametrize_with_cases("hfb", cases=HorizontalFlowBarrierCases)
 def test_partitioning_unstructured_hfb(
@@ -363,7 +358,6 @@ def test_partitioning_unstructured_hfb(
         )
 
 
-@pytest.mark.usefixtures("circle_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 @parametrize_with_cases("well", cases=WellCases)
 def test_partitioning_unstructured_with_well(
@@ -450,7 +444,6 @@ def get_exchange_masks(actual_flow_budget, expected_flow_budget):
     return is_exchange_cell, is_exchange_edge
 
 
-@pytest.mark.usefixtures("circle_model_transport")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partition_transport(
     tmp_path: Path,
@@ -503,7 +496,6 @@ def test_partition_transport(
         )
 
 
-@pytest.mark.usefixtures("circle_model_transport_multispecies_variable_density")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partition_transport_multispecies(
     tmp_path: Path,
@@ -580,7 +572,6 @@ def test_partition_transport_multispecies(
         )
 
 
-@pytest.mark.usefixtures("circle_model")
 def test_slice_model_twice(tmp_path, circle_model):
     flow_model = circle_model["GWF_1"]
     active = flow_model.domain

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured_discharge.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_unstructured_discharge.py
@@ -29,7 +29,6 @@ def save_and_load(tmp_path: Path, ugrid: UnstructuredData) -> xu.UgridDataset:
     return ugrid
 
 
-@pytest.mark.usefixtures("circle_model")
 @pytest.fixture(scope="function")
 def idomain_top(circle_model):
     idomain = circle_model["GWF_1"].domain
@@ -84,7 +83,6 @@ class PartitionArrayCases:
         return three_parts
 
 
-@pytest.mark.usefixtures("circle_model")
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_specific_discharge_results(
     tmp_path: Path, circle_model: Modflow6Simulation, partition_array: xu.UgridDataArray

--- a/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
+++ b/imod/tests/test_mf6/test_utilities/test_mf6hfb.py
@@ -13,7 +13,6 @@ from imod.mf6.utilities.mf6hfb import merge_hfb_packages
 from imod.prepare.hfb import linestring_to_square_zpolygons
 
 
-@pytest.mark.usefixtures("structured_flow_model")
 @pytest.fixture(scope="function")
 def modellayers_single_layer(structured_flow_model):
     model = structured_flow_model.clip_box(layer_max=1)
@@ -29,7 +28,6 @@ def modellayers_single_layer(structured_flow_model):
     }
 
 
-@pytest.mark.usefixtures("structured_flow_model")
 @pytest.fixture(scope="function")
 def modellayers(structured_flow_model):
     model = structured_flow_model

--- a/imod/util/spatial.py
+++ b/imod/util/spatial.py
@@ -358,7 +358,7 @@ def from_mdal_compliant_ugrid2d(dataset: xu.UgridDataset) -> xu.UgridDataset:
         grouped[name].append(da.assign_coords(layer=int(layer)))
 
     # Concatenate, and make sure the dimension order is natural.
-    ugrid_dims = {dim for grid in dataset.ugrid.grids for dim in grid.dimensions}
+    ugrid_dims = {dim for grid in dataset.ugrid.grids for dim in grid.sizes.keys()}
     for variable, das in grouped.items():
         da = xr.concat(sorted(das, key=lambda da: da["layer"]), dim="layer")
         newdims = list(da.dims)


### PR DESCRIPTION
Quells a lot more warnings thrown by test suite.

- Adds function ``enforce_scalar`` to enforce a scalar value
- Remove the pytest.mark.usefixtures decorators as these only give warnings and do not do much
- Change ``freq="H"`` in pandas to ``freq="h"``
- Remove references to deprecated ``dimensions`` attribute in xugrid
- Call xu.UgridDataArrray.from_structured2d instead of deprecated   xu.UgridDataArrray.from_structured
- Do not call ``set_repeat_stress`` anymore, as we deprecated this method ourselves.
