### PR TITLE
Issue #492 add logging simulation

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -13,7 +13,7 @@ Added
 ~~~~~
 
 - :meth:`imod.msw.MetaSwapModel.clip_box` to clip MetaSWAP models.
-
+- Methods of class :class:`imod.mf6.Modflow6Simulation` can now be logged.
 
 [1.0.0rc2] - 2025-03-05
 -----------------------

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1452,7 +1452,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         simulation._validation_context.strict_hfb_validation = False
 
         # import GWF model,
-        groundwaterFlowModel = GroundwaterFlowModel.from_imod5_data(
+        gwf_model = GroundwaterFlowModel.from_imod5_data(
             imod5_data,
             period_data,
             times,
@@ -1460,7 +1460,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             distributing_options,
             regridder_types,
         )
-        simulation["imported_model"] = groundwaterFlowModel
+        simulation["imported_model"] = gwf_model
 
         # generate ims package
         solution = SolutionPresetModerate(

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -131,6 +131,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         )
         self.create_time_discretization(additional_times=times)
 
+    @standard_log_decorator()
     def create_time_discretization(self, additional_times, validate: bool = True):
         """
         Collect all unique times from model packages and additional given
@@ -337,6 +338,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
 
         self.directory = directory
 
+    @standard_log_decorator()
     def run(self, mf6path: Union[str, Path] = "mf6") -> None:
         """
         Run Modflow 6 simulation. This method runs a subprocess calling
@@ -369,6 +371,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
                     f"{result.returncode}, and error message:\n\n{result.stdout.decode()} "
                 )
 
+    @standard_log_decorator()
     def open_head(
         self,
         dry_nan: bool = False,
@@ -427,6 +430,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             time_unit=time_unit,
         )
 
+    @standard_log_decorator()
     def open_transport_budget(
         self,
         species_ls: Optional[list[str]] = None,
@@ -466,6 +470,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             flowja=False,
         )
 
+    @standard_log_decorator()
     def open_flow_budget(
         self,
         flowja: bool = False,
@@ -535,6 +540,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             merge_to_dataset=True,
         )
 
+    @standard_log_decorator()
     def open_concentration(
         self,
         species_ls: Optional[list[str]] = None,
@@ -919,6 +925,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         return
 
     @staticmethod
+    @standard_log_decorator()
     def from_file(toml_path):
         classes = {
             item_cls.__name__: item_cls
@@ -980,6 +987,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
     def get_models(self):
         return {k: v for k, v in self.items() if isinstance(v, Modflow6Model)}
 
+    @standard_log_decorator()
     def clip_box(
         self,
         time_min: Optional[cftime.datetime | np.datetime64 | str] = None,
@@ -1069,6 +1077,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
                 raise ValueError(f"object of type {type(value)} cannot be clipped.")
         return clipped
 
+    @standard_log_decorator()
     def split(self, submodel_labels: GridDataArray) -> Modflow6Simulation:
         """
         Split a simulation in different partitions using a submodel_labels array.
@@ -1150,6 +1159,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         new_simulation._filter_inactive_cells_from_exchanges()
         return new_simulation
 
+    @standard_log_decorator()
     def regrid_like(
         self,
         regridded_simulation_name: str,
@@ -1328,6 +1338,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         flow_models = self.get_models_of_type("gwf6")
         return len(flow_models) == 1
 
+    @standard_log_decorator()
     def mask_all_models(
         self,
         mask: GridDataArray,

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -619,7 +619,6 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             raise RuntimeError(
                 f"Unexpected error when opening {output} for {modelnames}"
             )
-        return
 
     def _open_single_output(
         self, modelnames: list[str], output: str, **settings
@@ -908,7 +907,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             elif key in ["gwtgwf_exchanges", "split_exchanges"]:
                 toml_content[key] = collections.defaultdict(list)
                 for exchange_package in self[key]:
-                    exchange_type, filename, _, _ = exchange_package.get_specification()
+                    _, filename, _, _ = exchange_package.get_specification()
                     exchange_class_short = type(exchange_package).__name__
                     path = f"{filename}.nc"
                     exchange_package.dataset.to_netcdf(directory / path)
@@ -921,8 +920,6 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
 
         with open(directory / f"{self.name}.toml", "wb") as f:
             tomli_w.dump(toml_content, f)
-
-        return
 
     @staticmethod
     @standard_log_decorator()


### PR DESCRIPTION
Fixes #492

# Description
Adds some simple logging to the simulation object. I didn't add solver settings, these are listed in the .ims file. I also didn't add stdout of MODFLOW6, as this is already logged in the LIST file and would require some extra work.

Furthermore some boyscouting: fix some easy-to-fix issues raised by Sonarcloud:

- Remove unreachable return statements
- Don't use caps in variable's name

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
