### PR TITLE
Issue #915 fix clip_repeat_stress when time_start or time_end is None

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -15,6 +15,15 @@ Added
 - :meth:`imod.msw.MetaSwapModel.clip_box` to clip MetaSWAP models.
 - Methods of class :class:`imod.mf6.Modflow6Simulation` can now be logged.
 
+Fixed
+~~~~~
+
+- Fixed bug where :meth:`imod.mf6.River.clip_box`,
+  :meth:`imod.mf6.Drainage.clip_box`, and
+  :meth:`imod.mf6.GeneralHeadBoundary.clip_box` threw an error when
+  ``time_start`` or ``time_end`` were set to ``None`` and a ``"repeat_stress"``
+  was included in the dataset.
+
 [1.0.0rc2] - 2025-03-05
 -----------------------
 

--- a/imod/tests/test_common/test_utilities/test_clip.py
+++ b/imod/tests/test_common/test_utilities/test_clip.py
@@ -382,6 +382,7 @@ def test_clip_repeat_stress__all_repeats_promoted(dataset):
     from 2000-01-01 to 2000-12-01. After clipping, the values should be promoted
     to 2005-01-01 to 2005-12-01.
     """
+    # Arrange
     dataset = dataset.copy()
     keys = pd.date_range("2001-01-01", "2009-12-01", freq="MS")
     values = np.tile(dataset["time"], reps=9)
@@ -393,7 +394,7 @@ def test_clip_repeat_stress__all_repeats_promoted(dataset):
     time = dataset["time"].values
     time_start = imod.util.time.to_datetime_internal("2005-01-01", False)
     time_end = imod.util.time.to_datetime_internal("2008-12-01", False)
-
+    # Act
     indexer = clip_time_indexer(
         time=time,
         time_start=time_start,
@@ -406,7 +407,6 @@ def test_clip_repeat_stress__all_repeats_promoted(dataset):
         time_end=time_end,
     )
     indexer = repeat_indexer.combine_first(indexer).astype(int)
-
     keys = repeat_stress.loc[:, 0]
     values = repeat_stress.loc[:, 1]
     actual = dataset.drop_vars("time").isel(time=indexer)
@@ -429,6 +429,7 @@ def test_clip_repeat_stress__some_repeats_promoted(dataset_time_outlying):
     After clipping, the values in 2000 should be promoted to the year 2005. The
     three prior values in 2005 should be preserved.
     """
+    # Arrange
     dataset = dataset_time_outlying.copy()
     keys = pd.date_range("2001-01-01", "2009-12-01", freq="MS")
     values = np.tile(dataset["time"][:12], reps=9)
@@ -440,7 +441,7 @@ def test_clip_repeat_stress__some_repeats_promoted(dataset_time_outlying):
     time = dataset["time"].values
     time_start = imod.util.time.to_datetime_internal("2005-01-01", False)
     time_end = imod.util.time.to_datetime_internal("2008-12-01", False)
-
+    # Act
     indexer = clip_time_indexer(
         time=dataset["time"].values,
         time_start=time_start,
@@ -453,12 +454,11 @@ def test_clip_repeat_stress__some_repeats_promoted(dataset_time_outlying):
         time_end=time_end,
     )
     indexer = repeat_indexer.combine_first(indexer).astype(int)
-
     keys = repeat_stress.loc[:, 0]
     values = repeat_stress.loc[:, 1]
     actual = dataset.drop_vars("time").isel(time=indexer)
-    time_actual = actual.coords["time"]
     # Assert
+    time_actual = actual.coords["time"]
     np.testing.assert_array_equal(time_actual.dt.year, np.repeat([2005], repeats=15))
     np.testing.assert_array_equal(
         time_actual.dt.month,
@@ -485,6 +485,7 @@ def test_clip_repeat_stress__no_end(dataset_time_outlying):
     promoted to the year 2005. The three prior values in 2005 should be
     preserved.
     """
+    # Arrange
     dataset = dataset_time_outlying.copy()
     keys = pd.date_range("2001-01-01", "2009-12-01", freq="MS")
     values = np.tile(dataset["time"][:12], reps=9)
@@ -496,7 +497,7 @@ def test_clip_repeat_stress__no_end(dataset_time_outlying):
     time = dataset["time"].values
     time_start = imod.util.time.to_datetime_internal("2005-01-01", False)
     time_end = None
-
+    # Act
     indexer = clip_time_indexer(
         time=dataset["time"].values,
         time_start=time_start,
@@ -509,10 +510,10 @@ def test_clip_repeat_stress__no_end(dataset_time_outlying):
         time_end=time_end,
     )
     indexer = repeat_indexer.combine_first(indexer).astype(int)
-
     keys = repeat_stress.loc[:, 0]
     values = repeat_stress.loc[:, 1]
     actual = dataset.drop_vars("time").isel(time=indexer)
+    # Assert
     time_actual = actual.coords["time"]
     np.testing.assert_array_equal(time_actual.dt.year, np.repeat([2005], repeats=15))
     np.testing.assert_array_equal(
@@ -536,6 +537,7 @@ def test_clip_repeat_stress__no_start_no_end(dataset_time_outlying):
     Test where no time_start and no time_end is specified. Dataset should stay
     the same.
     """
+    # Arrange
     dataset = dataset_time_outlying.copy()
     keys = pd.date_range("2001-01-01", "2009-12-01", freq="MS")
     values = np.tile(dataset["time"][:12], reps=9)
@@ -547,7 +549,7 @@ def test_clip_repeat_stress__no_start_no_end(dataset_time_outlying):
     time = dataset["time"].values
     time_start = None
     time_end = None
-
+    # Act
     indexer = clip_time_indexer(
         time=dataset["time"].values,
         time_start=time_start,
@@ -560,7 +562,6 @@ def test_clip_repeat_stress__no_start_no_end(dataset_time_outlying):
         time_end=time_end,
     )
     indexer = repeat_indexer.combine_first(indexer).astype(int)
-
     keys = repeat_stress.loc[:, 0]
     values = repeat_stress.loc[:, 1]
     actual = dataset.drop_vars("time").isel(time=indexer)

--- a/imod/tests/test_common/test_utilities/test_clip.py
+++ b/imod/tests/test_common/test_utilities/test_clip.py
@@ -457,16 +457,15 @@ def test_clip_repeat_stress__some_repeats_promoted(dataset_time_outlying):
     keys = repeat_stress.loc[:, 0]
     values = repeat_stress.loc[:, 1]
     actual = dataset.drop_vars("time").isel(time=indexer)
+    time_actual = actual.coords["time"]
     # Assert
+    np.testing.assert_array_equal(time_actual.dt.year, np.repeat([2005], repeats=15))
     np.testing.assert_array_equal(
-        actual.coords["time"].dt.year, np.repeat([2005], repeats=15)
-    )
-    np.testing.assert_array_equal(
-        actual.coords["time"].dt.month,
+        time_actual.dt.month,
         np.array([1, 1, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
     )
     np.testing.assert_array_equal(
-        actual.coords["time"].dt.day,
+        time_actual.dt.day,
         np.array([1, 15, 1, 15, 1, 15, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
     )
     assert np.array_equal(
@@ -474,7 +473,7 @@ def test_clip_repeat_stress__some_repeats_promoted(dataset_time_outlying):
     )
     assert np.array_equal(keys.dt.year, np.repeat([2006, 2007, 2008], repeats=12))
     assert np.array_equal(keys.dt.month, values.dt.month)
-    assert np.isin(values, actual["time"]).all()
+    assert np.isin(values, time_actual).all()
 
 
 def test_clip_repeat_stress__no_end(dataset_time_outlying):
@@ -514,15 +513,14 @@ def test_clip_repeat_stress__no_end(dataset_time_outlying):
     keys = repeat_stress.loc[:, 0]
     values = repeat_stress.loc[:, 1]
     actual = dataset.drop_vars("time").isel(time=indexer)
+    time_actual = actual.coords["time"]
+    np.testing.assert_array_equal(time_actual.dt.year, np.repeat([2005], repeats=15))
     np.testing.assert_array_equal(
-        actual.coords["time"].dt.year, np.repeat([2005], repeats=15)
-    )
-    np.testing.assert_array_equal(
-        actual.coords["time"].dt.month,
+        time_actual.dt.month,
         np.array([1, 1, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
     )
     np.testing.assert_array_equal(
-        actual.coords["time"].dt.day,
+        time_actual.dt.day,
         np.array([1, 15, 1, 15, 1, 15, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
     )
     assert np.array_equal(
@@ -530,7 +528,7 @@ def test_clip_repeat_stress__no_end(dataset_time_outlying):
     )
     assert np.array_equal(keys.dt.year, np.repeat([2006, 2007, 2008, 2009], repeats=12))
     assert np.array_equal(keys.dt.month, values.dt.month)
-    assert np.isin(values, actual["time"]).all()
+    assert np.isin(values, time_actual).all()
 
 
 def test_clip_repeat_stress__no_start_no_end(dataset_time_outlying):

--- a/imod/tests/test_common/test_utilities/test_clip.py
+++ b/imod/tests/test_common/test_utilities/test_clip.py
@@ -295,7 +295,10 @@ def dataset():
 
 
 @pytest.fixture(scope="function")
-def dataset2():
+def dataset_time_outlying():
+    """
+    Dataset with time coordinates with 3 outlying timestamps.
+    """
     dataset = xr.Dataset()
     time = np.concatenate(
         [
@@ -372,7 +375,13 @@ def test_clip_time_indexer__within(dataset):
     assert indexer.equals(expected)
 
 
-def test_clip_repeat_stress__all_repeats(dataset):
+def test_clip_repeat_stress__all_repeats_promoted(dataset):
+    """
+    Test where all repeat values should be promoted to new dates. The repeat
+    stress range is from 2001-01-01 to 2009-12-01. The repeated values range
+    from 2000-01-01 to 2000-12-01. After clipping, the values should be promoted
+    to 2005-01-01 to 2005-12-01.
+    """
     dataset = dataset.copy()
     keys = pd.date_range("2001-01-01", "2009-12-01", freq="MS")
     values = np.tile(dataset["time"], reps=9)
@@ -386,7 +395,7 @@ def test_clip_repeat_stress__all_repeats(dataset):
     time_end = imod.util.time.to_datetime_internal("2008-12-01", False)
 
     indexer = clip_time_indexer(
-        time=dataset["time"].values,
+        time=time,
         time_start=time_start,
         time_end=time_end,
     )
@@ -401,20 +410,26 @@ def test_clip_repeat_stress__all_repeats(dataset):
     keys = repeat_stress.loc[:, 0]
     values = repeat_stress.loc[:, 1]
     actual = dataset.drop_vars("time").isel(time=indexer)
-    assert actual["time"].size == 12
+    time_actual = actual.coords["time"]
     # Assert
-    np.testing.assert_array_equal(
-        actual.coords["time"].dt.year, np.repeat([2005], repeats=12)
-    )
-    np.testing.assert_array_equal(actual.coords["time"].dt.month, np.arange(1, 13))
-    np.testing.assert_array_equal(actual.coords["time"].dt.day, np.ones(12))
+    assert time_actual.size == 12
+    np.testing.assert_array_equal(time_actual.dt.year, np.repeat([2005], repeats=12))
+    np.testing.assert_array_equal(time_actual.dt.month, np.arange(1, 13))
+    np.testing.assert_array_equal(time_actual.dt.day, np.ones(12))
     assert np.array_equal(keys.dt.year, np.repeat([2006, 2007, 2008], repeats=12))
     assert np.array_equal(keys.dt.month, values.dt.month)
-    assert np.isin(values, actual["time"]).all()
+    assert np.isin(values, time_actual).all()
 
 
-def test_clip_repeat_stress__some_repeats(dataset2):
-    dataset = dataset2.copy()
+def test_clip_repeat_stress__some_repeats_promoted(dataset_time_outlying):
+    """
+    Test where some repeat values should be promoted to new dates. The repeat
+    stress range is from 2001-01-01 to 2009-12-01. The repeated values range
+    from 2000-01-01 to 2000-12-01, plus 2005-01-15, 2005-02-15, 2005-03-15.
+    After clipping, the values in 2000 should be promoted to the year 2005. The
+    three prior values in 2005 should be preserved.
+    """
+    dataset = dataset_time_outlying.copy()
     keys = pd.date_range("2001-01-01", "2009-12-01", freq="MS")
     values = np.tile(dataset["time"][:12], reps=9)
     dataset["repeat_stress"] = xr.DataArray(
@@ -462,8 +477,16 @@ def test_clip_repeat_stress__some_repeats(dataset2):
     assert np.isin(values, actual["time"]).all()
 
 
-def test_clip_repeat_stress__no_end(dataset2):
-    dataset = dataset2.copy()
+def test_clip_repeat_stress__no_end(dataset_time_outlying):
+    """
+    Test where no time_end is specified. Some repeat values should be promoted
+    to new dates. The repeat stress range is from 2001-01-01 to 2009-12-01. The
+    repeated values range from 2000-01-01 to 2000-12-01, plus 2005-01-15,
+    2005-02-15, 2005-03-15. After clipping, the values in 2000 should be
+    promoted to the year 2005. The three prior values in 2005 should be
+    preserved.
+    """
+    dataset = dataset_time_outlying.copy()
     keys = pd.date_range("2001-01-01", "2009-12-01", freq="MS")
     values = np.tile(dataset["time"][:12], reps=9)
     dataset["repeat_stress"] = xr.DataArray(
@@ -510,8 +533,12 @@ def test_clip_repeat_stress__no_end(dataset2):
     assert np.isin(values, actual["time"]).all()
 
 
-def test_clip_repeat_stress__no_start_no_end(dataset2):
-    dataset = dataset2.copy()
+def test_clip_repeat_stress__no_start_no_end(dataset_time_outlying):
+    """
+    Test where no time_start and no time_end is specified. Dataset should stay
+    the same.
+    """
+    dataset = dataset_time_outlying.copy()
     keys = pd.date_range("2001-01-01", "2009-12-01", freq="MS")
     values = np.tile(dataset["time"][:12], reps=9)
     dataset["repeat_stress"] = xr.DataArray(

--- a/imod/tests/test_common/test_utilities/test_clip.py
+++ b/imod/tests/test_common/test_utilities/test_clip.py
@@ -403,7 +403,9 @@ def test_clip_repeat_stress__all_repeats(dataset):
     actual = dataset.drop_vars("time").isel(time=indexer)
     assert actual["time"].size == 12
     # Assert
-    np.testing.assert_array_equal(actual.coords["time"].dt.year, np.repeat([2005], repeats=12))
+    np.testing.assert_array_equal(
+        actual.coords["time"].dt.year, np.repeat([2005], repeats=12)
+    )
     np.testing.assert_array_equal(actual.coords["time"].dt.month, np.arange(1, 13))
     np.testing.assert_array_equal(actual.coords["time"].dt.day, np.ones(12))
     assert np.array_equal(keys.dt.year, np.repeat([2006, 2007, 2008], repeats=12))
@@ -441,9 +443,17 @@ def test_clip_repeat_stress__some_repeats(dataset2):
     values = repeat_stress.loc[:, 1]
     actual = dataset.drop_vars("time").isel(time=indexer)
     # Assert
-    np.testing.assert_array_equal(actual.coords["time"].dt.year, np.repeat([2005], repeats=15))
-    np.testing.assert_array_equal(actual.coords["time"].dt.month, np.array([1, 1, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]))
-    np.testing.assert_array_equal(actual.coords["time"].dt.day, np.array([1, 15, 1, 15, 1, 15, 1, 1, 1, 1, 1, 1, 1, 1, 1]))
+    np.testing.assert_array_equal(
+        actual.coords["time"].dt.year, np.repeat([2005], repeats=15)
+    )
+    np.testing.assert_array_equal(
+        actual.coords["time"].dt.month,
+        np.array([1, 1, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+    )
+    np.testing.assert_array_equal(
+        actual.coords["time"].dt.day,
+        np.array([1, 15, 1, 15, 1, 15, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    )
     assert np.array_equal(
         actual["multiplier"], [1, 13, 2, 14, 3, 15, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     )
@@ -481,9 +491,17 @@ def test_clip_repeat_stress__no_end(dataset2):
     keys = repeat_stress.loc[:, 0]
     values = repeat_stress.loc[:, 1]
     actual = dataset.drop_vars("time").isel(time=indexer)
-    np.testing.assert_array_equal(actual.coords["time"].dt.year, np.repeat([2005], repeats=15))
-    np.testing.assert_array_equal(actual.coords["time"].dt.month, np.array([1, 1, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]))
-    np.testing.assert_array_equal(actual.coords["time"].dt.day, np.array([1, 15, 1, 15, 1, 15, 1, 1, 1, 1, 1, 1, 1, 1, 1]))
+    np.testing.assert_array_equal(
+        actual.coords["time"].dt.year, np.repeat([2005], repeats=15)
+    )
+    np.testing.assert_array_equal(
+        actual.coords["time"].dt.month,
+        np.array([1, 1, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+    )
+    np.testing.assert_array_equal(
+        actual.coords["time"].dt.day,
+        np.array([1, 15, 1, 15, 1, 15, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    )
     assert np.array_equal(
         actual["multiplier"], [1, 13, 2, 14, 3, 15, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     )
@@ -523,11 +541,7 @@ def test_clip_repeat_stress__no_start_no_end(dataset2):
     actual = dataset.drop_vars("time").isel(time=indexer)
     # Assert
     assert dataset.coords["time"].equals(actual.coords["time"])
-    assert np.array_equal(
-        actual["multiplier"], np.arange(1, 16)
-    )
-    assert np.array_equal(
-        keys.dt.year, np.repeat(np.arange(9) + 2001, repeats=12)
-    )
+    assert np.array_equal(actual["multiplier"], np.arange(1, 16))
+    assert np.array_equal(keys.dt.year, np.repeat(np.arange(9) + 2001, repeats=12))
     assert np.array_equal(keys.dt.month, values.dt.month)
     assert np.isin(values, actual["time"]).all()


### PR DESCRIPTION
Fixes #915

# Description
- Adds extra tests for ``clip_repeat_stress`` where ``time_start`` or ``time_end`` is None
- In ``clip_repeat_stress``, make clipping work with ``time_start`` or ``time_end`` is None
- In ``clip_repeat_stress``, prepend repeated values before lookup keys, to ensure these values are accounted for in the clipping and subsequent promoting of keys.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
