### PR TITLE
Fix invalid escape chars on for python 3.12

### DIFF
--- a/imod/formats/ipf.py
+++ b/imod/formats/ipf.py
@@ -70,7 +70,7 @@ def _read_ipf(path, kwargs=None) -> Tuple[pd.DataFrame, int, str]:
 
 
 def _read(path, kwargs=None, assoc_kwargs=None):
-    """
+    r"""
     Read one IPF file to a single pandas.DataFrame, including associated (TXT) files.
 
     Parameters
@@ -123,7 +123,7 @@ def _read(path, kwargs=None, assoc_kwargs=None):
 
 
 def read_associated(path, kwargs={}):
-    """
+    r"""
     Read an IPF associated file (TXT).
 
     Parameters
@@ -239,7 +239,7 @@ def read_associated(path, kwargs={}):
 
 
 def read(path, kwargs={}, assoc_kwargs={}):
-    """
+    r"""
     Read one or more IPF files to a single pandas.DataFrame, including associated
     (TXT) files.
 

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -145,10 +145,11 @@ def _derive_connected_cell_ids(
     edge_index :
         The indices of the edges from which the connected cell ids are computed
 
-    Returns A dataset containing the cell_id1 and cell_id2 data variables. The  cell dimensions are stored in the
-    cell_dims coordinates.
+    Returns 
     -------
-
+    xr.Dataset :
+        A dataset containing the cell_id1 and cell_id2 data variables. The cell
+        dimensions are stored in the cell_dims coordinates.
     """
     edge_faces = grid.edge_face_connectivity
     cell2d = edge_faces[edge_index]

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -145,7 +145,7 @@ def _derive_connected_cell_ids(
     edge_index :
         The indices of the edges from which the connected cell ids are computed
 
-    Returns 
+    Returns
     -------
     xr.Dataset :
         A dataset containing the cell_id1 and cell_id2 data variables. The cell

--- a/imod/prepare/hfb.py
+++ b/imod/prepare/hfb.py
@@ -116,7 +116,7 @@ def _line_to_trapezoid_zpolygon(
     zt: Tuple[float, float],
     zb: Tuple[float, float],
 ) -> PolygonType:
-    """
+    r"""
     Creates polygon as follows::
 
         xy0,zt0
@@ -146,7 +146,7 @@ def linestring_to_trapezoid_zpolygons(
     barrier_ztop: List[float],
     barrier_zbottom: List[float],
 ) -> List[PolygonType]:
-    """
+    r"""
     Create trapezoid vertical polygons from linestrings, with a varying ztop and
     zbottom over the line. These are shaped as follows::
 


### PR DESCRIPTION
Fixes #1488

Makes some of the docstrings a raw string; not sure what what was up with the `hfb` doctring, maybe copy-pasted from somewhere, it was misformatted anyway.