### PR TITLE
Issue #1510 Print unexpected coordinate names in mask_all_packages

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+[Unreleased]
+------------
+
+Fixed
+~~~~~
+
+- Upon providing an unexpected coordinate in the mask or regridding grid,
+  :meth:`imod.mf6.Modflow6Simulation.regrid_like` and
+  :meth:`imod.mf6.Modflow6Simulation.mask` now present the unexpected
+  coordinates in the error message.
+
 [1.0.0rc3] - 2025-04-17
 -----------------------
 

--- a/imod/tests/test_mf6/test_mf6_model_masking.py
+++ b/imod/tests/test_mf6/test_mf6_model_masking.py
@@ -235,7 +235,6 @@ def test_mask_unstructured(
 
 
 def test_mask_with_time_coordinate(
-    tmp_path: Path,
     unstructured_flow_model: GroundwaterFlowModel,
 ):
     nlayer = 3
@@ -251,7 +250,9 @@ def test_mask_with_time_coordinate(
     mask.sel(time=1).values = np.array([1, 1, 0])
     mask.sel(time=2).values = np.array([1, 0, 1])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Unexpected coordinates in masking domain: {'time'}"
+    ):
         unstructured_flow_model.mask_all_packages(mask)
 
 

--- a/imod/tests/test_mf6/test_mf6_regrid_package.py
+++ b/imod/tests/test_mf6/test_mf6_regrid_package.py
@@ -145,15 +145,11 @@ def test_regrid_unstructured():
 
     new_idomain = new_packages[0].dataset["icelltype"]
     for new_package in new_packages:
-        # TODO github-398: package write validation crashes for VerticesDiscretization so we skip that one
-        if not isinstance(new_package, imod.mf6.VerticesDiscretization):
-            errors = new_package._validate(
-                new_package._write_schemata,
-                idomain=new_idomain,
-            )
-            assert len(errors) == 0
-        else:
-            continue
+        errors = new_package._validate(
+            new_package._write_schemata,
+            idomain=new_idomain,
+        )
+        assert len(errors) == 0
 
 
 def test_regrid_structured_missing_dx_and_dy():


### PR DESCRIPTION
Fixes #1510

# Description
Quality-of-life improvement: Print unexpected coordinate names, saves some headache figuring out what is wrong with the mask.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
