### PR TITLE
Consistently spell "MODFLOW 6" in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ datasets. Some of its core functionalities are:
 
 * Preparing and modifying data from a variety of GIS, scientific, and MODFLOW
   file formats;
-* Regridding, clipping, masking, and splitting MODFLOW6 models;
+* Regridding, clipping, masking, and splitting MODFLOW 6 models;
 * Fast writing of data to MODFLOW-based models;
 * Selecting and evaluating, e.g. for time series comparison or water budgets;
 * Visualizing cross sections, time series, or 3D animations.
@@ -27,7 +27,7 @@ We currently support the following MODFLOW-based kernels:
 * `iMOD-WQ`_, which integrates SEAWAT (density-dependent
   groundwater flow) and MT3DMS (multi-species reactive transport calculations)
 
-Development currently focuses on supporting more Modflow 6 functionalities.
+Development currently focuses on supporting more MODFLOW 6 functionalities.
 iMOD-WQ has been sunset and will no longer be developed.
 
 Why ``imod``?
@@ -36,7 +36,7 @@ Why ``imod``?
 1\. Easily create grid-based model packages
 -------------------------------------------
 
-Seamlessly integrate your GIS rasters or meshes with MODFLOW6, by using `xarray`_
+Seamlessly integrate your GIS rasters or meshes with MODFLOW 6, by using `xarray`_
 and `xugrid`_ arrays, for structured and unstructured grids, respectively, to
 create grid-based model packages. 
 
@@ -88,7 +88,7 @@ layer, row and column:
 
 iMOD Python will take care of the rest and assign the wells to the correct model
 layers upon writing the model. It will furthermore distribute well rates based
-on transmissivities. To verify how wells will be assigned to MODFLOW6 cells before
+on transmissivities. To verify how wells will be assigned to MODFLOW 6 cells before
 writing the entire simulation, you can use the following command:
 
 .. code-block:: python
@@ -114,7 +114,7 @@ across layers.
 4\. Create stress periods based on times assigned to boundary conditions
 --------------------------------------------------------------------------
 
-MODFLOW6 requires that all stress periods are defined in the time discretization
+MODFLOW 6 requires that all stress periods are defined in the time discretization
 package. However, usually boundary conditions are defined at inconsistent
 times. iMOD Python can help you to create a time discretization package that is
 consistent, based on all the unique times assigned to the boundary conditions.
@@ -139,10 +139,10 @@ consistent, based on all the unique times assigned to the boundary conditions.
   print(simulation["time_discretization"].dataset)
 
 
-5\. Regridding MODFLOW6 models to different grids
--------------------------------------------------
+5\. Regridding MODFLOW 6 models to different grids
+--------------------------------------------------
 
-Regrid MODFLOW6 models to different grids, even from structured to unstructured
+Regrid MODFLOW 6 models to different grids, even from structured to unstructured
 grids. iMOD Python takes care of properly scaling the input parameters. You can
 also configure scaling methods yourself for each input parameter, for example
 when you want to upscale drainage elevations with the minimum instead of the
@@ -157,8 +157,8 @@ average.
 
 `See further explanation here <https://deltares.github.io/imod-python/user-guide/08-regridding.html>`_
 
-6\. Clip MODFLOW6 models to a bounding box
-------------------------------------------
+6\. Clip MODFLOW 6 models to a bounding box
+-------------------------------------------
 
 To reduce the size of your model, you can clip it to a bounding box. This is
 useful for example when you want to create a smaller model for testing purposes.
@@ -184,10 +184,10 @@ You can even provide states for the model, which will be set on the model bounda
   # model.
   print(sim_clipped["gwf"])
 
-7\. Performant writing of MODFLOW6 models
------------------------------------------
+7\. Performant writing of MODFLOW 6 models
+------------------------------------------
 
-iMOD Python efficiently writes MODFLOW6 models to disk, especially large models.
+iMOD Python efficiently writes MODFLOW 6 models to disk, especially large models.
 Tests we have conducted for the Dutch National Groundwater Model (LHM) show that
 iMOD Python can write a model with 21.84 million cells 5 to 60 times faster (for
 respectively 1 and 365 stress periods) than the alternative `Flopy`_ package. 
@@ -227,10 +227,10 @@ If you are not interested in deriving models from spatial data, but just want to
 allocate boundary conditions based on layer, row, column numbers, or create a
 model of a 2D cross-section: You are better off using `Flopy`_.
 
-2\. Not all MODFLOW6 features are supported
--------------------------------------------
+2\. Not all MODFLOW 6 features are supported
+--------------------------------------------
 
-Currently, we don't support the following MODFLOW6 features:
+Currently, we don't support the following MODFLOW 6 features:
 
 - timeseries files
 - DISU package

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -51,7 +51,7 @@ values than before.
 Removed
 ~~~~~~~
 - ``imod.flow`` module has been removed for generating iMODFLOW models. Use
-  ``imod.mf6`` instead to generate MODFLOW6 models.
+  ``imod.mf6`` instead to generate MODFLOW 6 models.
 
 Added
 ~~~~~
@@ -79,7 +79,7 @@ Changed
   zero layer numbers to grid coordinates.
 - In :class:`imod.mf6.StructuredDiscretization`, IDOMAIN can now respectively be
   > 0 to indicate an active cell and <0 to indicate a vertical passthrough cell,
-  consistent with MODFLOW6. Previously this could only be indicated with 1 and
+  consistent with MODFLOW 6. Previously this could only be indicated with 1 and
   -1.
 - :meth:`imod.mf6.Well.from_imod5_data` and
   :meth:`imod.mf6.LayeredWell.from_imod5_data` now also accept the argument
@@ -93,7 +93,7 @@ Changed
   :func:`imod.prepare.wells.assign_wells`, :meth:`imod.mf6.Well.from_imod5_data`
   and :meth:`imod.mf6.LayeredWell.from_imod5_data` now have default values for
   ``minimum_thickness`` and ``minimum_k`` set to 0.0.
-- When intitating a MODFLOW6 package with a ``layer`` coordinate with
+- When intitating a MODFLOW 6 package with a ``layer`` coordinate with
   values <= 0, iMOD Python will throw an error.
 - :class:`imod.mf6.HorizontalFlowBarrierResistance`,
   :class:`imod.mf6.HorizontalFlowBarrierSingleLayerResistance` and other HFB now
@@ -183,7 +183,7 @@ Added
   :class:`imod.mf6.LayeredWell` package from iMOD5 data in the CAP package (for
   MetaSWAP). Currently only griddata (IDF) is supported.
 - :meth:`imod.mf6.Recharge.from_imod5_cap_data` to construct a recharge package
-  for coupling a MODFLOW6 model to MetaSWAP.
+  for coupling a MODFLOW 6 model to MetaSWAP.
 - :meth:`imod.msw.MetaSwapModel.from_imod5_data` to construct a MetaSWAP model
   from data in an iMOD5 projectfile.
 - :meth:`imod.msw.MetaSwapModel.write` has a ``validate`` argument, which can be
@@ -242,7 +242,7 @@ Changed
   We plan to remove this object in the final 1.0 release. `Use the xugrid
   regridder to regrid individual grids instead.
   <https://deltares.github.io/xugrid/examples/regridder_overview.html>`_ To
-  regrid entire MODFLOW6 packages or simulations, `see the user guide here.
+  regrid entire MODFLOW 6 packages or simulations, `see the user guide here.
   <https://deltares.github.io/imod-python/user-guide/08-regridding.html>`_.
 
 [0.18.1] - 2024-11-20
@@ -343,7 +343,7 @@ Changed
 - :func:`imod.prepare.fill` now takes a ``dims`` argument instead of ``by``,
   and will fill over N dimensions. Secondly, the function no longer takes
   an ``invalid`` argument, but instead always treats NaNs as missing.
-- Reverted the need for providing WriteContext objects to MODFLOW6 Model and
+- Reverted the need for providing WriteContext objects to MODFLOW 6 Model and
   Package objects' ``write`` method. These now use similar arguments to the
   :meth:`imod.mf6.Modflow6Simulation.write` method.
 - :class:`imod.msw.CouplingMapping`, :class:`imod.msw.Sprinkling`,
@@ -387,7 +387,7 @@ Added
   definitely will fail.
 - :meth:`imod.msw.MetaSwapModel.regrid_like` to regrid MetaSWAP models.
 - :meth:`imod.mf6.GroundwaterFlowModel.prepare_wel_for_mf6` to prepare wells for
-  MODFLOW6, for debugging purposes.
+  MODFLOW 6, for debugging purposes.
 
 Removed
 ~~~~~~~
@@ -634,7 +634,7 @@ Fixed
 - Packages and boundary conditions in the ``imod.mf6`` module will now throw an
   error upon initialization if coordinate labels are inconsistent amongst
   variables
-- Improved performance for merging structured multimodel Modflow 6 output
+- Improved performance for merging structured multimodel MODFLOW 6 output
 - Bug where :func:`imod.formats.idf.open_subdomains` did not properly support custom
   patterns
 - Added missing validation for ``concentration`` for :class:`imod.mf6.Drainage` and
@@ -741,7 +741,7 @@ Changed
   imod-environment-dev.yml file (containing additional packages for developers).
 - Changed the way :class:`imod.mf6.Modflow6Simulation`,
   :class:`imod.mf6.GroundwaterFlowModel`,
-  :class:`imod.mf6.GroundwaterTransportModel`, and Modflow 6 packages are
+  :class:`imod.mf6.GroundwaterTransportModel`, and MODFLOW 6 packages are
   represented while printing.
 - The grid-agnostic packages :meth:`imod.mf6.Well.regrid_like` and
   :meth:`imod.mf6.HorizontalFlowBarrier.regrid_like` now return a clip with the
@@ -806,14 +806,14 @@ Removed
 Changed
 ~~~~~~~
 
-- TWRI Modflow 6 example uses the grid-agnostic :class:`imod.mf6.Well`
+- TWRI MODFLOW 6 example uses the grid-agnostic :class:`imod.mf6.Well`
   package instead of the :class:`imod.mf6.WellDisStructured` package.
 
 Fixed
 ~~~~~
 
 - :class:`imod.mf6.HorizontalFlowBarrier` would write to a binary file by
-  default. However, the current version of Modflow 6 does not support this.
+  default. However, the current version of MODFLOW 6 does not support this.
   Therefore, this class now always writes to text file.
 
 
@@ -909,13 +909,13 @@ Added
 
 - :class:`imod.mf6.OutputControl` now takes parameters ``head_file``,
   ``concentration_file``, and ``budget_file`` to specify where to store
-  MODFLOW6 output files.
+  MODFLOW 6 output files.
 - :func:`imod.util.spatial.from_mdal_compliant_ugrid2d` to "restack" the variables that
   have have been "unstacked" in :func:`imod.util.spatial.mdal_compliant_ugrid2d`.
 - Added support for the Modflow6 Lake package
 - :func:`imod.select.points_in_bounds`, :func:`imod.select.points_indices`,
   :func:`imod.select.points_values` now support unstructured grids.
-- Added support for the Modflow 6 Lake package: :class:`imod.mf6.Lake`,
+- Added support for the MODFLOW 6 Lake package: :class:`imod.mf6.Lake`,
   :class:`imod.mf6.LakeData`, :class:`imod.mf6.OutletManning`, :class:`OutletSpecified`,
   :class:`OutletWeir`. See the examples for an application of the Lake package.
 - :meth:`imod.mf6.simulation.Modflow6Simulation.dump` now supports dumping to MDAL compliant
@@ -976,7 +976,7 @@ Added
 
 - Added an extra optional argument in
   :meth:`imod.couplers.metamod.MetaMod.write` named ``modflow6_write_kwargs``,
-  which can be used to provide keyword arguments to the writing of the Modflow 6
+  which can be used to provide keyword arguments to the writing of the MODFLOW 6
   Simulation.
 
 Fixed
@@ -992,7 +992,7 @@ Fixed
 ~~~~~
 
 - :meth:`imod.mf6.Modflow6Simulation.write` with ``binary=False`` no longer
-  results in invalid MODFLOW6 input for 2D grid data, such as DIS top.
+  results in invalid MODFLOW 6 input for 2D grid data, such as DIS top.
 - ``imod.flow.ImodflowModel.write`` no longer writes incorrect project
   files for non-grid values with a time and layer dimension.
 - :func:`imod.evaluate.interpolate_value_boundaries`: Fix edge case when
@@ -1071,7 +1071,7 @@ Changed
   which models should be solved in a single numerical solution. This is
   required to simulate groundwater flow and transport as they should be
   in separate solutions.
-- When writing MODFLOW6 input option blocks, a NaN value is now recognized as
+- When writing MODFLOW 6 input option blocks, a NaN value is now recognized as
   an alternative to None (and the entry will not be included in the options
   block).
 
@@ -1144,7 +1144,7 @@ Added
 -  :meth:`imod.wq.SeawatModel.to_netcdf` has been added to write all model
    packages to netCDF files.
 -  :func:`imod.mf6.open_cbc` has been added to read the budget data of
-   structured (DIS) MODFLOW6 models. The data is read lazily into xarray
+   structured (DIS) MODFLOW 6 models. The data is read lazily into xarray
    DataArrays per timestep.
 -  :func:`imod.visualize.streamfunction` and :func:`imod.visualize.quiver`
    were added to plot a 2D representation of the groundwater flow field using
@@ -1170,8 +1170,8 @@ Added
 -  Added ``imod.flow.ImodflowModel`` to write to model iMODFLOW project
    file.
 -  :meth:`imod.mf6.Modflow6Simulation.write` now has a ``binary`` keyword. When set
-   to ``False``, all MODFLOW6 input is written to text rather than binary files.
--  Added :class:`imod.mf6.DiscretizationVertices` to write MODFLOW6 DISV model
+   to ``False``, all MODFLOW 6 input is written to text rather than binary files.
+-  Added :class:`imod.mf6.DiscretizationVertices` to write MODFLOW 6 DISV model
    input.
 -  Packages for :class:`imod.mf6.GroundwaterFlowModel` will now accept
    :class:`xugrid.UgridDataArray` objects for (DISV) unstructured grids, next to
@@ -1188,7 +1188,7 @@ Added
 -  :meth:`imod.mf6.Modflow6Simulation.run` has been added to more easily run a model,
    especially in examples and tests.
 -  :func:`imod.mf6.open_cbc` and :func:`imod.mf6.open_hds` will automatically
-   return a ``xugrid.UgridDataArray`` for MODFLOW6 DISV model output.
+   return a ``xugrid.UgridDataArray`` for MODFLOW 6 DISV model output.
 
 Changed
 ~~~~~~~
@@ -1209,7 +1209,7 @@ Changed
    packages now contain an internal (xarray) Dataset, rather than inheriting
    from the xarray Dataset.
 -  :class:`imod.mf6.SpecificStorage` or :class:`imod.mf6.StorageCoefficient` is
-   now mandatory for every MODFLOW6 model to avoid accidental steady-state
+   now mandatory for every MODFLOW 6 model to avoid accidental steady-state
    configuration.
 
 Removed
@@ -1339,7 +1339,7 @@ Added
 -  64-bit IDF files can be opened :meth:`imod.idf.open`
 -  64-bit IDF files can be written using :meth:`imod.idf.save` and (:meth:`imod.idf.write`) using keyword ``dtype=np.float64``
 -  ``sel`` and ``isel`` methods to ``SeawatModel`` to support taking out a subdomain
--  Docstrings for the Modflow 6 classes in :mod:`imod.mf6`
+-  Docstrings for the MODFLOW 6 classes in :mod:`imod.mf6`
 -  :meth:`imod.select.upper_active_layer` function to get the upper active layer from ibound ``xr.DataArray``
 
 Changed
@@ -1359,7 +1359,7 @@ Fixed
 Added
 ~~~~~
 -  Laplace grid interpolation :meth:`imod.prepare.laplace_interpolate`
--  Experimental Modflow 6 structured model write support :mod:`imod.mf6`
+-  Experimental MODFLOW 6 structured model write support :mod:`imod.mf6`
 -  More supported visualizations :mod:`imod.visualize`
 -  More extensive reading and writing of GDAL raster in :mod:`imod.rasterio`
 

--- a/docs/api/mf6.rst
+++ b/docs/api/mf6.rst
@@ -1,6 +1,6 @@
 .. currentmodule:: imod.mf6
 
-MODFLOW6
+MODFLOW 6
 ========
 
 Read Output

--- a/docs/faq/API-design.rst
+++ b/docs/faq/API-design.rst
@@ -11,5 +11,5 @@ start at 0. Coordinate labels have no direct meaning to Python, so instead iMOD
 Python decides how coordinates should be labeled. The ``"layer"`` coordinate
 contains labels, just like the ``"x"`` and ``"y"`` coordinates. Because these
 labels are not used for indexing, we decided to keep the ``"layer"`` labels the
-same as the MODFLOW6 layers. MODFLOW6 is written in Fortran, in which the
+same as the MODFLOW 6 layers. MODFLOW 6 is written in Fortran, in which the
 indices start at 1.

--- a/docs/faq/general.rst
+++ b/docs/faq/general.rst
@@ -16,7 +16,7 @@ FloPy nearly fully supports a list of models and software:
 * MODFLOW2005
 * MODFLOW-LGR
 * MODFLOW-USG
-* MODFLOW6
+* MODFLOW 6
 * SEAWAT
 * MODPATH
 * MT3D
@@ -24,7 +24,7 @@ FloPy nearly fully supports a list of models and software:
 imod supports (partially):
 
 * iMOD-WQ
-* MODFLOW6
+* MODFLOW 6
 
 Data structures
 ~~~~~~~~~~~~~~~
@@ -39,7 +39,7 @@ computing in Python; imod is built on xarray. To quote "`Why xarray?`_":
 imod-python started out as a package to read iMODFLOW files (IDF, IPF) into
 Python as xarray and pandas data structures. The `Why xarray?`_ page provides
 more background, but we can demonstrate with an example of two tasks for a
-(structured) MODFLOW6 model:
+(structured) MODFLOW 6 model:
 
     1. selecting the heads at a specified (x, y) point;
     2. computing a mean of the heads over time.

--- a/docs/faq/imod5_backwards_compatibility.rst
+++ b/docs/faq/imod5_backwards_compatibility.rst
@@ -26,16 +26,16 @@ Known issues
   x-coordinate of the well (e.g. 0.1 mm).
 - There is a bug in iMOD5 in how the HFB's hydraulic characteristic is computed.
   iMDO5 adds the background resistance of the aquifer to the HFB resistance when
-  writing the MODFLOW6 input files. The background resistance is already
-  accounted for by MODFLOW6 internally, so in practice this means the background
+  writing the MODFLOW 6 input files. The background resistance is already
+  accounted for by MODFLOW 6 internally, so in practice this means the background
   resistance is added twice. This is especially noticeable when a HFB intersects
   a low permeable layer. The workaround in iMOD5 is to specify a negative HFB
   factor in the projectfile, which makes iMOD5 to skip adding the background
   resistance.
 - By specifying a negative HFB factor in the projectfile, the iMOD5
   documentation mentions this will turn on the option to override a resistance
-  in between cells with the HFB resistance. This is NOT supported by MODFLOW6,
-  as MODFLOW6 always adds the background resistance to the HFB resistance to
+  in between cells with the HFB resistance. This is NOT supported by MODFLOW 6,
+  as MODFLOW 6 always adds the background resistance to the HFB resistance to
   compute the resistance inbetween cells.
 
 
@@ -50,8 +50,8 @@ Notes
 - When importing models with the ANI package, make sure to activate the "XT3D"
   in the NodePropertyFlow package of the model.
 - Solver settings (PCG) are NOT imported from iMOD5, instead a solver settings
-  preset from MODFLOW6 ("Moderate") is set. This is because the solvers between
-  iMODLFOW and MODFLOW6 are different. You are advised to test settings
+  preset from MODFLOW 6 ("Moderate") is set. This is because the solvers between
+  iMODLFOW and MODFLOW 6 are different. You are advised to test settings
   yourself.
 - The imported iMOD5 discretization for the model is created by taking the
   smallest grid and finest resolution amongst the TOP, BOT, and BND grids. This
@@ -81,10 +81,10 @@ Here an overview of iMOD5 files supported:
     Open raster data (.asc),:func:`imod.formats.rasterio.open`,
     Open legend file (.leg),:func:`imod.visualize.read_imod_legend`,
 
-MODFLOW6
+MODFLOW 6
 --------
 
-Here an overview of iMOD5 MODFLOW6 features:
+Here an overview of iMOD5 MODFLOW 6 features:
 
 .. csv-table::
    :header-rows: 1
@@ -101,7 +101,7 @@ Here an overview of iMOD5 MODFLOW6 features:
     "BND, TOP, BOT",Clip,:meth:`imod.mf6.StructuredDiscretization.clip_box`
     "BND, SHD",set constant heads starting head (IBOUND = -1),:meth:`imod.mf6.ConstantHead.from_imod5_shd_data`
     "BND, CHD",set constant heads (IBOUND = -1),:meth:`imod.mf6.ConstantHead.from_imod5_data`
-    "KDW, VCW, KVV, THK",Quasi-3D permeability from grid (IDF),Quasi-3D is only supported by MODFLOW2005. MODFLOW6 requires fully 3D.
+    "KDW, VCW, KVV, THK",Quasi-3D permeability from grid (IDF),Quasi-3D is only supported by MODFLOW2005. MODFLOW 6 requires fully 3D.
     "KHV, KVA",3D permeability from grid (IDF),:meth:`imod.mf6.NodePropertyFlow.from_imod5_data`
     ANI,Set horizontal anistropy ,:meth:`imod.mf6.NodePropertyFlow.from_imod5_data`
     "KHV, KVA, ANI",Align iMOD5 input grids,:meth:`imod.mf6.NodePropertyFlow.from_imod5_data`

--- a/docs/faq/known-issues.rst
+++ b/docs/faq/known-issues.rst
@@ -1,10 +1,10 @@
 Known Issues
 ============
 
-Modflow 6 versions
+MODFLOW 6 versions
 ------------------
 
-iMOD Python is tested to work with Modflow 6 versions:
+iMOD Python is tested to work with MODFLOW 6 versions:
 
 * All 6.2, 6.3 versions
 * 6.4.0, 6.4.2

--- a/docs/faq/modeling.rst
+++ b/docs/faq/modeling.rst
@@ -94,16 +94,16 @@ at the water table, where air is replaced by water.
     In the BCF package of older MODFLOW versions, storage can only be
     configured via the storage coefficient values; in the LPF package, storage
     can only be configured via specific storage values. In MODFLOW2005's LPF
-    package and MODFLOW6's NPF package, storage values are read as **specific**
+    package and MODFLOW 6's NPF package, storage values are read as **specific**
     storage by default and will be multiplied by layer thickness by MODFLOW
     internally.  By using a "STORAGECOEFFICIENT" option, MODFLOW will read the
     values as storativity instead. In LPF and NPF, specific yield is a separate
     parameter (and will only be used if there are convertible layers).
     
-MODFLOW6
+MODFLOW 6
 --------
 
-Use a river infiltration factor in MODFLOW6
+Use a river infiltration factor in MODFLOW 6
 *******************************************
     
 .. |m-1| replace:: m\ :sup:`-1`\

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ datasets. Some of its core functionalities are:
 
 * Preparing and modifying data from a variety of GIS, scientific, and MODFLOW
   file formats;
-* Regridding, clipping, masking, and splitting MODFLOW6 models;
+* Regridding, clipping, masking, and splitting MODFLOW 6 models;
 * Fast writing of data to MODFLOW-based models;
 * Selecting and evaluating, e.g. for time series comparison or water budgets;
 * Visualizing cross sections, time series, or 3D animations.
@@ -30,7 +30,7 @@ We currently support the following MODFLOW-based kernels:
 * `iMOD-WQ`_, which integrates SEAWAT (density-dependent
   groundwater flow) and MT3DMS (multi-species reactive transport calculations)
 
-Development currently focuses on supporting more Modflow 6 functionalities.
+Development currently focuses on supporting more MODFLOW 6 functionalities.
 iMOD-WQ has been sunset and will no longer be developed.
 
 Why ``imod``?
@@ -39,7 +39,7 @@ Why ``imod``?
 1\. Easily create grid-based model packages
 -------------------------------------------
 
-Seamlessly integrate your GIS rasters or meshes with MODFLOW6, by using `xarray`_
+Seamlessly integrate your GIS rasters or meshes with MODFLOW 6, by using `xarray`_
 and `xugrid`_ arrays, for structured and unstructured grids, respectively, to
 create grid-based model packages. 
 
@@ -91,7 +91,7 @@ layer, row and column:
 
 iMOD Python will take care of the rest and assign the wells to the correct model
 layers upon writing the model. It will furthermore distribute well rates based
-on transmissivities. To verify how wells will be assigned to MODFLOW6 cells before
+on transmissivities. To verify how wells will be assigned to MODFLOW 6 cells before
 writing the entire simulation, you can use the following command:
 
 .. code-block:: python
@@ -117,7 +117,7 @@ across layers.
 4\. Create stress periods based on times assigned to boundary conditions
 --------------------------------------------------------------------------
 
-MODFLOW6 requires that all stress periods are defined in the time discretization
+MODFLOW 6 requires that all stress periods are defined in the time discretization
 package. However, usually boundary conditions are defined at inconsistent
 times. iMOD Python can help you to create a time discretization package that is
 consistent, based on all the unique times assigned to the boundary conditions.
@@ -142,10 +142,10 @@ consistent, based on all the unique times assigned to the boundary conditions.
   print(simulation["time_discretization"].dataset)
 
 
-5\. Regridding MODFLOW6 models to different grids
--------------------------------------------------
+5\. Regridding MODFLOW 6 models to different grids
+--------------------------------------------------
 
-Regrid MODFLOW6 models to different grids, even from structured to unstructured
+Regrid MODFLOW 6 models to different grids, even from structured to unstructured
 grids. iMOD Python takes care of properly scaling the input parameters. You can
 also configure scaling methods yourself for each input parameter, for example
 when you want to upscale drainage elevations with the minimum instead of the
@@ -160,8 +160,8 @@ average.
 
 `See further explanation here <https://deltares.github.io/imod-python/user-guide/08-regridding.html>`_
 
-6\. Clip MODFLOW6 models to a bounding box
-------------------------------------------
+6\. Clip MODFLOW 6 models to a bounding box
+-------------------------------------------
 
 To reduce the size of your model, you can clip it to a bounding box. This is
 useful for example when you want to create a smaller model for testing purposes.
@@ -187,10 +187,10 @@ You can even provide states for the model, which will be set on the model bounda
   # model.
   print(sim_clipped["gwf"])
 
-7\. Performant writing of MODFLOW6 models
------------------------------------------
+7\. Performant writing of MODFLOW 6 models
+------------------------------------------
 
-iMOD Python efficiently writes MODFLOW6 models to disk, especially large models.
+iMOD Python efficiently writes MODFLOW 6 models to disk, especially large models.
 Tests we have conducted for the Dutch National Groundwater Model (LHM) show that
 iMOD Python can write a model with 21.84 million cells 5 to 60 times faster (for
 respectively 1 and 365 stress periods) than the alternative `Flopy`_ package. 
@@ -230,10 +230,10 @@ If you are not interested in deriving models from spatial data, but just want to
 allocate boundary conditions based on layer, row, column numbers, or create a
 model of a 2D cross-section: You are better off using `Flopy`_.
 
-2\. Not all MODFLOW6 features are supported
--------------------------------------------
+2\. Not all MODFLOW 6 features are supported
+--------------------------------------------
 
-Currently, we don't support the following MODFLOW6 features:
+Currently, we don't support the following MODFLOW 6 features:
 
 - timeseries files
 - DISU package

--- a/examples/metaswap/README.rst
+++ b/examples/metaswap/README.rst
@@ -2,4 +2,4 @@ MetaSWAP
 ========
 
 These examples demonstrate how to use iMOD Python to build MetaSWAP and coupled
-Modflow 6 models.
+MODFLOW 6 models.

--- a/examples/mf6/Henry.py
+++ b/examples/mf6/Henry.py
@@ -10,7 +10,7 @@ In overview, we'll set the following steps:
     * Create a suitable 2d (x, z) grid.
     * Create a groundwater flow model, with variable density.
     * Create a solute transport model.
-    * Combine these models into a single MODFLOW6 simulation.
+    * Combine these models into a single MODFLOW 6 simulation.
     * Write to modflow6 files.
     * Run the model.
     * Open the results back into xarray DataArrays.
@@ -257,7 +257,7 @@ simulation.write(modeldir, binary=False)
 # .. note::
 #
 #   The following lines assume the ``mf6`` executable is available on your PATH.
-#   :ref:`The Modflow 6 examples introduction <mf6-introduction>` shortly
+#   :ref:`The MODFLOW 6 examples introduction <mf6-introduction>` shortly
 #   describes how to add it to yours.
 
 simulation.run()

--- a/examples/mf6/README.rst
+++ b/examples/mf6/README.rst
@@ -1,15 +1,15 @@
 .. _mf6-introduction:
 
-MODFLOW6
-========
+MODFLOW 6
+=========
 
-These examples demonstrate how to use imod to build MODFLOW6 models.
+These examples demonstrate how to use imod to build MODFLOW 6 models.
 
 .. attention:: 
 
-    The examples expect you to have added the Modflow 6 executable to your PATH.
+    The examples expect you to have added the MODFLOW 6 executable to your PATH.
     If you have not done this yet:
-    First, `download the latest Modflow 6 executables here. <https://water.usgs.gov/water-resources/software/MODFLOW-6/>`_
+    First, `download the latest MODFLOW 6 executables here. <https://water.usgs.gov/water-resources/software/MODFLOW-6/>`_
     Next, follow the following instructions to add the executable to your PATH on Windows 10:
 
     1. Press the Start key on your keyboard.

--- a/examples/mf6/circle.py
+++ b/examples/mf6/circle.py
@@ -8,7 +8,7 @@ model using the ``imod`` package and associated packages.
 In overview, we'll set the following steps:
 
     * Create a triangular mesh for a disk geometry.
-    * Create the xugrid UgridDataArrays containg the MODFLOW6 parameters.
+    * Create the xugrid UgridDataArrays containg the MODFLOW 6 parameters.
     * Feed these arrays into the imod mf6 classes.
     * Write to modflow6 files.
     * Run the model.
@@ -162,7 +162,7 @@ simulation.write(modeldir)
 # .. note::
 #
 #   The following lines assume the ``mf6`` executable is available on your PATH.
-#   :ref:`The Modflow 6 examples introduction <mf6-introduction>` shortly
+#   :ref:`The MODFLOW 6 examples introduction <mf6-introduction>` shortly
 #   describes how to add it to yours.
 
 simulation.run()
@@ -178,7 +178,7 @@ head = simulation.open_head()
 head
 
 # %%
-# For a DISV MODFLOW6 model, the heads are returned as a UgridDataArray.  While
+# For a DISV MODFLOW 6 model, the heads are returned as a UgridDataArray.  While
 # all layers and timesteps are available, they are only loaded into memory as
 # needed.
 #

--- a/examples/mf6/circle_transport.py
+++ b/examples/mf6/circle_transport.py
@@ -56,9 +56,9 @@ ax.set_aspect(1)
 # %%
 # However a triangular grid has the issue that the direction of the fluxes
 # between cell centres is not perpendicular to the cell vertices. The default
-# formulation of Modflow 6 does not account for this, which causes mass balance
+# formulation of MODFLOW 6 does not account for this, which causes mass balance
 # errors. The XT3D formulation is able to account for this, but the last version
-# of Modflow 6 (6.3 at time of writing) does not support this in combination
+# of MODFLOW 6 (6.3 at time of writing) does not support this in combination
 # with the Buoyancy package and using XT3D comes with an extra, significant
 # computational burden. It is therefore easier to use a voronoi grid, for which
 # `Xugrid <https://deltares.github.io/xugrid/index.html>`_ has a very convenient

--- a/examples/mf6/ex01_twri.py
+++ b/examples/mf6/ex01_twri.py
@@ -2,7 +2,7 @@
 TWRI
 ====
 
-This example has been converted from the `MODFLOW6 Example problems`_.  See the
+This example has been converted from the `MODFLOW 6 Example problems`_.  See the
 `description`_ and the `notebook`_ which uses `FloPy`_ to setup the model.
 
 This example is a modified version of the original MODFLOW example
@@ -15,7 +15,7 @@ explicitly simulated, to an equivalent three-dimensional problem.
 In overview, we'll set the following steps:
 
     * Create a structured grid for a rectangular geometry.
-    * Create the xarray DataArrays containg the MODFLOW6 parameters.
+    * Create the xarray DataArrays containg the MODFLOW 6 parameters.
     * Feed these arrays into the imod mf6 classes.
     * Write to modflow6 files.
     * Run the model.
@@ -189,7 +189,7 @@ simulation.write(modeldir)
 # .. note::
 #
 #   The following lines assume the ``mf6`` executable is available on your PATH.
-#   :ref:`The Modflow 6 examples introduction <mf6-introduction>` shortly
+#   :ref:`The MODFLOW 6 examples introduction <mf6-introduction>` shortly
 #   describes how to add it to yours.
 
 simulation.run()
@@ -213,7 +213,7 @@ head.isel(layer=0, time=0).plot.contourf()
 
 
 # %%
-# .. _MODFLOW6 example problems: https://github.com/MODFLOW-USGS/modflow6-examples
+# .. _MODFLOW 6 example problems: https://github.com/MODFLOW-USGS/modflow6-examples
 # .. _description: https://modflow6-examples.readthedocs.io/en/master/_examples/ex-gwf-twri.html
 # .. _notebook: https://github.com/MODFLOW-USGS/modflow6-examples/blob/develop/scripts/ex-gwf-twri.py
 # .. _Techniques of Water-Resources Investigation: https://pubs.usgs.gov/twri/twri7-c1/

--- a/examples/mf6/example_1d_transport.py
+++ b/examples/mf6/example_1d_transport.py
@@ -2,7 +2,7 @@
 1D Solute Transport Benchmarks
 ==============================
 
-This example is taken from the MODFLOW6 Examples, number 35.
+This example is taken from the MODFLOW 6 Examples, number 35.
 
 As explained there, the setup is a simple 1d homogeneous aquifer with a steady
 state flow field of constant velocity. The benchmark consists of four transport

--- a/examples/mf6/hondsrug.py
+++ b/examples/mf6/hondsrug.py
@@ -5,7 +5,7 @@ Regional model
 This example shows a simplified script for building a groundwater model in the
 northeast of the Netherlands. A primary feature of this area is an ice-pushed
 ridge called the Hondsrug. This examples demonstrates modifying external data
-for use in a MODFLOW6 model.
+for use in a MODFLOW 6 model.
 
 In overview, the model features:
 
@@ -50,7 +50,7 @@ layermodel = imod.data.hondsrug_layermodel()
 # Make sure that the idomain is provided as integers
 idomain = layermodel["idomain"].astype(int)
 
-# We only need to provide the data for the top as a 2D array. Modflow 6 will
+# We only need to provide the data for the top as a 2D array. MODFLOW 6 will
 # compare the top against the uppermost active bottom cell.
 top = layermodel["top"].max(dim="layer")
 
@@ -264,7 +264,7 @@ gwf_model["chd"] = imod.mf6.ConstantHead(
 # slicing the area to the model's miminum and maximum dimensions.
 #
 # Note that the meteorological data has mm/d as unit and
-# this has to be converted to m/d for Modflow 6.
+# this has to be converted to m/d for MODFLOW 6.
 
 xmin = 230_000.0
 xmax = 257_000.0
@@ -606,7 +606,7 @@ simulation.create_time_discretization(
 # .. note::
 #
 #   The following lines assume the ``mf6`` executable is available on your PATH.
-#   :ref:`The Modflow 6 examples introduction <mf6-introduction>` shortly
+#   :ref:`The MODFLOW 6 examples introduction <mf6-introduction>` shortly
 #   describes how to add it to yours.
 
 modeldir = imod.util.temporary_directory()
@@ -665,7 +665,7 @@ hds.sel(layer=slice(3, 5)).mean(dim="layer").isel(time=3).plot(ax=ax)
 # Assign dates to head
 # --------------------
 #
-# MODFLOW6 has no concept of a calendar, so the output is not labelled only
+# MODFLOW 6 has no concept of a calendar, so the output is not labelled only
 # in terms of "time since start" in floating point numbers. For this model
 # the time unit is days and we can assign a date coordinate as follows:
 

--- a/examples/mf6/lake.py
+++ b/examples/mf6/lake.py
@@ -202,7 +202,7 @@ simulation.write(modeldir)
 # .. note::
 #
 #   The following lines assume the ``mf6`` executable is available on your PATH.
-#   :ref:`The Modflow 6 examples introduction <mf6-introduction>` shortly
+#   :ref:`The MODFLOW 6 examples introduction <mf6-introduction>` shortly
 #   describes how to add it to yours.
 
 simulation.run()

--- a/examples/user-guide/00-index-examples.py
+++ b/examples/user-guide/00-index-examples.py
@@ -35,7 +35,7 @@ tmp_dir.mkdir(parents=True, exist_ok=True)
 interpolated_elevation.rio.to_raster(tmp_dir / "elevation.tif")
 
 # %%
-# Seamlessly integrate your GIS rasters or meshes with MODFLOW6, by using `xarray`_
+# Seamlessly integrate your GIS rasters or meshes with MODFLOW 6, by using `xarray`_
 # and `xugrid`_ arrays, for structured and unstructured grids respectively, to
 # create grid-based model packages.
 
@@ -101,7 +101,7 @@ print(wel_mf6_pkg["cellid"])
 print(wel_mf6_pkg["rate"])
 
 # %%
-# MODFLOW6 requires that all stress periods are defined in the time discretization
+# MODFLOW 6 requires that all stress periods are defined in the time discretization
 # package. However, usually boundary conditions are defined at insconsistent
 # times. iMOD Python can help you to create a time discretization package that is
 # consistent, based on all the unique times assigned to the boundary conditions.
@@ -120,7 +120,7 @@ simulation.create_time_discretization(additional_times=["2000-01-07"])
 print(simulation["time_discretization"].dataset)
 
 # %%
-# Regrid MODFLOW6 models to different grids, even from structured to unstructured
+# Regrid MODFLOW 6 models to different grids, even from structured to unstructured
 # grids. iMOD Python takes care of properly scaling the input parameters. You can
 # also configure scaling methods yourself for each input parameter, for example
 # when you want to upscale drainage elevations with the minimum instead of the

--- a/examples/user-guide/05-unstructured-grids.py
+++ b/examples/user-guide/05-unstructured-grids.py
@@ -2,7 +2,7 @@
 Unstructured Grids
 ==================
 
-MODFLOW6 supports unstructured grids. Unlike raster data, the connectivity of
+MODFLOW 6 supports unstructured grids. Unlike raster data, the connectivity of
 unstructured grids is irregular. This means that the number of neighboring
 cells is not constant; for structured grids, every cell has 4 neighbors (in
 2D), or 6 neighbors (in 3D).

--- a/examples/user-guide/06-lazy-evaluation.py
+++ b/examples/user-guide/06-lazy-evaluation.py
@@ -94,7 +94,7 @@ eager_result.data
 # ----------------------------------------
 #
 # The input and output functions in the imod package have been written to work
-# with xarray's delayed evaluation. This means that opening IDFs or MODFLOW6
+# with xarray's delayed evaluation. This means that opening IDFs or MODFLOW 6
 # will not load the data from the files into memory until they are needed.
 #
 # Let's grab some example results, store them in a temporarily directory, and

--- a/examples/user-guide/07-time-discretization.py
+++ b/examples/user-guide/07-time-discretization.py
@@ -13,7 +13,7 @@ functionality is activated with the ``create_time_discretization()`` method.
 # ------
 #
 # To demonstrate the ``create_time_discretization()`` method, we first have to
-# create a Model object. In this case we'll use a Modflow 6 simulation, but the
+# create a Model object. In this case we'll use a MODFLOW 6 simulation, but the
 # ``imod.wq.SeawatModel`` also supports this.
 #
 # .. note::
@@ -21,7 +21,7 @@ functionality is activated with the ``create_time_discretization()`` method.
 #    The simulation created in this example misses some mandatory packes, so is
 #    not able to write a functional simulation. It is purely intended to describe
 #    the workings of the ``time_discretization`` method. For a fully functional
-#    Modflow 6 model, see the examples in :ref:`mf6-introduction`.
+#    MODFLOW 6 model, see the examples in :ref:`mf6-introduction`.
 #
 # Wel'll start off with the usual imports:
 

--- a/examples/user-guide/09-topsystem.py
+++ b/examples/user-guide/09-topsystem.py
@@ -6,7 +6,7 @@ iMOD Python has multiple features to help you define the topsystem of the
 groundwater system. With "topsystem" we mean all forcings which act on the top
 of the groundwater system. These are usually either meteorological
 (precipitation & evapotranspiration) or hydrological (rivers, ditches, lakes,
-sea) in nature. In MODFLOW6 these are usually simulated with the DRN, RIV, GHB,
+sea) in nature. In MODFLOW 6 these are usually simulated with the DRN, RIV, GHB,
 and RCH package. This data is usually provided as planar grids (x, y) without
 any vertical dimension. This user guide will show you how to allocate these
 forcings across model layers to grid cells and how to distribute conductances
@@ -404,10 +404,10 @@ plt.tight_layout()
 # layer.
 
 # %%
-# MODFLOW6 package
+# MODFLOW 6 package
 # ----------------
 #
-# The data created can now be used to create a MODFLOW6 package. To construct 3D
+# The data created can now be used to create a MODFLOW 6 package. To construct 3D
 # grids from planar grids for the stages, we can utilize xarrays broadcasting:
 from imod.typing.grid import enforce_dim_order
 

--- a/examples/user-guide/10-cleanup.py
+++ b/examples/user-guide/10-cleanup.py
@@ -216,10 +216,10 @@ gwf_simulation.write(tmp_dir)
 #
 # Great! The model was succesfully written!
 #
-# Cleaning data without a MODFLOW6 simulation
+# Cleaning data without a MODFLOW 6 simulation
 # -------------------------------------------
 #
-# There might be situations where you do not have a MODFLOW6 simulation or River
+# There might be situations where you do not have a MODFLOW 6 simulation or River
 # package at hand, and you still want to clean up your river grids. In this
 # case, you can use the :func:`imod.prepare.cleanup_riv` function. This function
 # requires you to to separately provide your grids and returns a dictionary of


### PR DESCRIPTION
# Description
Consistently spell "MODFLOW 6" in docs, [which is the official spelling.](https://modflow6.readthedocs.io/en/stable/_dev/contributing.html)