### PR TITLE
Issue #305 Throw error upon space in directory name.

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+[Unreleased]
+------------
+
+Changed
+~~~~~~~
+
+- :meth:`imod.wq.SeawatModel.write` now throws an error if trying to write in a
+  directory with a space in the path. (iMOD-WQ does not support this.)
+
 [1.0.0rc3] - 2025-04-17
 -----------------------
 

--- a/imod/tests/test_wq/test_wq_model.py
+++ b/imod/tests/test_wq/test_wq_model.py
@@ -772,3 +772,26 @@ def test_write_result_dir_is_workdir(basicmodel, tmp_path):
 
     assert line.split("=")[-1].strip() == "."
     # TODO: more rigorous testing
+
+
+def test_write__error_space_in_path(basicmodel, tmp_path):
+    """
+    Test if error is raised when there is a space in the path.
+    """
+    m = basicmodel
+    m.create_time_discretization("2000-01-06")
+
+    txt_to_match = r"Spaces in directory names are not allowed"
+    with pytest.raises(ValueError, match=txt_to_match):
+        m.write(
+            directory=tmp_path / "test model",
+            result_dir=tmp_path / "results",
+            resultdir_is_workdir=True,
+        )
+
+    with pytest.raises(ValueError, match=txt_to_match):
+        m.write(
+            directory=tmp_path / "test_model",
+            result_dir=tmp_path / "re sults",
+            resultdir_is_workdir=True,
+        )

--- a/imod/wq/model.py
+++ b/imod/wq/model.py
@@ -635,6 +635,14 @@ class SeawatModel(Model):
         # If more complex dependencies do show up, probably push methods down
         # to the individual packages.
 
+    @staticmethod
+    def _validate_space_in_path(path):
+        """
+        Check if there are spaces in the path. If so, raise a ValueError.
+        """
+        if " " in str(path):
+            raise ValueError(f"Spaces in directory names are not allowed: {path}.")
+
     def write(
         self, directory=pathlib.Path("."), result_dir=None, resultdir_is_workdir=False
     ):
@@ -679,6 +687,10 @@ class SeawatModel(Model):
             result_dir = pathlib.Path("results")
         else:
             result_dir = pathlib.Path(result_dir)
+
+        # Validate no spaces in directories
+        self._validate_space_in_path(directory)
+        self._validate_space_in_path(result_dir)
 
         # Create directories if necessary
         directory.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
Closes #305 

# Description

This throws an error when a user tries to write a model in a directory with a space in it.

Follow-up to https://github.com/Deltares/imod-python/pull/1514

See my comment here: https://github.com/Deltares/imod-python/pull/1514#issuecomment-2829863678

> Thanks for hotfixing this. FYI: This is not an immediate problem anymore: I just talked to @TeunvanWoerkom, he moved to a drive without spaces in the path.
> 
> I'm not sure if we should merge this, as the `wq` test bench doesn't have the coverage of the `mf6` module. Most notably, we don't run a model with iMOD-WQ to test if it breaks. The current `wq` module is tried and tested in many projects, so that is sufficient to do work with. I don't want to risk breaking it with changes.
> 
> Besides, Teun manually quoted the paths in his runfile to fix this and then iMOD-WQ apparently also isn't able to deal with spaces in paths (at least the version he used). It crashes upon attempting to create the results directories.
> 
> Alternatively: We could raise an error if a user attempts to write a `wq` model in a folder with a space in the path?


It turned out that adding quotes doesn't do the trick, as iMOD-WQ also cannot handle spaces in paths, even when they are quoted in the runfile. It crashes upon writing results.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
