### PR TITLE
Issue #1515 fix xorigin yorigin disv

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -19,6 +19,14 @@ Fixed
 - :class:`imod.mf6.VerticesDiscretization` now correctly sets the ``xorigins``
   and ``yorigins`` options in the ``.disv`` file. Incorrect origins cause issues
   when splitting models and computing with XT3D on the exchanges.
+- :func:`imod.mf6.open_cbc` and :func:`imod.mf6.open_head` now account for
+  xorigins and yorigins for models ran with
+  :class:`imod.mf6.VerticesDiscretization`. **WARNING**: Given that these were
+  set incorrectly in previous versions of iMOD Python (see previous item in this
+  list), this means that reading MODFLOW6 DISV output of models generated with a
+  previous version of iMOD Python will result in a grid with an erroneous
+  offset. You can work around this by creating the model again with this
+  version of iMOD Python or newer.
 
 Changed
 ~~~~~~~
@@ -311,9 +319,9 @@ Fixed
   would be snapped to the same cell edge. These are now summed.
 - Improve performance validation upon Package initialization
 - Improve performance writing ``HorizontalFlowBarrier`` objects
-- `imod.mf6.open_cbc` failing with ``flowja=False`` on budget output for
+- :func:`imod.mf6.open_cbc` failing with ``flowja=False`` on budget output for
   DISV models if the model contained inactive cells.
-- `imod.mf6.open_cbc` now works for 2D and 1D models.
+- :func:`imod.mf6.open_cbc` now works for 2D and 1D models.
 - :func:`imod.prepare.fill` previously assigned to the result of an xarray
   ``.sel`` operation. This might not work for dask backed data and has been
   addressed.

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -16,6 +16,9 @@ Fixed
   :meth:`imod.mf6.Modflow6Simulation.regrid_like` and
   :meth:`imod.mf6.Modflow6Simulation.mask` now present the unexpected
   coordinates in the error message.
+- :class:`imod.mf6.VerticesDiscretization` now correctly sets the ``xorigins``
+  and ``yorigins`` options in the ``.disv`` file. Incorrect origins cause issues
+  when splitting models and computing with XT3D on the exchanges.
 
 Changed
 ~~~~~~~

--- a/imod/mf6/dis.py
+++ b/imod/mf6/dis.py
@@ -132,7 +132,7 @@ class StructuredDiscretization(Package, IRegridPackage, IMaskingSettings):
         else:
             raise ValueError(f"Unhandled type of {dx}")
 
-    def render(self, directory, pkgname, globaltimes, binary):
+    def _get_render_dictionary(self, directory, pkgname, globaltimes, binary):
         disdirectory = pathlib.Path(directory) / pkgname
         d: dict[str, Any] = {}
         x = self.dataset["idomain"].coords["x"]
@@ -156,8 +156,7 @@ class StructuredDiscretization(Package, IRegridPackage, IMaskingSettings):
         d["idomain_layered"], d["idomain"] = self._compose_values(
             self["idomain"], disdirectory, "idomain", binary=binary
         )
-
-        return self._template.render(d)
+        return d
 
     def _validate(self, schemata, **kwargs):
         # Insert additional kwargs

--- a/imod/mf6/disv.py
+++ b/imod/mf6/disv.py
@@ -106,8 +106,8 @@ class VerticesDiscretization(Package, IRegridPackage, IMaskingSettings):
         disdirectory = directory / pkgname
         d = {}
         grid = self.dataset.ugrid.grid
-        d["xorigin"] = grid.node_x.min()
-        d["yorigin"] = grid.node_y.min()
+        d["xorigin"] = 0.0
+        d["yorigin"] = 0.0
         d["nlay"] = self.dataset["idomain"].coords["layer"].size
         facedim = grid.face_dimension
         d["ncpl"] = self.dataset["idomain"].coords[facedim].size

--- a/imod/mf6/disv.py
+++ b/imod/mf6/disv.py
@@ -102,7 +102,7 @@ class VerticesDiscretization(Package, IRegridPackage, IMaskingSettings):
         super().__init__(dict_dataset)
         self._validate_init_schemata(validate)
 
-    def render(self, directory, pkgname, globaltimes, binary):
+    def _get_render_dictionary(self, directory, pkgname, globaltimes, binary):
         disdirectory = directory / pkgname
         d: dict[str, Any] = {}
         grid = self.dataset.ugrid.grid
@@ -122,7 +122,7 @@ class VerticesDiscretization(Package, IRegridPackage, IMaskingSettings):
         d["idomain_layered"], d["idomain"] = self._compose_values(
             self["idomain"], disdirectory, "idomain", binary=binary
         )
-        return self._template.render(d)
+        return d
 
     def _verts_dataframe(self) -> pd.DataFrame:
         grid = self.dataset.ugrid.grid

--- a/imod/mf6/disv.py
+++ b/imod/mf6/disv.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Any
 
 import numpy as np
 import pandas as pd
@@ -104,7 +104,7 @@ class VerticesDiscretization(Package, IRegridPackage, IMaskingSettings):
 
     def render(self, directory, pkgname, globaltimes, binary):
         disdirectory = directory / pkgname
-        d = {}
+        d: dict[str, Any] = {}
         grid = self.dataset.ugrid.grid
         d["xorigin"] = 0.0
         d["yorigin"] = 0.0

--- a/imod/mf6/disv.py
+++ b/imod/mf6/disv.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import Any, List
 
 import numpy as np
 import pandas as pd

--- a/imod/mf6/disv.py
+++ b/imod/mf6/disv.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any, List
 
 import numpy as np
@@ -146,14 +147,8 @@ class VerticesDiscretization(Package, IRegridPackage, IMaskingSettings):
             )
         return df
 
-    def write_blockfile(self, pkgname, globaltimes, write_context: WriteContext):
-        dir_for_render = write_context.get_formatted_write_directory()
-        content = self.render(
-            dir_for_render, pkgname, globaltimes, write_context.use_binary
-        )
-        filename = write_context.write_directory / f"{pkgname}.{self._pkg_id}"
-        with open(filename, "w") as f:
-            f.write(content)
+    def _append_vertices_and_cell2d(self, filename: Path | str) -> None:
+        with open(filename, "a") as f:
             f.write("\n\n")
 
             f.write("begin vertices\n")
@@ -167,6 +162,14 @@ class VerticesDiscretization(Package, IRegridPackage, IMaskingSettings):
                 f, header=False, sep=" ", lineterminator="\n"
             )
             f.write("end cell2d\n")
+
+        return
+
+    def write_blockfile(self, pkgname, globaltimes, write_context: WriteContext):
+        super().write_blockfile(pkgname, globaltimes, write_context)
+        filename = write_context.write_directory / f"{pkgname}.{self._pkg_id}"
+        self._append_vertices_and_cell2d(filename)
+
         return
 
     def _validate(self, schemata, **kwargs):

--- a/imod/mf6/out/disv.py
+++ b/imod/mf6/out/disv.py
@@ -53,14 +53,17 @@ def read_grb(f: BinaryIO, ntxt: int, lentxt: int) -> Dict[str, Any]:
     nja = struct.unpack("i", f.read(4))[0]
     if ncells != (nlayer * ncells_per_layer):
         raise ValueError(f"Invalid file {ncells} {nlayer} {ncells_per_layer}")
-    _ = struct.unpack("d", f.read(8))[0]  # xorigin
-    _ = struct.unpack("d", f.read(8))[0]  # yorigin
+    xorigin = struct.unpack("d", f.read(8))[0]  # xorigin
+    yorigin = struct.unpack("d", f.read(8))[0]  # yorigin
     f.seek(8, 1)  # skip angrot
     top_np = np.fromfile(f, np.float64, ncells_per_layer)
     bottom_np = np.reshape(
         np.fromfile(f, np.float64, ncells), (nlayer, ncells_per_layer)
     )
     vertices = np.reshape(np.fromfile(f, np.float64, nvert * 2), (nvert, 2))
+    # Add origins to vertices
+    vertices[:, 0] += xorigin
+    vertices[:, 1] += yorigin
     _ = np.fromfile(f, np.float64, ncells_per_layer)  # cellx
     _ = np.fromfile(f, np.float64, ncells_per_layer)  # celly
     # Python is 0-based; MODFLOW6 is Fortran 1-based

--- a/imod/tests/conftest.py
+++ b/imod/tests/conftest.py
@@ -41,6 +41,7 @@ from .fixtures.mf6_circle_fixture import (
     circle_model_transport_multispecies_variable_density,
     circle_partitioned,
     circle_result,
+    circle_result__offset_origins,
     circle_result_evt,
     circle_result_sto,
 )

--- a/imod/tests/test_mf6/test_mf6_dis.py
+++ b/imod/tests/test_mf6/test_mf6_dis.py
@@ -22,9 +22,9 @@ def idomain_and_bottom():
 
     dx = 5000.0
     dy = -5000.0
-    xmin = 0.0
+    xmin = 10_000.0
     xmax = dx * ncol
-    ymin = 0.0
+    ymin = 10_000.0
     ymax = abs(dy) * nrow
     dims = ("layer", "y", "x")
 
@@ -47,8 +47,8 @@ def test_render(idomain_and_bottom):
     expected = textwrap.dedent(
         """\
         begin options
-          xorigin 0.0
-          yorigin 0.0
+          xorigin 10000.0
+          yorigin 10000.0
         end options
 
         begin dimensions

--- a/imod/tests/test_mf6/test_mf6_dis.py
+++ b/imod/tests/test_mf6/test_mf6_dis.py
@@ -23,9 +23,9 @@ def idomain_and_bottom():
     dx = 5000.0
     dy = -5000.0
     xmin = 10_000.0
-    xmax = dx * ncol
+    xmax = dx * ncol + xmin
     ymin = 10_000.0
-    ymax = abs(dy) * nrow
+    ymax = abs(dy) * nrow + ymin
     dims = ("layer", "y", "x")
 
     layer = np.array([1, 2, 3])

--- a/imod/tests/test_mf6/test_mf6_disv.py
+++ b/imod/tests/test_mf6/test_mf6_disv.py
@@ -21,9 +21,9 @@ def idomain_and_bottom():
     dx = 5000.0
     dy = -5000.0
     xmin = 10_000.0
-    xmax = dx * ncol
+    xmax = dx * ncol + xmin
     ymin = 10_000.0
-    ymax = abs(dy) * nrow
+    ymax = abs(dy) * nrow + ymin
     dims = ("layer", "y", "x")
 
     layer = np.array([1, 2, 3])

--- a/imod/tests/test_mf6/test_mf6_disv.py
+++ b/imod/tests/test_mf6/test_mf6_disv.py
@@ -20,9 +20,9 @@ def idomain_and_bottom():
 
     dx = 5000.0
     dy = -5000.0
-    xmin = 0.0
+    xmin = 10_000.0
     xmax = dx * ncol
-    ymin = 0.0
+    ymin = 10_000.0
     ymax = abs(dy) * nrow
     dims = ("layer", "y", "x")
 

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import textwrap
 from filecmp import dircmp
 from pathlib import Path
 
@@ -235,6 +236,40 @@ def test_partitioning_structured(
     np.testing.assert_allclose(
         head["head"].values, original_head.values, rtol=1e-4, atol=1e-4
     )
+
+
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
+def test_partitioning_dis_origins(
+    tmp_path: Path,
+    transient_twri_model: Modflow6Simulation,
+    partition_array: xr.DataArray,
+):
+    """
+    Verify if the dis origin is set correctly in the partitioned simulation.
+    MODFLOW6 uses this when computing with XT3D on the exchanges between
+    submodels.
+    """
+    simulation = transient_twri_model
+    # Partition the simulation, run it, and save the (merged) results
+    split_simulation = simulation.split(partition_array)
+    split_simulation.write(tmp_path, binary=False)
+    modelnames = split_simulation.get_models_of_type("gwf6").keys()
+    for modelname in modelnames:
+        pkg = split_simulation[modelname]["dis"]
+        x = pkg.dataset["idomain"].coords["x"]
+        y = pkg.dataset["idomain"].coords["y"]
+        _, xmin, _ = imod.util.spatial.coord_reference(x)
+        _, ymin, _ = imod.util.spatial.coord_reference(y)
+        actual = pkg.render(tmp_path, "dis", None, True)
+        expected = textwrap.dedent(
+            f"""\
+            begin options
+              xorigin {xmin}
+              yorigin {ymin}
+            end options
+            """
+        )
+        assert expected in actual
 
 
 @parametrize_with_cases(


### PR DESCRIPTION
Fixes #1515

# Description
Adds the following:

- Hardcode xorigins and yorigins in DISV package to 0.0.
- Add tests to verify if the xorigins and yorigins and DIS and DISV packages are rendered correctly
- Offset the grid in the DIS and DISV unittests, to verify if xorigins and yorigins are properly rendered.
- Account for xorigin and yorigin in the disv grb read funtion
- Add a test which has an offset in DISV, to see if our read DISV grb function actually properly deals with that. This is in the case somebody wants to read model output of a DISV model generated with Flopy that has an offset in xorigins and yorigins.
- Small refactor to override ``_get_render_dictionary`` instead of ``render`` in DIS and DISV
- Small refactor, move append of vertices and cell2d data to blockfile to a separate method.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
