### PR TITLE
Issue #1528 Failing usage of relative paths for extra MetaSWAP files in iMOD projectfile

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -36,8 +36,8 @@ Fixed
   version of iMOD Python or newer.
 - :meth:`imod.mf6.Modflow6Simulation.split` supports label array with a
   different name than ``"idomain"``.
-- :func:`imod.formats.prj._parse_extrablock` now supports the usage of relative
-  paths.
+- :func:`imod.msw.MetaSwapModel.from_imod5_data` now supports the usage of
+  relative paths for the extra files block.
 
 Changed
 ~~~~~~~

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -36,6 +36,8 @@ Fixed
   version of iMOD Python or newer.
 - :meth:`imod.mf6.Modflow6Simulation.split` supports label array with a
   different name than ``"idomain"``.
+- :func:`imod.formats.prj._parse_extrablock` now supports the usage of relative
+  paths.
 
 Changed
 ~~~~~~~

--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -330,7 +330,9 @@ def _parse_capblock(
 
 def _parse_extrablock(lines: _LineIterator, n: int) -> Dict[str, List[str]]:
     """Parse the MetaSWAP "extra files" block"""
-    return {"paths": [next(lines) for _ in range(n)]}
+    content = {"paths": [next(lines) for _ in range(n)]}
+    content["paths"] = [[Path(x[0]).resolve()] for x in content["paths"]]
+    return content
 
 
 def _parse_timeblock(

--- a/imod/tests/test_formats/test_prj.py
+++ b/imod/tests/test_formats/test_prj.py
@@ -399,13 +399,30 @@ def test_parse_pcgblock():
         prj._parse_pcgblock(lines)
 
 
-def test__parse_block():
+def test__parse_block__header_error():
     lines = prj._LineIterator([["1", "(bla)", "1"]])
     content = {}
     with pytest.raises(
         ValueError, match=re.escape("Failed to recognize header keyword: (bla)")
     ):
         prj._parse_block(lines, content)
+
+
+def test__parse_blockline__path_resolved():
+    lines = prj._LineIterator(
+        [["1", "2", "1", "1.0", "0.0", "-999.99", "./ibound.idf"]]
+    )
+    parsed = prj._parse_blockline(lines, "2000-01-01 00:00:00")
+    # Resolved paths are always absolute
+    assert parsed["path"].is_absolute()
+
+
+def test__parse_extrablock__path_resolved():
+    lines = prj._LineIterator(["./ibound.idf", "./para_sim.inp"])
+    n = 2
+    parsed = prj._parse_extrablock(lines, n)
+    # Resolved paths are always absolute
+    assert all(i.is_absolute() for i in parsed["paths"][0])
 
 
 def test__parse_periodsblock():


### PR DESCRIPTION
Fixes #1528 

# Description
<!---
Thanks for opening a PR!

Please add your description here of changes made and how they are going to
resolve the linked issue 
-->
Fixes the issue of using relative paths for the extra MetaSWAP files in the iMOD project file.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
