### PR TITLE
Issue #1530 coordinate order msw idf svat

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -36,6 +36,8 @@ Fixed
   version of iMOD Python or newer.
 - :meth:`imod.mf6.Modflow6Simulation.split` supports label array with a
   different name than ``"idomain"``.
+- :class:`imod.msw.IdfMapping` swapped order of y_grid and x_grid in dictionary
+  for writing the correct order of coordinates in idf_svat.inp.
 
 Changed
 ~~~~~~~

--- a/imod/msw/idf_mapping.py
+++ b/imod/msw/idf_mapping.py
@@ -27,12 +27,12 @@ class IdfMapping(MetaSwapPackage, IRegridPackage):
         "svat": VariableMetaData(10, 1, 9999999, int),
         "rows": VariableMetaData(10, 1, 9999999, int),
         "columns": VariableMetaData(10, 1, 9999999, int),
-        "y_grid": VariableMetaData(15, -9999999.0, 9999999.0, float),
         "x_grid": VariableMetaData(15, -9999999.0, 9999999.0, float),
+        "y_grid": VariableMetaData(15, -9999999.0, 9999999.0, float),
     }
 
     _with_subunit = ()
-    _without_subunit = ("rows", "columns", "y_grid", "x_grid")
+    _without_subunit = ("rows", "columns", "x_grid", "y_grid")
     _to_fill = ()
 
     _regrid_method = IdfMappingRegridMethod()


### PR DESCRIPTION
Fixes #1530

# Description
The coordinate order of the written idf_svat.inp file is incorrect: it should be x y intead of y x.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
