### PR TITLE
Render inactive cells with rates as "" instead of 0.0

### DIFF
--- a/imod/msw/fixed_format.py
+++ b/imod/msw/fixed_format.py
@@ -15,11 +15,15 @@ class VariableMetaData:
 
 
 def format_fixed_width(value, metadata):
-    if metadata.dtype == str:
+    if value == "":
+        col_width = metadata.column_width - 2
+        format_string = "{:" + f"{col_width}" + '}""'
+        return format_string.format(value)
+    if metadata.dtype is str:
         format_string = "{:" + f"{metadata.column_width}" + "}"
-    elif metadata.dtype == int:
+    elif metadata.dtype is int:
         format_string = "{:" + f"{metadata.column_width}d" + "}"
-    elif metadata.dtype == float:
+    elif metadata.dtype is float:
         whole_number_digits = len(str(int(abs(value))))
         decimal_number_width = max(0, metadata.column_width - whole_number_digits - 2)
         format_string = "{:" + f"{metadata.column_width}.{decimal_number_width}f" + "}"

--- a/imod/msw/sprinkling.py
+++ b/imod/msw/sprinkling.py
@@ -136,7 +136,11 @@ class Sprinkling(MetaSwapPackage, IRegridPackage):
         well_row = well_cellid.sel(dim_cellid="row").data - 1
         well_column = well_cellid.sel(dim_cellid="column").data - 1
 
-        max_rate_per_svat = self.dataset["max_abstraction_groundwater"].where(svat > 0)
+        max_rate = (
+            self.dataset["max_abstraction_groundwater"]
+            + self.dataset["max_abstraction_surfacewater"]
+        )
+        max_rate_per_svat = max_rate.where(svat > 0)
         well_layer_per_svat = xr.full_like(max_rate_per_svat, np.nan)
         well_layer_per_svat.values[:, well_row, well_column] = well_layer
 
@@ -165,6 +169,10 @@ class Sprinkling(MetaSwapPackage, IRegridPackage):
         )
 
         self._check_range(dataframe)
+
+        for var in self._with_subunit:
+            s = dataframe[var]
+            dataframe[var] = s.where(s > 0.0).fillna("")
 
         return self.write_dataframe_fixed_width(file, dataframe)
 

--- a/imod/tests/fixtures/msw_fixture.py
+++ b/imod/tests/fixtures/msw_fixture.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import xarray as xr
 
@@ -19,8 +20,12 @@ def fixed_format_parser():
                 for varname, metadata in metadata_dict.items():
                     # Take first part of line
                     value = line[: metadata.column_width]
+                    # Check if value is empty
+                    if value[-2:] == '""':
+                        converted_value = np.nan
                     # Convert to correct type
-                    converted_value = metadata.dtype(value)
+                    else:
+                        converted_value = metadata.dtype(value)
                     # Add to results
                     results[varname].append(converted_value)
                     # Truncate line

--- a/imod/tests/test_msw/test_sprinkling.py
+++ b/imod/tests/test_msw/test_sprinkling.py
@@ -192,6 +192,96 @@ def test_simple_model_some_svats(fixed_format_parser):
     assert_equal(results["svat_groundwater"], np.array([1, 2, 4]))
 
 
+def test_simple_model_inconsistent_active_capacity(fixed_format_parser):
+    x = [1.0, 2.0, 3.0]
+    y = [1.0, 2.0, 3.0]
+    subunit = [0, 1]
+    dx = 1.0
+    dy = 1.0
+    # fmt: off
+    max_abstraction_groundwater = xr.DataArray(
+        np.array(
+            [
+                [[nan, 100.0, nan],
+                [nan, 0.0, nan],
+                [nan, 0.0, nan]],
+                [[nan, nan, nan],
+                [nan, 200.0, nan],
+                [nan, nan, nan]]
+            ]
+        ),
+        dims=("subunit", "y", "x"),
+        coords={"subunit": subunit, "y": y, "x": x, "dx": dx, "dy": dy}
+    )
+
+    max_abstraction_surfacewater = xr.DataArray(
+        np.array(
+            [
+                [[nan, 0.0, nan],
+                [nan, 200.0, nan],
+                [nan, 300.0, nan]],
+                [[nan, nan, nan],
+                [nan, 200.0, nan],
+                [nan, nan, nan]]
+            ]
+        ),
+        dims=("subunit", "y", "x"),
+        coords={"subunit": subunit, "y": y, "x": x, "dx": dx, "dy": dy}
+    )
+
+    svat = xr.DataArray(
+        np.array(
+            [
+                [[0, 1, 0],
+                 [0, 0, 0],
+                 [0, 2, 0]],
+
+                [[0, 3, 0],
+                 [0, 4, 0],
+                 [0, 0, 0]],
+            ]
+        ),
+        dims=("subunit", "y", "x"),
+        coords={"subunit": subunit, "y": y, "x": x, "dx": dx, "dy": dy}
+    )
+    # fmt: on
+    index = (svat != 0).values.ravel()
+
+    # Well
+    well_layer = [3, 2, 1]
+    well_y = [1.0, 2.0, 3.0]
+    well_x = [2.0, 2.0, 2.0]
+    well_rate = [-5.0] * 3
+    cellids = derive_cellid_from_points(svat, well_x, well_y, well_layer)
+    well = Mf6Wel(cellids, well_rate)
+
+    coupler_mapping = msw.Sprinkling(
+        max_abstraction_groundwater,
+        max_abstraction_surfacewater,
+    )
+
+    with tempfile.TemporaryDirectory() as output_dir:
+        output_dir = Path(output_dir)
+        coupler_mapping.write(output_dir, index, svat, None, well)
+
+        results = fixed_format_parser(
+            output_dir / msw.Sprinkling._file_name,
+            msw.Sprinkling._metadata_dict,
+        )
+
+    assert_equal(results["svat"], np.array([1, 2, 4]))
+    assert_almost_equal(
+        results["max_abstraction_groundwater"],
+        np.array([100.0, nan, 200.0]),
+    )
+    assert_almost_equal(
+        results["max_abstraction_surfacewater"],
+        np.array([nan, 300.0, 200.0]),
+    )
+    assert_equal(results["layer"], np.array([3, 1, 2]))
+    assert_equal(results["svat_groundwater"], np.array([1, 2, 4]))
+
+
 def test_simple_model_1_subunit(fixed_format_parser):
     x = [1.0, 2.0, 3.0]
     y = [1.0, 2.0, 3.0]


### PR DESCRIPTION
Fixes #1532

# Description
Render inactive cells in ``scap_svat.inp`` as "" instead of 0.0. I'm not sure if this is entirely necessary as it complicates the nice fixed format writers.

# Checklist
- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
