### PR TITLE
Issue #1507 Add validation model options

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -55,7 +55,10 @@ Changed
   often than not perfectly rectangular in shape.
 - :func:`imod.prepare.create_partition_labels` now returns a griddata with the
   name ``"label"`` instead of ``"idomain"``.
-
+- Upon providing the wrong type to one of the options of
+  :class:`imod.mf6.GroundwaterFlowModel`,
+  :class:`imod.mf6.GroundwaterTransportModel`, this will throw a
+  ``ValidationError`` upon initialization and writing.
 
 [1.0.0rc3] - 2025-04-17
 -----------------------

--- a/imod/common/utilities/schemata.py
+++ b/imod/common/utilities/schemata.py
@@ -1,7 +1,9 @@
 from collections import defaultdict
 from collections.abc import Mapping
 from copy import deepcopy
+from typing import Optional
 
+from imod.common.statusinfo import NestedStatusInfo, StatusInfo, StatusInfoBase
 from imod.schemata import BaseSchema, SchemataDict, ValidationError
 
 
@@ -76,3 +78,26 @@ def validate_schemata_dict(
                 except ValidationError as e:
                     errors[variable].append(e)
     return errors
+
+
+def validation_pkg_error_message(pkg_errors):
+    messages = []
+    for var, var_errors in pkg_errors.items():
+        messages.append(f"- {var}")
+        messages.extend(f"    - {error}" for error in var_errors)
+    return "\n" + "\n".join(messages)
+
+
+def pkg_errors_to_status_info(
+    pkg_name: str,
+    pkg_errors: dict[str, list[ValidationError]],
+    footer_text: Optional[str],
+) -> StatusInfoBase:
+    pkg_status_info = NestedStatusInfo(f"{pkg_name} package")
+    for var_name, var_errors in pkg_errors.items():
+        var_status_info = StatusInfo(var_name)
+        for var_error in var_errors:
+            var_status_info.add_error(str(var_error))
+        pkg_status_info.add(var_status_info)
+    pkg_status_info.set_footer_text(footer_text)
+    return pkg_status_info

--- a/imod/common/utilities/schemata.py
+++ b/imod/common/utilities/schemata.py
@@ -106,7 +106,7 @@ def pkg_errors_to_status_info(
 class ValidateFuncProtocol(Protocol):
     """
     Protocol for a method that validates a schemata dictionary, showing the
-    call signature of this method.
+    call signature the method is expected to have.
     """
 
     def __call__(

--- a/imod/common/utilities/schemata.py
+++ b/imod/common/utilities/schemata.py
@@ -101,3 +101,15 @@ def pkg_errors_to_status_info(
         pkg_status_info.add(var_status_info)
     pkg_status_info.set_footer_text(footer_text)
     return pkg_status_info
+
+
+def validate_with_error_message(
+    validate: bool, schemata: SchemataDict, data: Mapping
+) -> None:
+    if not validate:
+        return
+    errors = validate_schemata_dict(schemata, data)
+    if len(errors) > 0:
+        message = validation_pkg_error_message(errors)
+        raise ValidationError(message)
+    return

--- a/imod/common/utilities/schemata.py
+++ b/imod/common/utilities/schemata.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from collections.abc import Mapping
 from copy import deepcopy
-from typing import Tuple
 
 from imod.schemata import BaseSchema, SchemataDict, ValidationError
 

--- a/imod/common/utilities/schemata.py
+++ b/imod/common/utilities/schemata.py
@@ -108,6 +108,7 @@ class ValidateFuncProtocol(Protocol):
     Protocol for a method that validates a schemata dictionary, showing the
     call signature of this method.
     """
+
     def __call__(
         self, schemata: SchemataDict, **kwargs: Any
     ) -> dict[str, list[ValidationError]]: ...

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -25,7 +25,7 @@ from imod.common.utilities.schemata import (
     concatenate_schemata_dicts,
     pkg_errors_to_status_info,
     validate_schemata_dict,
-    validation_pkg_error_message,
+    validate_with_error_message,
 )
 from imod.logging import LogLevel, logger, standard_log_decorator
 from imod.mf6.drn import Drainage
@@ -75,20 +75,15 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
     ) -> dict[str, list[ValidationError]]:
         return validate_schemata_dict(schemata, self._options, **kwargs)
 
-    def _validate_init_schemata_options(self, validate: bool):
+    @standard_log_decorator()
+    def validate_init_schemata_options(self, validate: bool) -> None:
         """
         Run the "cheap" schema validations.
 
         The expensive validations are run during writing. Some are only
         available then: e.g. idomain to determine active part of domain.
         """
-        if not validate:
-            return
-        errors = self.validate_options(self._init_schemata)
-        if len(errors) > 0:
-            message = validation_pkg_error_message(errors)
-            raise ValidationError(message)
-        return
+        validate_with_error_message(validate, self._init_schemata, self._options)
 
     def __setitem__(self, key, value):
         if len(key) > 16:

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -75,7 +75,6 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
     ) -> dict[str, list[ValidationError]]:
         return validate_schemata_dict(schemata, self._options, **kwargs)
 
-    @standard_log_decorator()
     def validate_init_schemata_options(self, validate: bool) -> None:
         """
         Run the "cheap" schema validations.
@@ -83,7 +82,9 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         The expensive validations are run during writing. Some are only
         available then: e.g. idomain to determine active part of domain.
         """
-        validate_with_error_message(validate, self._init_schemata, self._options)
+        validate_with_error_message(
+            self.validate_options, validate, self._init_schemata
+        )
 
     def __setitem__(self, key, value):
         if len(key) > 16:

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -49,13 +49,16 @@ def pkg_has_cleanup(pkg: Package):
     return any(isinstance(pkg, pkgtype) for pkgtype in PKGTYPES_WITH_CLEANUP)
 
 
-def concatenate_schemata(schemata1: dict[list], schemata2: dict[list]) -> dict[list]:
+def concatenate_schemata(
+    schemata1: SchemataDict, schemata2: SchemataDict
+) -> SchemataDict:
     schemata = deepcopy(schemata1)
     for key, value in schemata2.items():
         if key not in schemata.keys():
             schemata[key] = value
         else:
-            schemata[key] += value
+            # Force to list to be able to concatenate
+            schemata[key] = list(schemata[key]) + list(value)
     return schemata
 
 
@@ -71,9 +74,9 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         env = jinja2.Environment(loader=loader, keep_trailing_newline=True)
         return env.get_template(name)
 
-    def __init__(self, options: dict):
+    def __init__(self):
         collections.UserDict.__init__(self)
-        self._options = options
+        self._options = {}
 
     @standard_log_decorator()
     def _validate_options(

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -23,7 +23,9 @@ from imod.common.utilities.mask import _mask_all_packages
 from imod.common.utilities.regrid import _regrid_like
 from imod.common.utilities.schemata import (
     concatenate_schemata_dicts,
+    pkg_errors_to_status_info,
     validate_schemata_dict,
+    validation_pkg_error_message,
 )
 from imod.logging import LogLevel, logger, standard_log_decorator
 from imod.mf6.drn import Drainage
@@ -33,7 +35,6 @@ from imod.mf6.mf6_wel_adapter import Mf6Wel
 from imod.mf6.package import Package
 from imod.mf6.riv import River
 from imod.mf6.utilities.mf6hfb import merge_hfb_packages
-from imod.mf6.validation import pkg_errors_to_status_info, validation_pkg_error_message
 from imod.mf6.validation_context import ValidationContext
 from imod.mf6.wel import GridAgnosticWell
 from imod.mf6.write_context import WriteContext

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -112,7 +112,7 @@ class GroundwaterFlowModel(Modflow6Model):
             "newton": newton,
             "under_relaxation": under_relaxation,
         }
-        self._validate_init_schemata_options(validate)
+        self.validate_init_schemata_options(validate)
 
     def clip_box(
         self,

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -39,6 +39,7 @@ from imod.prepare.topsystem.default_allocation_methods import (
     SimulationAllocationOptions,
     SimulationDistributingOptions,
 )
+from imod.schemata import TypeSchema
 from imod.typing import GridDataArray, StressPeriodTimesType
 from imod.typing.grid import zeros_like
 from imod.util.regrid import RegridderWeightsCache
@@ -82,6 +83,15 @@ class GroundwaterFlowModel(Modflow6Model):
     _model_id = "gwf6"
     _template = Modflow6Model._initialize_template("gwf-nam.j2")
 
+    _init_schemata = {
+        "listing_file": [TypeSchema(str)],
+        "print_input": [TypeSchema(bool)],
+        "print_flows": [TypeSchema(bool)],
+        "save_flows": [TypeSchema(bool)],
+        "newton": [TypeSchema(bool)],
+        "under_relaxation": [TypeSchema(bool)],
+    }
+
     @init_log_decorator()
     def __init__(
         self,
@@ -91,9 +101,9 @@ class GroundwaterFlowModel(Modflow6Model):
         save_flows: bool = False,
         newton: bool = False,
         under_relaxation: bool = False,
+        validate: bool = True,
     ):
-        super().__init__()
-        self._options = {
+        options = {
             "listing_file": listing_file,
             "print_input": print_input,
             "print_flows": print_flows,
@@ -101,6 +111,8 @@ class GroundwaterFlowModel(Modflow6Model):
             "newton": newton,
             "under_relaxation": under_relaxation,
         }
+        super().__init__(options=options)
+        self._validate_init_schemata_options(validate)
 
     def clip_box(
         self,

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -103,7 +103,8 @@ class GroundwaterFlowModel(Modflow6Model):
         under_relaxation: bool = False,
         validate: bool = True,
     ):
-        options = {
+        super().__init__()
+        self._options = {
             "listing_file": listing_file,
             "print_input": print_input,
             "print_flows": print_flows,
@@ -111,7 +112,6 @@ class GroundwaterFlowModel(Modflow6Model):
             "newton": newton,
             "under_relaxation": under_relaxation,
         }
-        super().__init__(options=options)
         self._validate_init_schemata_options(validate)
 
     def clip_box(

--- a/imod/mf6/model_gwt.py
+++ b/imod/mf6/model_gwt.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from imod.logging import init_log_decorator
 from imod.mf6.model import Modflow6Model
+from imod.schemata import TypeSchema
 
 
 class GroundwaterTransportModel(Modflow6Model):
@@ -36,6 +37,13 @@ class GroundwaterTransportModel(Modflow6Model):
     _model_id = "gwt6"
     _template = Modflow6Model._initialize_template("gwt-nam.j2")
 
+    _init_schemata = {
+        "listing_file": [TypeSchema(str)],
+        "print_input": [TypeSchema(bool)],
+        "print_flows": [TypeSchema(bool)],
+        "save_flows": [TypeSchema(bool)],
+    }
+
     @init_log_decorator()
     def __init__(
         self,
@@ -43,11 +51,13 @@ class GroundwaterTransportModel(Modflow6Model):
         print_input: bool = False,
         print_flows: bool = False,
         save_flows: bool = False,
+        validate: bool = True,
     ):
-        super().__init__()
-        self._options = {
+        options = {
             "listing_file": listing_file,
             "print_input": print_input,
             "print_flows": print_flows,
             "save_flows": save_flows,
         }
+        super().__init__(options=options)
+        self._validate_init_schemata_options(validate)

--- a/imod/mf6/model_gwt.py
+++ b/imod/mf6/model_gwt.py
@@ -60,4 +60,4 @@ class GroundwaterTransportModel(Modflow6Model):
             "print_flows": print_flows,
             "save_flows": save_flows,
         }
-        self._validate_init_schemata_options(validate)
+        self.validate_init_schemata_options(validate)

--- a/imod/mf6/model_gwt.py
+++ b/imod/mf6/model_gwt.py
@@ -53,11 +53,11 @@ class GroundwaterTransportModel(Modflow6Model):
         save_flows: bool = False,
         validate: bool = True,
     ):
-        options = {
+        super().__init__()
+        self._options = {
             "listing_file": listing_file,
             "print_input": print_input,
             "print_flows": print_flows,
             "save_flows": save_flows,
         }
-        super().__init__(options=options)
         self._validate_init_schemata_options(validate)

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -347,15 +347,16 @@ class Package(PackageBase, IPackage, abc.ABC):
         allnodata_errors = self._validate(allnodata_schemata)
         return len(allnodata_errors) > 0
 
-    @standard_log_decorator()
-    def _validate_init_schemata(self, validate: bool) -> None:
+    def _validate_init_schemata(self, validate: bool, **kwargs) -> None:
         """
         Run the "cheap" schema validations.
 
         The expensive validations are run during writing. Some are only
         available then: e.g. idomain to determine active part of domain.
         """
-        validate_with_error_message(validate, self._init_schemata, self.dataset)
+        validate_with_error_message(
+            self._validate, validate, self._init_schemata, **kwargs
+        )
 
     def copy(self) -> Any:
         # All state should be contained in the dataset.

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -23,7 +23,11 @@ from imod.common.utilities.regrid import (
     _regrid_like,
 )
 from imod.common.utilities.regrid_method_type import EmptyRegridMethod, RegridMethodType
-from imod.common.utilities.schemata import filter_schemata_dict, validate_schemata_dict
+from imod.common.utilities.schemata import (
+    filter_schemata_dict,
+    validate_schemata_dict,
+    validation_pkg_error_message,
+)
 from imod.common.utilities.value_filters import is_valid
 from imod.logging import standard_log_decorator
 from imod.mf6.auxiliary_variables import (
@@ -36,7 +40,6 @@ from imod.mf6.pkgbase import (
     TRANSPORT_PACKAGES,
     PackageBase,
 )
-from imod.mf6.validation import validation_pkg_error_message
 from imod.mf6.write_context import WriteContext
 from imod.schemata import (
     AllNoDataSchema,

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -26,7 +26,7 @@ from imod.common.utilities.regrid_method_type import EmptyRegridMethod, RegridMe
 from imod.common.utilities.schemata import (
     filter_schemata_dict,
     validate_schemata_dict,
-    validation_pkg_error_message,
+    validate_with_error_message,
 )
 from imod.common.utilities.value_filters import is_valid
 from imod.logging import standard_log_decorator
@@ -347,20 +347,15 @@ class Package(PackageBase, IPackage, abc.ABC):
         allnodata_errors = self._validate(allnodata_schemata)
         return len(allnodata_errors) > 0
 
-    def _validate_init_schemata(self, validate: bool):
+    @standard_log_decorator()
+    def _validate_init_schemata(self, validate: bool) -> None:
         """
         Run the "cheap" schema validations.
 
         The expensive validations are run during writing. Some are only
         available then: e.g. idomain to determine active part of domain.
         """
-        if not validate:
-            return
-        errors = self._validate(self._init_schemata)
-        if len(errors) > 0:
-            message = validation_pkg_error_message(errors)
-            raise ValidationError(message)
-        return
+        validate_with_error_message(validate, self._init_schemata, self.dataset)
 
     def copy(self) -> Any:
         # All state should be contained in the dataset.

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -42,7 +42,7 @@ from imod.mf6.write_context import WriteContext
 from imod.schemata import (
     AllNoDataSchema,
     EmptyIndexesSchema,
-    SchemaType,
+    SchemataDict,
     ValidationError,
 )
 from imod.typing import GridDataArray
@@ -63,8 +63,8 @@ class Package(PackageBase, IPackage, abc.ABC):
     """
 
     _pkg_id = ""
-    _init_schemata: dict[str, list[SchemaType] | Tuple[SchemaType, ...]] = {}
-    _write_schemata: dict[str, list[SchemaType] | Tuple[SchemaType, ...]] = {}
+    _init_schemata: SchemataDict = {}
+    _write_schemata: SchemataDict = {}
     _keyword_map: dict[str, str] = {}
     _regrid_method: RegridMethodType = EmptyRegridMethod()
     _template: jinja2.Template

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import abc
 import pathlib
-from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union, cast
@@ -24,7 +23,7 @@ from imod.common.utilities.regrid import (
     _regrid_like,
 )
 from imod.common.utilities.regrid_method_type import EmptyRegridMethod, RegridMethodType
-from imod.common.utilities.schemata import filter_schemata_dict
+from imod.common.utilities.schemata import filter_schemata_dict, validate_schemata_dict
 from imod.common.utilities.value_filters import is_valid
 from imod.logging import standard_log_decorator
 from imod.mf6.auxiliary_variables import (
@@ -326,17 +325,7 @@ class Package(PackageBase, IPackage, abc.ABC):
 
     @standard_log_decorator()
     def _validate(self, schemata: dict, **kwargs) -> dict[str, list[ValidationError]]:
-        errors = defaultdict(list)
-        for variable, var_schemata in schemata.items():
-            for schema in var_schemata:
-                if (
-                    variable in self.dataset.keys()
-                ):  # concentration only added to dataset if specified
-                    try:
-                        schema.validate(self.dataset[variable], **kwargs)
-                    except ValidationError as e:
-                        errors[variable].append(e)
-        return errors
+        return validate_schemata_dict(schemata, self.dataset, **kwargs)
 
     def is_empty(self) -> bool:
         """

--- a/imod/mf6/validation.py
+++ b/imod/mf6/validation.py
@@ -2,11 +2,10 @@
 This module contains specific validation utilities for Modflow 6.
 """
 
-from typing import Optional, cast
+from typing import cast
 
 import numpy as np
 
-from imod.common.statusinfo import NestedStatusInfo, StatusInfo, StatusInfoBase
 from imod.schemata import DimsSchema, NoDataComparisonSchema, ValidationError
 from imod.typing import GridDataArray
 
@@ -69,26 +68,3 @@ class DisBottomSchema(NoDataComparisonSchema):
             )
             if (overlaying_top_inactive & active).any():
                 raise ValidationError("inactive bottom above active cell")
-
-
-def validation_pkg_error_message(pkg_errors):
-    messages = []
-    for var, var_errors in pkg_errors.items():
-        messages.append(f"- {var}")
-        messages.extend(f"    - {error}" for error in var_errors)
-    return "\n" + "\n".join(messages)
-
-
-def pkg_errors_to_status_info(
-    pkg_name: str,
-    pkg_errors: dict[str, list[ValidationError]],
-    footer_text: Optional[str],
-) -> StatusInfoBase:
-    pkg_status_info = NestedStatusInfo(f"{pkg_name} package")
-    for var_name, var_errors in pkg_errors.items():
-        var_status_info = StatusInfo(var_name)
-        for var_error in var_errors:
-            var_status_info.add_error(str(var_error))
-        pkg_status_info.add(var_status_info)
-    pkg_status_info.set_footer_text(footer_text)
-    return pkg_status_info

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -20,6 +20,7 @@ import imod.mf6.utilities
 from imod.common.interfaces.ipointdatapackage import IPointDataPackage
 from imod.common.utilities.grid import broadcast_to_full_domain
 from imod.common.utilities.layer import create_layered_top
+from imod.common.utilities.schemata import validation_pkg_error_message
 from imod.logging import init_log_decorator, logger
 from imod.logging.logging_decorators import standard_log_decorator
 from imod.logging.loglevel import LogLevel
@@ -33,7 +34,6 @@ from imod.mf6.mf6_wel_adapter import Mf6Wel, concat_indices_to_cellid
 from imod.mf6.package import Package
 from imod.mf6.utilities.dataset import remove_inactive
 from imod.mf6.utilities.imod5_converter import well_from_imod5_cap_data
-from imod.mf6.validation import validation_pkg_error_message
 from imod.mf6.validation_context import ValidationContext
 from imod.mf6.write_context import WriteContext
 from imod.prepare import assign_wells

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -42,6 +42,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Type,
     TypeAlias,
     Union,
 )
@@ -135,6 +136,7 @@ class BaseSchema(abc.ABC):
 
 
 SchemaType: TypeAlias = BaseSchema
+SchemataDict: TypeAlias = dict[str, list[SchemaType] | Tuple[SchemaType, ...]]
 
 
 class SchemaUnion:
@@ -218,6 +220,26 @@ class DTypeSchema(BaseSchema):
 
         if not np.issubdtype(obj.dtype, self.dtype):
             raise ValidationError(f"dtype {obj.dtype} != {self.dtype}")
+
+
+class TypeSchema(BaseSchema):
+    def __init__(self, dtype: Type) -> None:
+        """
+        Validate type, used for model options instead of GridDataArrays.
+
+        Parameters
+        ----------
+        dtype : type
+            Type of the DataArray.
+        """
+        self.dtype = dtype
+
+    def validate(self, obj: Any, **kwargs) -> None:
+        if obj is None:
+            return
+
+        if not isinstance(obj, self.dtype):
+            raise ValidationError(f"type {type(obj)} != {self.dtype}")
 
 
 class GeometryTypeSchema(BaseSchema):

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -454,16 +454,16 @@ def test_model_init_validation(
     structured_flow_model: GroundwaterFlowModel,
 ):
     # Act
-    structured_flow_model._validate_init_schemata_options(
+    structured_flow_model.validate_init_schemata_options(
         validate=True,
     )
     # Arrange
     structured_flow_model._options["newton"] = 1
     # Act
-    structured_flow_model._validate_init_schemata_options(
+    structured_flow_model.validate_init_schemata_options(
         validate=False,
     )
     with pytest.raises(ValidationError):
-        structured_flow_model._validate_init_schemata_options(
+        structured_flow_model.validate_init_schemata_options(
             validate=True,
         )

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -432,3 +432,38 @@ def test_get_domain_geometry(structured_flow_model: GroundwaterFlowModel):
     assert np.all(np.isin(top.values, [10.0]))
     assert np.all(np.isin(bottom.values, [-1.0, -2.0, -3.0]))
     assert np.all(np.isin(idomain.values, [2]))
+
+
+def test_model_options_validation(
+    structured_flow_model: GroundwaterFlowModel,
+):
+    # Act
+    status = structured_flow_model.validate("modelname")
+    # Assert
+    assert not status.has_errors()
+
+    # Arrange
+    structured_flow_model._options["newton"] = 1
+    # Act
+    status = structured_flow_model.validate("modelname")
+    # Assert
+    assert status.has_errors()
+
+
+def test_model_init_validation(
+    structured_flow_model: GroundwaterFlowModel,
+):
+    # Act
+    structured_flow_model._validate_init_schemata_options(
+        validate=True,
+    )
+    # Arrange
+    structured_flow_model._options["newton"] = 1
+    # Act
+    structured_flow_model._validate_init_schemata_options(
+        validate=False,
+    )
+    with pytest.raises(ValidationError):
+        structured_flow_model._validate_init_schemata_options(
+            validate=True,
+        )

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -104,7 +104,7 @@ class TestModel:
         # Arrange.
         tmp_path = tmpdir_factory.mktemp("TestSimulation")
         model_name = "Test model"
-        model = Modflow6Model(options={"newton": True})
+        model = Modflow6Model()
         # create write context
         validation_context = ValidationContext()
         write_context = WriteContext(tmp_path)
@@ -132,7 +132,7 @@ class TestModel:
         # Arrange.
         tmp_path = tmpdir_factory.mktemp("TestSimulation")
         model_name = "Test model"
-        model = Modflow6Model(options={"newton": True})
+        model = Modflow6Model()
         # create write context
         validation_context = ValidationContext()
         write_context = WriteContext(tmp_path)
@@ -155,7 +155,7 @@ class TestModel:
         # Arrange.
         tmp_path = tmpdir_factory.mktemp("TestSimulation")
         model_name = "Test model"
-        model = Modflow6Model(options={"newton": True})
+        model = Modflow6Model()
         # create write context
         validation_context = ValidationContext()
         write_context = WriteContext(tmp_path)
@@ -189,7 +189,7 @@ class TestModel:
         validation_context = ValidationContext()
         write_context = WriteContext(simulation_directory=tmp_path)
 
-        model = Modflow6Model(options={"newton": True})
+        model = Modflow6Model()
 
         discretization_mock = MagicMock(spec_set=Package)
         discretization_mock._pkg_id = "dis"

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -104,7 +104,7 @@ class TestModel:
         # Arrange.
         tmp_path = tmpdir_factory.mktemp("TestSimulation")
         model_name = "Test model"
-        model = Modflow6Model()
+        model = Modflow6Model(options={"newton": True})
         # create write context
         validation_context = ValidationContext()
         write_context = WriteContext(tmp_path)
@@ -132,7 +132,7 @@ class TestModel:
         # Arrange.
         tmp_path = tmpdir_factory.mktemp("TestSimulation")
         model_name = "Test model"
-        model = Modflow6Model()
+        model = Modflow6Model(options={"newton": True})
         # create write context
         validation_context = ValidationContext()
         write_context = WriteContext(tmp_path)
@@ -155,7 +155,7 @@ class TestModel:
         # Arrange.
         tmp_path = tmpdir_factory.mktemp("TestSimulation")
         model_name = "Test model"
-        model = Modflow6Model()
+        model = Modflow6Model(options={"newton": True})
         # create write context
         validation_context = ValidationContext()
         write_context = WriteContext(tmp_path)
@@ -189,7 +189,7 @@ class TestModel:
         validation_context = ValidationContext()
         write_context = WriteContext(simulation_directory=tmp_path)
 
-        model = Modflow6Model()
+        model = Modflow6Model(options={"newton": True})
 
         discretization_mock = MagicMock(spec_set=Package)
         discretization_mock._pkg_id = "dis"


### PR DESCRIPTION
Fixes #1507

# Description
- Adds validation of model options
- Add TypeSchema to validate model options, which are not DataArray or UgridDataArray
- Clean up unused kwargs logic in ``Modflow6Model.__init__``
- Small refactor: move some logic to concatenate schemata to separate function, force to list to allow concatenating (hidden bug that showed up in mypy after .
- Small refactor: Add TypeAlias SchemaDict

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
