### PR TITLE
Issue #1536 reduce values calls splitting

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -40,6 +40,8 @@ Fixed
   relative paths for the extra files block.
 - :class:`imod.msw.IdfMapping` swapped order of y_grid and x_grid in dictionary
   for writing the correct order of coordinates in idf_svat.inp.
+- Improved performance of :meth:`imod.mf6.Modflow6Simulation.split` and
+  :meth:`imod.mf6.Modflow6Simulation.mask` when using dask.
 
 Changed
 ~~~~~~~

--- a/imod/common/utilities/mask.py
+++ b/imod/common/utilities/mask.py
@@ -81,7 +81,7 @@ def _skip_dataarray(da: GridDataArray) -> bool:
     if len(da.dims) == 0 or set(da.coords).issubset(["layer"]):
         return True
 
-    if is_scalar(da.values[()]):
+    if is_scalar(da):
         return True
 
     spatial_dims = ["x", "y", "mesh2d_nFaces", "layer"]

--- a/imod/common/utilities/mask.py
+++ b/imod/common/utilities/mask.py
@@ -9,7 +9,12 @@ from imod.common.interfaces.imaskingsettings import IMaskingSettings
 from imod.common.interfaces.imodel import IModel
 from imod.common.interfaces.ipackage import IPackage
 from imod.common.interfaces.isimulation import ISimulation
-from imod.typing.grid import GridDataArray, get_spatial_dimension_names, is_same_domain
+from imod.typing.grid import (
+    GridDataArray,
+    get_spatial_dimension_names,
+    is_same_domain,
+    is_spatial_grid,
+)
 
 # create dispatcher instance to limit scope of typedispatching
 dispatch = Dispatcher()
@@ -84,8 +89,7 @@ def _skip_dataarray(da: GridDataArray) -> bool:
     if is_scalar(da):
         return True
 
-    spatial_dims = ["x", "y", "mesh2d_nFaces", "layer"]
-    if not np.any([coord in spatial_dims for coord in da.coords]):
+    if not is_spatial_grid(da) and ("layer" not in da.dims):
         return True
 
     return False

--- a/imod/mf6/multimodel/exchange_creator_unstructured.py
+++ b/imod/mf6/multimodel/exchange_creator_unstructured.py
@@ -39,8 +39,8 @@ class ExchangeCreator_Unstructured(ExchangeCreator):
         face1 = edge_face_connectivity[self._connected_cell_edge_indices, 0]
         face2 = edge_face_connectivity[self._connected_cell_edge_indices, 1]
 
-        label_of_face1 = self._submodel_labels.values[face1]
-        label_of_face2 = self._submodel_labels.values[face2]
+        label_of_face1 = self._submodel_labels.data[face1]
+        label_of_face2 = self._submodel_labels.data[face2]
 
         connected_cell_info = pd.DataFrame(
             {
@@ -139,8 +139,8 @@ class ExchangeCreator_Unstructured(ExchangeCreator):
         face1 = edge_face_connectivity[:, 0]
         face2 = edge_face_connectivity[:, 1]
 
-        label_of_face1 = submodel_labels.values[face1]
-        label_of_face2 = submodel_labels.values[face2]
+        label_of_face1 = submodel_labels.data[face1]
+        label_of_face2 = submodel_labels.data[face2]
 
         is_internal_edge = label_of_face1 - label_of_face2 == 0
         is_external_boundary_edge = np.any((face1 == -1, face2 == -1), axis=0)

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1250,7 +1250,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
                 "x": id.sel({f"cell_dims{i}": f"column_{i}"}),
             }
         exchange_domain = domain.isel(exchange_cells)
-        active_exchange_domain = exchange_domain.where(exchange_domain.values > 0)
+        active_exchange_domain = exchange_domain.where(exchange_domain > 0)
         active_exchange_domain = active_exchange_domain.dropna("index")
         ex.dataset = ex.dataset.sel(index=active_exchange_domain["index"])
 

--- a/imod/tests/test_common/test_utilities/test_mask_util.py
+++ b/imod/tests/test_common/test_utilities/test_mask_util.py
@@ -1,0 +1,23 @@
+import xarray as xr
+from pytest_cases import parametrize_with_cases
+from xarray.tests import raise_if_dask_computes
+
+from imod.common.utilities.mask import _skip_dataarray
+from imod.tests.fixtures.package_instance_creation import get_grid_da
+
+
+class GridCases:
+    def case_structured(self):
+        return get_grid_da(False, float).chunk({"layer": 1})
+
+    def case_unstructured(self):
+        return get_grid_da(True, float).chunk({"layer": 1})
+
+
+@parametrize_with_cases("grid", cases=GridCases)
+def test_skip_dataarray(grid):
+    layer_da = xr.DataArray([1, 2, 3], coords={"layer": [1, 2, 3]}, dims=("layer",))
+    with raise_if_dask_computes():
+        assert _skip_dataarray(grid) is False
+        assert _skip_dataarray(xr.DataArray(True)) is True
+        assert _skip_dataarray(layer_da) is True


### PR DESCRIPTION
Fixes #1536

# Description
- Remove unnecessary calls to ``.values``
- Refactor exchange creation logic to use ``xr.Dataset().to_dataframe()``

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
