### PR TITLE
Issue #1542 Bug fix case sensitivity of periods keyword in iMOD project file.

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -43,6 +43,8 @@ Fixed
 - Fixed bug in :meth:`imod.mf6.Well.cleanup` and
   :meth:`imod.mf6.LayeredWell.cleanup` which caused an error when called with an
   unstructured discretization.
+- Fixed bug in :func:`imod.formats.prj.open_projectfile_data` which caused an
+  error when a periods keyword was used having an upper case.
 
 Changed
 ~~~~~~~

--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -1052,7 +1052,7 @@ def open_projectfile_data(path: FilePath) -> tuple[dict[str, Any], dict[str, Any
         # Set the year of a repeat date to 1899: this ensures it falls outside
         # of the iMOD calendar. Collisions are then always avoided.
         periods = {
-            key: _process_time(time, yearfirst=False).replace(year=1899)
+            key.lower(): _process_time(time, yearfirst=False).replace(year=1899)
             for key, time in periods_block.items()
         }
 

--- a/imod/tests/test_formats/test_prj.py
+++ b/imod/tests/test_formats/test_prj.py
@@ -82,10 +82,10 @@ PRJ_TEMPLATE = textwrap.dedent(
     1900-01-01
     001,001
         1,2, 001, 1.0, 0.0, -999.9900,"{basepath}/rch.idf",
-    summer
+    SUMMER
     001,001
         1,2, 001, 1.0, 0.0, -999.9900,"{basepath}/rch.idf",
-    winter
+    WINTER
     001,001
         1,2, 001, 1.0, 0.0, -999.9900,"{basepath}/rch.idf",
 
@@ -109,9 +109,9 @@ PRJ_TEMPLATE = textwrap.dedent(
         QERROR=  0.1000000
 
     Periods
-    summer
+    SUMMER
     01-04-1900 00:00:00
-    winter
+    WINTER
     01-10-1900 00:00:00
 
     Species


### PR DESCRIPTION
Fixes #1542 

# Description
<!---
Thanks for opening a PR!

Please add your description here of changes made and how they are going to
resolve the linked issue 
-->
This fixes a minor bug related to unwanted case sensitivity of the periods keyword in the iMOD project file.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
