### PR TITLE
Issue #1373 add test plan

### DIFF
--- a/docs/developing/index.rst
+++ b/docs/developing/index.rst
@@ -35,6 +35,7 @@ in-depth description.
    ci
    releasing
    docker
+   test-plan
 
 .. _Contributing to xarray guide: https://xarray.pydata.org/en/latest/contributing.html
 .. _pages: https://github.com/Deltares/imod-python/issues

--- a/docs/developing/test-plan.rst
+++ b/docs/developing/test-plan.rst
@@ -54,6 +54,5 @@ Criteria for user acceptance tests of the 1.0 release are:
   done in a reasonable amount of time and should not be much slower than iMOD5.
   This is subjective, but we aim for less than 5 minutes for the LHM model with
   1 timestep.
-*
-
+* Are there large differences in memory usage compared to iMOD5? 
 

--- a/docs/developing/test-plan.rst
+++ b/docs/developing/test-plan.rst
@@ -1,0 +1,59 @@
+iMOD Python test plan
+=====================
+
+This document describes how and when to perform tests for iMOD Python.
+
+Known shortcomings and issues can be documented `here
+<https://deltares.github.io/imod-python/faq/known-issues.html>`_ . Bugs can be
+reported on `GitHub <https://github.com/Deltares/imod-python/issues>`_ .
+
+Functional tests
+----------------
+
+The functional tests are run as part of the CI pipeline, and are short models.
+They can be run locally by running the following command in the root of the
+repository:
+
+```bash
+pixi run tests
+```
+
+These tests are run on every push to the repository, and on every pull request. T
+
+User acceptance tests
+---------------------
+
+The user acceptance tests are not run as part of the CI pipeline. This is a
+performance stress test that tests the capabilities of iMOD Python in dealing
+with large groundwater models. These tests are either too slow or require to
+much manual input to be part of our CI. The model currently used for the user
+acceptance tests is `the LHM model <https://nhi.nu/modellen/lhm/>`_, but more
+models might be added in the future.
+
+Run the user acceptance tests locally by following these steps:
+
+  1. Download the test data from <...insert...link...here...> and put it in a
+     directory of your liking.
+  2. Assign the environment variable ``LHM_PRJ`` to the path of the projectfile
+     of the test data. You can put this in the ``.env`` file in the root of the
+     repository, or set it in your shell.
+  3. Run the user acceptance tests by running the following command in the root 
+     of the repository:
+
+```bash
+pixi run user_acceptance
+```
+
+Criteria for user acceptance tests of the 1.0 release are:
+
+* The tests should run without errors.
+* The MODFLOW6 and MetaSWAP input files written by iMOD Python should be the
+  same as iMOD5 (accounting for differences in sorting.), unless there was a
+  conscious decision to divert from this.
+* The conversion from projectfile to MODFLOW6 and MetaSWAP input files should be
+  done in a reasonable amount of time and should not be much slower than iMOD5.
+  This is subjective, but we aim for less than 5 minutes for the LHM model with
+  1 timestep.
+*
+
+

--- a/docs/developing/test-plan.rst
+++ b/docs/developing/test-plan.rst
@@ -11,42 +11,47 @@ Functional tests
 ----------------
 
 The functional tests are run as part of the CI pipeline, and consist of
-unittests and short examples. They can be run locally by running the following
-commands in the root of the repository:
+unittests and short examples which will be containted in the documentation. They
+can be run locally by running the following commands in the root of the
+repository:
 
-```bash
-pixi run tests
-pixi run examples
-```
+.. code-block:: console
 
-These tests are run on every push to the repository, and on every pull request.
+  pixi run tests
+  pixi run examples
+
+These tests are run automatically on every push to the repository, and on every
+pull request. They will therefore presumably work as they are run regularly, but
+a final check can't harm anyway.
 
 User acceptance tests
 ---------------------
 
-The user acceptance tests are not run as part of the CI pipeline. This is a
-performance stress test that tests the capabilities of iMOD Python in dealing
-with large groundwater models. These tests are either too slow or require too
-much manual input to be part of our CI. The model currently used for the user
-acceptance tests is `the LHM model <https://nhi.nu/modellen/lhm/>`_, but more
-models might be added in the future.
+The user acceptance tests are not run as part of the CI pipeline, because they
+are are either too slow or require too much manual input to be part of our CI.
+These therefore require extra attention before a release.
 
-Run the user acceptance tests locally by following these steps:
+Performance tests
+*****************
 
-  1. Download the test data from <...insert...link...here...> and put it in a
-     directory of your liking.
-  2. Assign the environment variable ``LHM_PRJ`` to the path of the projectfile
-     of the test data. You can put this in the ``.env`` file in the root of the
-     repository, or set it in your shell.
-  3. Run the user acceptance tests by running the following command in the root 
-     of the repository:
+These are stress tests that tests the capabilities of iMOD Python in dealing
+with large groundwater models. The model currently used for the performance
+tests is `the LHM model <https://nhi.nu/modellen/lhm/>`_, but more models might
+be added in the future.
 
-     ```bash
-     pixi run user_acceptance
-     ```
+Run the performance tests locally by following these steps:
 
-Criteria
-********
+1. Download the test data from <...insert...link...here...> and put it in a
+   directory of your liking.
+2. Assign the environment variable ``LHM_PRJ`` to the path of the projectfile
+   of the test data. You can put this in the ``.env`` file in the root of the
+   repository, or set it in your shell.
+3. Run the user acceptance tests by running the following command in the root 
+   of the repository:
+
+.. code-block:: console
+
+  pixi run user_acceptance
 
 Criteria for user acceptance tests of the 1.0 release are:
 
@@ -57,8 +62,9 @@ Criteria for user acceptance tests of the 1.0 release are:
   conscious decision to divert from this.
 * The conversion from projectfile to MODFLOW6 and MetaSWAP input files should be
   done in a reasonable amount of time and should not be much slower than iMOD5.
-  This is subjective, but we aim for less than 5 minutes for the LHM model with
-  1 timestep on a machine with 32 GB RAM.
+  This is subjective and varies per machine, but we aim for less than 5 minutes
+  for the LHM model with 1 timestep on a machine with 32 GB RAM on a single
+  core.
 * The conversion of the transient LHM model run of 40 years on a daily timestep
   (140K timesteps) should be possible without memory overflow.
 
@@ -71,8 +77,32 @@ Manual checks
   mesh. Verify if the mesh is rendered properly, if not open an issue on `GitHub
   <https://github.com/Deltares/imod-python/issues>`_ .
   
-  ```bash
+.. code-block:: console
+
   pixi run export-qgis
-  ```
+
 - Work through the tutorial material here and verify it is up to date:
   https://deltares.github.io/iMOD-Documentation/
+
+Documentation
+*************
+
+Build the documentation locally by running the following command in the root of
+the repository:
+
+.. code-block:: console
+
+  pixi run docs
+
+Check if the documentation builds without errors and warnings. If there are
+errors or warnings, fix them before releasing in a pull request on `Github
+<https://github.com/Deltares/imod-python/pulls>`_ . Next, check if the
+documentation pages are rendered correctly and if the information on them is not
+outdated. You can do this by opening the HTML files in the ``docs/_build/html``.
+Focus on the following pages for the 1.0 release:
+
+- The `Install documentation <https://deltares.github.io/imod-python/installation/>`_
+- The `iMOD Python API documentation
+  <https://deltares.github.io/imod-python/api/>`_, focus on whether all classes,
+  methods, and functions that are part of the public API are documented.
+- The `iMOD5 Backwards compatibility documentation <faq/imod5_backwards_compatibility.html>`_

--- a/docs/developing/test-plan.rst
+++ b/docs/developing/test-plan.rst
@@ -10,22 +10,23 @@ reported on `GitHub <https://github.com/Deltares/imod-python/issues>`_ .
 Functional tests
 ----------------
 
-The functional tests are run as part of the CI pipeline, and are short models.
-They can be run locally by running the following command in the root of the
-repository:
+The functional tests are run as part of the CI pipeline, and consist of
+unittests and short examples. They can be run locally by running the following
+commands in the root of the repository:
 
 ```bash
 pixi run tests
+pixi run examples
 ```
 
-These tests are run on every push to the repository, and on every pull request. T
+These tests are run on every push to the repository, and on every pull request.
 
 User acceptance tests
 ---------------------
 
 The user acceptance tests are not run as part of the CI pipeline. This is a
 performance stress test that tests the capabilities of iMOD Python in dealing
-with large groundwater models. These tests are either too slow or require to
+with large groundwater models. These tests are either too slow or require too
 much manual input to be part of our CI. The model currently used for the user
 acceptance tests is `the LHM model <https://nhi.nu/modellen/lhm/>`_, but more
 models might be added in the future.
@@ -40,19 +41,38 @@ Run the user acceptance tests locally by following these steps:
   3. Run the user acceptance tests by running the following command in the root 
      of the repository:
 
-```bash
-pixi run user_acceptance
-```
+     ```bash
+     pixi run user_acceptance
+     ```
+
+Criteria
+********
 
 Criteria for user acceptance tests of the 1.0 release are:
 
 * The tests should run without errors.
+* The tests should run without warnings from iMOD Python, unless unavoidable.
 * The MODFLOW6 and MetaSWAP input files written by iMOD Python should be the
-  same as iMOD5 (accounting for differences in sorting.), unless there was a
+  same as iMOD5 (accounting for differences in row sorting.), unless there was a
   conscious decision to divert from this.
 * The conversion from projectfile to MODFLOW6 and MetaSWAP input files should be
   done in a reasonable amount of time and should not be much slower than iMOD5.
   This is subjective, but we aim for less than 5 minutes for the LHM model with
-  1 timestep.
-* Are there large differences in memory usage compared to iMOD5? 
+  1 timestep on a machine with 32 GB RAM.
+* The conversion of the transient LHM model run of 40 years on a daily timestep
+  (140K timesteps) should be possible without memory overflow.
 
+Manual checks
+*************
+
+- Run the pixi task written below. This will export data to a UGRID NetCDF and
+  save it under the name <......>. Open QGIS. Click "Layers" > "Add Layer" >
+  "Add mesh". Insert the path <......> in the text box. This will import the
+  mesh. Verify if the mesh is rendered properly, if not open an issue on `GitHub
+  <https://github.com/Deltares/imod-python/issues>`_ .
+  
+  ```bash
+  pixi run export-qgis
+  ```
+- Work through the tutorial material here and verify it is up to date:
+  https://deltares.github.io/iMOD-Documentation/


### PR DESCRIPTION
Fixes #1373

# Description
Adds test plan for the 1.0 release. Two remarks:

- The LHM stress test information is still aspecific on where to download data etc, as we are still conducting some tests here. We haven't fully arrived at a final test case here (we are still tweaking the case). When we have finished this work, we can upload it on a MinIO bucket.
- The pixi task to generate a grid to be imported for qgis still has to be made

# Checklist

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
