### PR TITLE
Issue #1553 add version number

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -15,6 +15,8 @@ Added
 - Added ``weights`` argument to :func:`imod.prepare.create_partition_labels` to
   weigh how the simulation should be partioned. Areas with higher weights will
   result in smaller partions.
+- iMOD Python version is now written in a comment line to MODFLOW6 and
+  MetaSWAP's ``para_sim.inp`` files. This is useful for debugging purposes.
 
 Fixed
 ~~~~~

--- a/imod/common/utilities/version.py
+++ b/imod/common/utilities/version.py
@@ -1,7 +1,8 @@
+from typing import Optional
+
 import imod
 from imod.logging import LogLevel, logger
 
-from typing import Optional
 
 def get_version() -> str:
     """
@@ -36,9 +37,7 @@ def prepend_content_with_version_info(content: str) -> str:
 
 def log_versions(version_saved: Optional[dict[str, str]]) -> None:
     version = get_version()
-    logger.log(
-        LogLevel.INFO, f"iMOD Python version in current environment: {version}"
-    )
+    logger.log(LogLevel.INFO, f"iMOD Python version in current environment: {version}")
     if version_saved:
         version_msg = (
             f"iMOD Python version in dumped simulation: {version_saved['imod-python']}"

--- a/imod/common/utilities/version.py
+++ b/imod/common/utilities/version.py
@@ -1,0 +1,20 @@
+import imod
+
+
+def prepend_content_with_version_info(content: str) -> str:
+    """
+    Prepends file content with comment with iMOD Python version information.
+
+    Parameters
+    ----------
+    content: str
+        The file content to prepended.
+
+    Returns
+    -------
+    str
+        Content prepended with the version information.
+    """
+    version = imod.__version__
+
+    return f"# File written with iMOD Python version: {version}\n\n{content}"

--- a/imod/common/utilities/version.py
+++ b/imod/common/utilities/version.py
@@ -1,4 +1,18 @@
 import imod
+from imod.logging import LogLevel, logger
+
+from typing import Optional
+
+def get_version() -> str:
+    """
+    Returns the version of the iMOD Python package.
+
+    Returns
+    -------
+    str
+        The version of the iMOD Python package.
+    """
+    return imod.__version__
 
 
 def prepend_content_with_version_info(content: str) -> str:
@@ -15,6 +29,23 @@ def prepend_content_with_version_info(content: str) -> str:
     str
         Content prepended with the version information.
     """
-    version = imod.__version__
+    version = get_version()
 
     return f"# File written with iMOD Python version: {version}\n\n{content}"
+
+
+def log_versions(version_saved: Optional[dict[str, str]]) -> None:
+    version = get_version()
+    logger.log(
+        LogLevel.INFO, f"iMOD Python version in current environment: {version}"
+    )
+    if version_saved:
+        version_msg = (
+            f"iMOD Python version in dumped simulation: {version_saved['imod-python']}"
+        )
+    else:
+        version_msg = "No iMOD Python version information found in dumped simulation."
+    logger.log(
+        LogLevel.INFO,
+        version_msg,
+    )

--- a/imod/common/utilities/version.py
+++ b/imod/common/utilities/version.py
@@ -19,7 +19,8 @@ def get_version() -> str:
 
 
 def prepend_content_with_version_info(
-    content: str, comment_char="#", n_newlines=2
+    content: str,
+    comment_char="#",
 ) -> str:
     """
     Prepends file content with comment with iMOD Python version information.
@@ -30,8 +31,6 @@ def prepend_content_with_version_info(
         The file content to prepended.
     comment_char: str, optional
         The character used for comments in the file. Defaults to "#".
-    n_newlines: int, optional
-        The number of newlines to add after the version comment. Defaults to 2.
 
     Returns
     -------
@@ -39,10 +38,9 @@ def prepend_content_with_version_info(
         Content prepended with the version information.
     """
     version = get_version()
-    newlines = "\n" * n_newlines
     line_text = "File written with iMOD Python version"
 
-    return f"{comment_char} {line_text}: {version}{newlines}{content}"
+    return f"{comment_char} {line_text}: {version}\n\n{content}"
 
 
 def log_versions(version_saved: Optional[dict[str, str]]) -> None:

--- a/imod/common/utilities/version.py
+++ b/imod/common/utilities/version.py
@@ -6,7 +6,9 @@ from imod.logging import LogLevel, logger
 
 def get_version() -> str:
     """
-    Returns the version of the iMOD Python package.
+    Returns the version of the iMOD Python package. This now is a trivial
+    function, but it can be later expanded to also include git hashes with a
+    package like setuptools-scm or hash-vcs.
 
     Returns
     -------
@@ -16,7 +18,9 @@ def get_version() -> str:
     return imod.__version__
 
 
-def prepend_content_with_version_info(content: str) -> str:
+def prepend_content_with_version_info(
+    content: str, comment_char="#", n_newlines=2
+) -> str:
     """
     Prepends file content with comment with iMOD Python version information.
 
@@ -24,6 +28,10 @@ def prepend_content_with_version_info(content: str) -> str:
     ----------
     content: str
         The file content to prepended.
+    comment_char: str, optional
+        The character used for comments in the file. Defaults to "#".
+    n_newlines: int, optional
+        The number of newlines to add after the version comment. Defaults to 2.
 
     Returns
     -------
@@ -31,8 +39,10 @@ def prepend_content_with_version_info(content: str) -> str:
         Content prepended with the version information.
     """
     version = get_version()
+    newlines = "\n" * n_newlines
+    line_text = "File written with iMOD Python version"
 
-    return f"# File written with iMOD Python version: {version}\n\n{content}"
+    return f"{comment_char} {line_text}: {version}{newlines}{content}"
 
 
 def log_versions(version_saved: Optional[dict[str, str]]) -> None:

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -27,6 +27,7 @@ from imod.common.utilities.schemata import (
     validate_schemata_dict,
     validate_with_error_message,
 )
+from imod.common.utilities.version import prepend_content_with_version_info
 from imod.logging import LogLevel, logger, standard_log_decorator
 from imod.mf6.drn import Drainage
 from imod.mf6.ghb import GeneralHeadBoundary
@@ -399,6 +400,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
 
         # write model namefile
         namefile_content = self.render(modelname, write_context)
+        namefile_content = prepend_content_with_version_info(namefile_content)
         namefile_path = modeldirectory / f"{modelname}.nam"
         with open(namefile_path, "w") as f:
             f.write(namefile_content)

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -40,6 +40,7 @@ from imod.common.utilities.schemata import (
     validate_with_error_message,
 )
 from imod.common.utilities.value_filters import is_valid
+from imod.common.utilities.version import prepend_content_with_version_info
 from imod.logging import standard_log_decorator
 from imod.mf6.auxiliary_variables import (
     expand_transient_auxiliary_variables,
@@ -144,6 +145,7 @@ class Package(PackageBase, IPackage, abc.ABC):
             globaltimes=globaltimes,
             binary=write_context.use_binary,
         )
+        content = prepend_content_with_version_info(content)
         filename = write_context.write_directory / f"{pkgname}.{self._pkg_id}"
         with open(filename, "w") as f:
             f.write(content)

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -19,6 +19,7 @@ import xarray as xr
 import xugrid as xu
 
 import imod
+from imod.common.utilities.version import log_versions
 import imod.logging
 import imod.mf6.exchangebase
 from imod.common.interfaces.imodel import IModel
@@ -28,7 +29,7 @@ from imod.common.utilities.mask import _mask_all_models
 from imod.common.utilities.regrid import _regrid_like
 from imod.common.utilities.regrid_method_type import RegridMethodType
 from imod.common.utilities.version import prepend_content_with_version_info
-from imod.logging import LogLevel, logger, standard_log_decorator
+from imod.logging import standard_log_decorator
 from imod.mf6.gwfgwf import GWFGWF
 from imod.mf6.gwfgwt import GWFGWT
 from imod.mf6.gwtgwt import GWTGWT
@@ -86,22 +87,6 @@ def get_packages(simulation: Modflow6Simulation) -> dict[str, Package]:
         for pkg_name, pkg in simulation.items()
         if isinstance(pkg, Package)
     }
-
-
-def log_versions(version_saved: Optional[dict[str, str]]) -> None:
-    logger.log(
-        LogLevel.INFO, f"iMOD Python version in current environment: {imod.__version__}"
-    )
-    if version_saved:
-        version_msg = (
-            f"iMOD Python version in dumped simulation: {version_saved['imod-python']}"
-        )
-    else:
-        version_msg = "No iMOD Python version information found in dumped simulation."
-    logger.log(
-        LogLevel.INFO,
-        version_msg,
-    )
 
 
 class Modflow6Simulation(collections.UserDict, ISimulation):

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -19,7 +19,6 @@ import xarray as xr
 import xugrid as xu
 
 import imod
-from imod.common.utilities.version import log_versions
 import imod.logging
 import imod.mf6.exchangebase
 from imod.common.interfaces.imodel import IModel
@@ -28,7 +27,11 @@ from imod.common.statusinfo import NestedStatusInfo
 from imod.common.utilities.mask import _mask_all_models
 from imod.common.utilities.regrid import _regrid_like
 from imod.common.utilities.regrid_method_type import RegridMethodType
-from imod.common.utilities.version import prepend_content_with_version_info
+from imod.common.utilities.version import (
+    get_version,
+    log_versions,
+    prepend_content_with_version_info,
+)
 from imod.logging import standard_log_decorator
 from imod.mf6.gwfgwf import GWFGWF
 from imod.mf6.gwfgwt import GWFGWT
@@ -880,7 +883,8 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
 
         toml_content: DefaultDict[str, dict] = collections.defaultdict(dict)
         # Dump version number
-        toml_content["version"] = {"imod-python": imod.__version__}
+        version = get_version()
+        toml_content["version"] = {"imod-python": version}
         # Dump models and exchanges
         for key, value in self.items():
             cls_name = type(value).__name__

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -27,6 +27,7 @@ from imod.common.statusinfo import NestedStatusInfo
 from imod.common.utilities.mask import _mask_all_models
 from imod.common.utilities.regrid import _regrid_like
 from imod.common.utilities.regrid_method_type import RegridMethodType
+from imod.common.utilities.version import prepend_content_with_version_info
 from imod.logging import LogLevel, logger, standard_log_decorator
 from imod.mf6.gwfgwf import GWFGWF
 from imod.mf6.gwfgwt import GWFGWT
@@ -291,6 +292,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
 
         # Write simulation namefile
         mfsim_content = self.render(write_context)
+        mfsim_content = prepend_content_with_version_info(mfsim_content)
         mfsim_path = directory / "mfsim.nam"
         with open(mfsim_path, "w") as f:
             f.write(mfsim_content)

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -10,6 +10,7 @@ import numpy as np
 import xarray as xr
 
 from imod.common.utilities.value_filters import enforce_scalar
+from imod.common.utilities.version import prepend_content_with_version_info
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.mf6_wel_adapter import Mf6Wel
 from imod.msw.copy_files import FileCopier
@@ -264,8 +265,12 @@ class MetaSwapModel(Model):
         )
 
         filename = directory / self._file_name
+        rendered = self._template.render(settings=simulation_settings)
+        # Prepend version information
+        rendered = prepend_content_with_version_info(
+            rendered, comment_char="*", n_newlines=1
+        )
         with open(filename, "w") as f:
-            rendered = self._template.render(settings=simulation_settings)
             f.write(rendered)
 
     def write(

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -267,9 +267,7 @@ class MetaSwapModel(Model):
         filename = directory / self._file_name
         rendered = self._template.render(settings=simulation_settings)
         # Prepend version information
-        rendered = prepend_content_with_version_info(
-            rendered, comment_char="*", n_newlines=1
-        )
+        rendered = prepend_content_with_version_info(rendered, comment_char="*")
         with open(filename, "w") as f:
             f.write(rendered)
 

--- a/imod/tests/test_mf6/test_ex01_twri.py
+++ b/imod/tests/test_mf6/test_ex01_twri.py
@@ -8,11 +8,11 @@ import pytest
 import xarray as xr
 
 import imod
+from imod.common.utilities.version import get_version
 from imod.mf6.validation_context import ValidationContext
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.typing.grid import ones_like
-from imod.common.utilities.version import get_version
 
 
 def test_dis_render(twri_model, tmp_path):

--- a/imod/tests/test_mf6/test_ex01_twri.py
+++ b/imod/tests/test_mf6/test_ex01_twri.py
@@ -12,6 +12,7 @@ from imod.mf6.validation_context import ValidationContext
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.typing.grid import ones_like
+from imod.common.utilities.version import get_version
 
 
 def test_dis_render(twri_model, tmp_path):
@@ -283,8 +284,11 @@ def test_wel_render(twri_model, tmp_path):
     with open(wel_path, "r") as wel_file:
         actual = wel_file.read()
 
+    version = get_version()
     expected = textwrap.dedent(
-        """\
+        f"""\
+            # File written with iMOD Python version: {version}
+
             begin options
               save_flows
             end options

--- a/imod/tests/test_mf6/test_mf6_drn.py
+++ b/imod/tests/test_mf6/test_mf6_drn.py
@@ -10,6 +10,7 @@ from pytest_cases import parametrize_with_cases
 
 import imod
 import imod.mf6.drn
+from imod.common.utilities.version import get_version
 from imod.logging import LoggerType, LogLevel
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.npf import NodePropertyFlow
@@ -104,8 +105,11 @@ def test_write(drainage, tmp_path):
     write_context = WriteContext(simulation_directory=tmp_path, use_binary=True)
     drn._write("mydrn", [1], write_context)
 
+    version = get_version()
     block_expected = textwrap.dedent(
-        """\
+        f"""\
+        # File written with iMOD Python version: {version}
+
         begin options
         end options
 

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -21,6 +21,7 @@ from pytest_cases import parametrize_with_cases
 
 import imod
 from imod.common.statusinfo import NestedStatusInfo, StatusInfo
+from imod.common.utilities.version import get_version
 from imod.logging import LoggerType, LogLevel
 from imod.mf6 import LayeredWell, Well
 from imod.mf6.model import Modflow6Model
@@ -80,7 +81,7 @@ def test_dump_version_number__version_written(twri_model, tmpdir_factory):
     toml_path = tmp_path / f"{twri_model.name}.toml"
     with open(toml_path, "rb") as f:
         toml_content = tomli.load(f)
-    assert toml_content["version"]["imod-python"] == imod.__version__
+    assert toml_content["version"]["imod-python"] == get_version()
 
 
 def test_from_file_version_logged__version_in_dumped(twri_model, tmpdir_factory):

--- a/imod/tests/test_msw/test_model.py
+++ b/imod/tests/test_msw/test_model.py
@@ -45,7 +45,13 @@ def test_msw_model_write_settings_roundtrip(msw_model, tmp_path):
     # Act
     msw_model._write_simulation_settings(output_dir)
     # Assert
-    parasim_settings = read_para_sim(output_dir / "para_sim.inp")
+    # Test first line of the file contains version information
+    filename = output_dir / "para_sim.inp"
+    with open(filename, "r") as f:
+        lines = f.readlines()
+    assert lines[0].startswith("* File written with iMOD Python version:")
+
+    parasim_settings = read_para_sim(filename)
     for key in keys_to_drop:
         parasim_settings.pop(key)
 


### PR DESCRIPTION
Fixes #1553

# Description
- Render ``para_sim.inp`` (MetaSWAP) and ``.nam`` and package files like ``.riv`` (MODFLOW6)  with a comment line indicating the released iMOD Python version with which the file is written.
- Refactor: Move logic to log and write the iMOD Python version to a separate module 

Example ``para_sim.inp``:

```
* File written with iMOD Python version: 1.0.0rc3

vegetation_mdl = 1
evapotranspiration_mdl = 1
saltstress_mdl = 0
...
```

Example ``mfsim.nam``:

```
# File written with iMOD Python version: 1.0.0rc3

begin options
end options

begin timing
  tdis6 time_discretization.tdis
end timing

begin models
  gwf6 GWF_1/GWF_1.nam GWF_1
end models
...
```

I'm toying with the idea to also include the git hash for dev installs using either https://github.com/ofek/hatch-vcs or https://setuptools-scm.readthedocs.io/en/latest/ . From what I've seen, this would require some extra logic, which can be added to the ``get_version`` function. This is something for a follow-up issue.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
