### PR TITLE
Also return legend labels from read_imod_legend

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -94,6 +94,10 @@ Changed
 - :meth:`imod.mf6.ConstantHead.from_imod5_data` and
   :meth:`imod.mf6.Recharge.from_imod5_data` got extra arguments for
   ``period_data``, ``time_min`` and ``time_max``.
+- :func:`imod.prepare.read_imod_legend` now also returns the labels as an extra
+  argument. Update your code by changing 
+  ``colors, levels = read_imod_legend(...)`` to 
+  ``colors, levels, labels = read_imod_legend(...)``.
 
 
 [1.0.0rc3] - 2025-04-17

--- a/imod/tests/test_visualize/test_visualize_spatial.py
+++ b/imod/tests/test_visualize/test_visualize_spatial.py
@@ -41,7 +41,7 @@ def write_legend():
 def test_read_legend(write_legend, delim, tmp_path):
     leg_path = tmp_path / "example_legend.leg"
     write_legend(delim=delim, path=leg_path)
-    colors, levels = imod.visualize.spatial.read_imod_legend(path=leg_path)
+    colors, levels, labels = imod.visualize.spatial.read_imod_legend(path=leg_path)
 
     assert colors == [
         "#00007d",
@@ -79,6 +79,25 @@ def test_read_legend(write_legend, delim, tmp_path):
         4.0,
         6.0,
         10.0,
+    ]
+    assert labels == [
+        "< 0 m",
+        "0 - 0.2 m",
+        "0.2 - 0.4 m",
+        "0.4 - 0.6 m",
+        "0.6 - 0.8 m",
+        "0.8 - 1.0 m",
+        "1.0 - 1.2 m",
+        "1.2 - 1.4 m",
+        "1.4 - 1.6 m",
+        "1.6 - 1.8 m",
+        "1.8 - 2.0 m",
+        "2.0 - 2.5 m",
+        "2.5 - 3.0 m",
+        "3.0 - 4.0 m",
+        "4.0 - 6.0 m",
+        "6.0 - 10.0 m",
+        "> 10 m",
     ]
 
 

--- a/imod/visualize/spatial.py
+++ b/imod/visualize/spatial.py
@@ -16,7 +16,9 @@ except ImportError:
     ctx = MissingOptionalModule("contextily")
 
 
-def read_imod_legend(path):
+def read_imod_legend(
+    path: str | pathlib.Path,
+) -> tuple[list[str], list[float], list[str]]:
     """
     Parameters
     ----------
@@ -28,6 +30,8 @@ def read_imod_legend(path):
     colors : List of hex colors of length N.
     levels : List of floats of length N-1. These are the boundaries between
         the legend colors/classes.
+    labels : List of strings of length N. These are the labels for the
+        legend colors/classes.
     """
 
     # Read file. Do not rely the headers in the leg file.
@@ -37,8 +41,8 @@ def read_imod_legend(path):
             header=1,
             sep=sep,
             index_col=False,
-            usecols=[0, 1, 2, 3, 4],
-            names=["upper", "lower", "red", "green", "blue"],
+            usecols=[0, 1, 2, 3, 4, 5],
+            names=["upper", "lower", "red", "green", "blue", "labels"],
         )
 
     # Try both comma and whitespace separated
@@ -53,8 +57,9 @@ def read_imod_legend(path):
     green = legend["green"]
     colors = [f"#{r:02x}{g:02x}{b:02x}" for r, g, b in zip(red, green, blue)][::-1]
     levels = list(legend["lower"])[::-1][1:]
+    labels = list(legend["labels"])[::-1]
 
-    return colors, levels
+    return colors, levels, labels
 
 
 def _crs2string(crs):


### PR DESCRIPTION
Fixes #332

# Description
Also return legend labels from ``read_imod_legend``. 

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
