### PR TITLE
Issue #1561 improve performance splitting

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -17,6 +17,10 @@ Added
   result in smaller partions.
 - iMOD Python version is now written in a comment line to MODFLOW6 and
   MetaSWAP's ``para_sim.inp`` files. This is useful for debugging purposes.
+- Added option ``ignore_time_purge_empty`` to
+  :class:`imod.mf6.Modflow6Simulation.split` to consider a package empty if its
+  first times step is all nodata. This can save a lot of time splitting
+  transient models.
 
 Fixed
 ~~~~~
@@ -62,6 +66,9 @@ Fixed
   :meth:`imod.mf6.GeneralHeadBoundary.from_imod5_data` can now deal with
   constant values for variables. One variable per package still needs to be a
   grid.
+- fix bug where an error was thrown in :class:`imod.mf6.Well` when an entry had
+  to be filtered and its ``id`` didn't match the index.
+
 
 Changed
 ~~~~~~~

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -68,6 +68,8 @@ Fixed
   grid.
 - fix bug where an error was thrown in :class:`imod.mf6.Well` when an entry had
   to be filtered and its ``id`` didn't match the index.
+- Improved performance of :class:`imod.mf6.Modflow6Simulation.split` for
+  structured models, as unnecessary masking is avoided.
 
 
 Changed

--- a/imod/common/interfaces/imodel.py
+++ b/imod/common/interfaces/imodel.py
@@ -16,7 +16,9 @@ class IModel(IDict):
         raise NotImplementedError
 
     @abstractmethod
-    def purge_empty_packages(self, model_name: Optional[str] = "") -> None:
+    def purge_empty_packages(
+        self, model_name: Optional[str] = "", ignore_time: bool = False
+    ) -> None:
         raise NotImplementedError
 
     @abstractmethod

--- a/imod/common/utilities/regrid.py
+++ b/imod/common/utilities/regrid.py
@@ -315,7 +315,6 @@ def _regrid_like(
     output_domain = handle_extra_coords("dx", target_grid, output_domain)
     output_domain = handle_extra_coords("dy", target_grid, output_domain)
     new_model.mask_all_packages(output_domain)
-    new_model.purge_empty_packages()
     if validate:
         status_info = NestedStatusInfo("Model validation status")
         status_info.add(new_model.validate("Regridded model"))

--- a/imod/common/utilities/schemata.py
+++ b/imod/common/utilities/schemata.py
@@ -10,7 +10,7 @@ from imod.schemata import BaseSchema, SchemataDict, ValidationError
 def filter_schemata_dict(
     schemata_dict: SchemataDict,
     schema_types: tuple[type[BaseSchema], ...],
-) -> dict[str, list[BaseSchema]]:
+) -> SchemataDict:
     """
     Filter schemata dict with a tuple of schema types. Keys which do not have
     provided types in their corresponding schema list are dropped. The schema

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -693,8 +693,18 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
 
         return self._to_mf6_pkg(idomain, top, bottom, k, validation_context)
 
-    def is_empty(self) -> bool:
-        if super().is_empty():
+    def is_empty(self, ignore_time: bool = False) -> bool:
+        """
+        Returns True if the package is empty, that is if it contains only
+        no-data values.
+
+        Parameters
+        ----------
+        ignore_time: bool, optional
+            If True, the time dimension is dropped before validation. Irrelevant
+            for this package as it doesn't support a time dimension.
+        """
+        if super().is_empty(ignore_time=ignore_time):
             return True
 
         linestrings = self.dataset["geometry"]

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -713,13 +713,20 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
 
         _mask_all_packages(self, mask)
 
-    def purge_empty_packages(self, model_name: Optional[str] = "") -> None:
+    def purge_empty_packages(
+        self, model_name: Optional[str] = "", ignore_time: bool = False
+    ) -> None:
         """
         This function removes empty packages from the model.
         """
         empty_packages = [
-            package_name for package_name, package in self.items() if package.is_empty()
+            package_name
+            for package_name, package in self.items()
+            if package.is_empty(ignore_time=ignore_time)
         ]
+        logger.info(
+            f"packages: {empty_packages} removed in {model_name}, because all empty"
+        )
         for package_name in empty_packages:
             self.pop(package_name)
 

--- a/imod/mf6/multimodel/modelsplitter.py
+++ b/imod/mf6/multimodel/modelsplitter.py
@@ -118,5 +118,5 @@ def slice_model(partition_info: PartitionInfo, model: IModel) -> IModel:
             new_model[pkg_name] = sliced_package
 
         if isinstance(package, BoundaryCondition):
-            expand_transient_auxiliary_variables(package)
+            expand_transient_auxiliary_variables(sliced_package)
     return new_model

--- a/imod/mf6/multimodel/modelsplitter.py
+++ b/imod/mf6/multimodel/modelsplitter.py
@@ -1,20 +1,18 @@
-from typing import List, NamedTuple, Optional
+from typing import List, NamedTuple
 
 import numpy as np
 
 from imod.common.interfaces.imodel import IModel
 from imod.common.utilities.clip import clip_by_grid
-from imod.common.utilities.grid import get_active_domain_slice
 from imod.mf6.auxiliary_variables import (
     expand_transient_auxiliary_variables,
     remove_expanded_auxiliary_variables_from_dataset,
 )
 from imod.mf6.boundary_condition import BoundaryCondition
 from imod.mf6.hfb import HorizontalFlowBarrierBase
-from imod.mf6.package import Package
 from imod.mf6.wel import Well
 from imod.typing import GridDataArray
-from imod.typing.grid import is_unstructured, ones_like
+from imod.typing.grid import ones_like
 
 HIGH_LEVEL_PKGS = (HorizontalFlowBarrierBase, Well)
 

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -539,10 +539,11 @@ class GridAgnosticWell(BoundaryCondition, IPointDataPackage, abc.ABC):
         else:
             message += " The first 10 unplaced wells are: \n"
 
+        is_filtered = self.dataset["id"].isin([filtered_wells])
         for i in range(min(10, len(filtered_wells))):
             ids = filtered_wells[i]
-            x = self.dataset["x"][int(filtered_wells[i])].values[()]
-            y = self.dataset["y"][int(filtered_wells[i])].values[()]
+            x = self.dataset["x"].data[is_filtered][i]
+            y = self.dataset["y"].data[is_filtered][i]
             message += f" id = {ids} x = {x}  y = {y} \n"
         return message
 

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -654,7 +654,7 @@ class AllNoDataSchema(NoDataSchema):
 
     def validate(self, obj: GridDataArray, **kwargs) -> None:
         valid = self.is_notnull(obj)
-        if valid.all():
+        if ~valid.any():
             raise ValidationError("all nodata")
 
 
@@ -665,7 +665,7 @@ class AnyNoDataSchema(NoDataSchema):
 
     def validate(self, obj: GridDataArray, **kwargs) -> None:
         valid = self.is_notnull(obj)
-        if valid.any():
+        if ~valid.all():
             raise ValidationError("found a nodata value")
 
 

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -654,7 +654,7 @@ class AllNoDataSchema(NoDataSchema):
 
     def validate(self, obj: GridDataArray, **kwargs) -> None:
         valid = self.is_notnull(obj)
-        if ~valid.any():
+        if valid.all():
             raise ValidationError("all nodata")
 
 
@@ -665,7 +665,7 @@ class AnyNoDataSchema(NoDataSchema):
 
     def validate(self, obj: GridDataArray, **kwargs) -> None:
         valid = self.is_notnull(obj)
-        if ~valid.all():
+        if valid.any():
             raise ValidationError("found a nodata value")
 
 

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -202,6 +202,26 @@ class HorizontalFlowBarrierCases:
             },
         )
 
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases)
+def test_partitioning_structured__masking(
+    transient_twri_model: Modflow6Simulation,
+    partition_array: xr.DataArray,
+):
+    simulation = transient_twri_model
+    # Act
+    # Partition the simulation
+    split_simulation = simulation.split(partition_array)
+    # Assert
+    # Check if the partitioned simulation has the correct number of models
+    modelnames = split_simulation.get_models_of_type("gwf6").keys()
+    unique_partitions = np.unique(partition_array)
+    assert len(modelnames) == len(unique_partitions)
+
+    for partition_nr, modelname in zip(unique_partitions, modelnames):
+        is_partition = partition_array == partition_nr
+        model_active = split_simulation[modelname].domain == 1
+        assert np.all(is_partition == model_active)
+
 
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_structured(

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -202,6 +202,7 @@ class HorizontalFlowBarrierCases:
             },
         )
 
+
 @parametrize_with_cases("partition_array", cases=PartitionArrayCases)
 def test_partitioning_structured__masking(
     transient_twri_model: Modflow6Simulation,


### PR DESCRIPTION
Fixes #1561

# Description
- Add option ``ignore_time_purge_empty`` to only check ``imod.mf6.Modflow6Simulation.split`` the first timestep during the purge of empty packages. This saves a lot of time evaluating models with multiple stress periods.
- Fix bug where an error was thrown in :class:`imod.mf6.Well` when an entry had to be filtered and its ``id`` didn't match the index.
- Refactor: Call ``purge_empty_packages`` instead of separate logic for removing empty packages in ``imod.mf6.Modflow6Simulation.split``
- Performance: During splitting, only mask grids when structured, for unstructured grids this is unnecessary.
- Refactor: Remove unnecessary duplicate masking for structured grids when splitting

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
