### PR TITLE
Issue #1564 reduce cost validation

### DIFF
--- a/imod/common/interfaces/imodel.py
+++ b/imod/common/interfaces/imodel.py
@@ -24,7 +24,9 @@ class IModel(IDict):
 
     @abstractmethod
     def validate(
-        self, validation_context: ValidationContext, model_name: str = ""
+        self,
+        model_name: str = "",
+        validation_context: Optional[ValidationContext] = None,
     ) -> StatusInfoBase:
         raise NotImplementedError
 

--- a/imod/common/interfaces/imodel.py
+++ b/imod/common/interfaces/imodel.py
@@ -3,8 +3,8 @@ from typing import Optional, Tuple
 
 from imod.common.interfaces.idict import IDict
 from imod.common.statusinfo import StatusInfoBase
-from imod.typing import GridDataArray
 from imod.mf6.validation_context import ValidationContext
+from imod.typing import GridDataArray
 
 
 class IModel(IDict):
@@ -23,7 +23,9 @@ class IModel(IDict):
         raise NotImplementedError
 
     @abstractmethod
-    def validate(self, validation_context: ValidationContext, model_name: str = "") -> StatusInfoBase:
+    def validate(
+        self, validation_context: ValidationContext, model_name: str = ""
+    ) -> StatusInfoBase:
         raise NotImplementedError
 
     @property

--- a/imod/common/interfaces/imodel.py
+++ b/imod/common/interfaces/imodel.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 from imod.common.interfaces.idict import IDict
 from imod.common.statusinfo import StatusInfoBase
 from imod.typing import GridDataArray
+from imod.mf6.validation_context import ValidationContext
 
 
 class IModel(IDict):
@@ -22,7 +23,7 @@ class IModel(IDict):
         raise NotImplementedError
 
     @abstractmethod
-    def validate(self, model_name: str = "") -> StatusInfoBase:
+    def validate(self, validation_context: ValidationContext, model_name: str = "") -> StatusInfoBase:
         raise NotImplementedError
 
     @property

--- a/imod/common/utilities/regrid.py
+++ b/imod/common/utilities/regrid.py
@@ -317,9 +317,9 @@ def _regrid_like(
     output_domain = handle_extra_coords("dy", target_grid, output_domain)
     new_model.mask_all_packages(output_domain)
     if validate:
-        validation_context = ValidationContext()
+        validation_context = ValidationContext(validate=validate)
         status_info = NestedStatusInfo("Model validation status")
-        status_info.add(new_model.validate(validation_context, "Regridded model"))
+        status_info.add(new_model.validate("Regridded model", validation_context))
         if status_info.has_errors():
             raise ValidationError("\n" + status_info.to_string())
     return new_model

--- a/imod/common/utilities/regrid.py
+++ b/imod/common/utilities/regrid.py
@@ -18,6 +18,7 @@ from imod.common.statusinfo import NestedStatusInfo
 from imod.common.utilities.clip import clip_by_grid
 from imod.common.utilities.regrid_method_type import EmptyRegridMethod, RegridMethodType
 from imod.common.utilities.value_filters import is_valid
+from imod.mf6.validation_context import ValidationContext
 from imod.schemata import ValidationError
 from imod.typing.grid import (
     GridDataArray,
@@ -316,8 +317,9 @@ def _regrid_like(
     output_domain = handle_extra_coords("dy", target_grid, output_domain)
     new_model.mask_all_packages(output_domain)
     if validate:
+        validation_context = ValidationContext()
         status_info = NestedStatusInfo("Model validation status")
-        status_info.add(new_model.validate("Regridded model"))
+        status_info.add(new_model.validate(validation_context, "Regridded model"))
         if status_info.has_errors():
             raise ValidationError("\n" + status_info.to_string())
     return new_model

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -234,8 +234,13 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
 
     @standard_log_decorator()
     def validate(
-        self, validation_context: ValidationContext, model_name: str = ""
+        self,
+        model_name: str = "",
+        validation_context: Optional[ValidationContext] = None,
     ) -> StatusInfoBase:
+        if validation_context is None:
+            validation_context = ValidationContext(validate=True)
+
         try:
             diskey = self._get_diskey()
         except Exception as e:
@@ -494,8 +499,9 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         """
         modeldirectory = pathlib.Path(directory) / modelname
         modeldirectory.mkdir(exist_ok=True, parents=True)
-        if validate:
-            statusinfo = self.validate()
+        validation_context = ValidationContext(validate=validate)
+        if validation_context.validate:
+            statusinfo = self.validate(modelname, validation_context)
             if statusinfo.has_errors():
                 raise ValidationError(statusinfo.to_string())
 

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -233,7 +233,9 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         return npf["k"]
 
     @standard_log_decorator()
-    def validate(self, validation_context: ValidationContext, model_name: str = "") -> StatusInfoBase:
+    def validate(
+        self, validation_context: ValidationContext, model_name: str = ""
+    ) -> StatusInfoBase:
         try:
             diskey = self._get_diskey()
         except Exception as e:

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -233,7 +233,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         return npf["k"]
 
     @standard_log_decorator()
-    def validate(self, model_name: str = "") -> StatusInfoBase:
+    def validate(self, validation_context: ValidationContext, model_name: str = "") -> StatusInfoBase:
         try:
             diskey = self._get_diskey()
         except Exception as e:
@@ -269,6 +269,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
                 schemata=schemata,
                 idomain=idomain,
                 bottom=bottom,
+                validation_context=validation_context,
             )
             if len(pkg_errors) > 0:
                 footer = SUGGESTION_TEXT if pkg_has_cleanup(pkg) else None
@@ -394,7 +395,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         modeldirectory = workdir / modelname
         Path(modeldirectory).mkdir(exist_ok=True, parents=True)
         if validate_context.validate:
-            model_status_info = self.validate(modelname)
+            model_status_info = self.validate(modelname, validate_context)
             if model_status_info.has_errors():
                 return model_status_info
 

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -52,7 +52,7 @@ from imod.mf6.pkgbase import (
     TRANSPORT_PACKAGES,
     PackageBase,
 )
-from imod.mf6.validation_context import trim_time_dimension
+from imod.mf6.validation_context import ValidationContext, trim_time_dimension
 from imod.mf6.write_context import WriteContext
 from imod.schemata import (
     AllNoDataSchema,
@@ -365,9 +365,8 @@ class Package(PackageBase, IPackage, abc.ABC):
         allnodata_schemata = filter_schemata_dict(
             self._write_schemata, (AllNoDataSchema, EmptyIndexesSchema)
         )
-        ds = self.dataset
-        if ignore_time:
-            ds = self.dataset.isel(time=0, drop=True, missing_dims="ignore")
+        validation_context = ValidationContext(ignore_time=ignore_time)
+        ds = trim_time_dimension(self.dataset, validation_context=validation_context)
         # Find if packages throws ValidationError for AllNoDataSchema or
         # EmptyIndexesSchema.
         allnodata_errors = validate_schemata_dict(allnodata_schemata, ds)

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -52,7 +52,7 @@ from imod.mf6.pkgbase import (
     TRANSPORT_PACKAGES,
     PackageBase,
 )
-from imod.mf6.validation_context import ValidationContext, trim_time_dimension
+from imod.mf6.validation_context import trim_time_dimension
 from imod.mf6.write_context import WriteContext
 from imod.schemata import (
     AllNoDataSchema,

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -52,6 +52,7 @@ from imod.mf6.pkgbase import (
     TRANSPORT_PACKAGES,
     PackageBase,
 )
+from imod.mf6.validation_context import ValidationContext, trim_time_dimension
 from imod.mf6.write_context import WriteContext
 from imod.schemata import (
     AllNoDataSchema,
@@ -341,7 +342,8 @@ class Package(PackageBase, IPackage, abc.ABC):
 
     @standard_log_decorator()
     def _validate(self, schemata: dict, **kwargs) -> dict[str, list[ValidationError]]:
-        return validate_schemata_dict(schemata, self.dataset, **kwargs)
+        ds = trim_time_dimension(self.dataset, **kwargs)
+        return validate_schemata_dict(schemata, ds, **kwargs)
 
     def is_empty(self, ignore_time: bool = False) -> bool:
         """

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1067,7 +1067,9 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
 
     @standard_log_decorator()
     def split(
-        self, submodel_labels: GridDataArray, ignore_time_purge_empty: bool = False
+        self,
+        submodel_labels: GridDataArray,
+        ignore_time_purge_empty: Optional[bool] = None,
     ) -> Modflow6Simulation:
         """
         Split a simulation in different partitions using a submodel_labels
@@ -1081,11 +1083,11 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             similar shape as a layer in the domain. The values in the array
             indicate to which partition a cell belongs. The values should be
             zero or greater.
-        ignore_time_purge_empty: bool, default False
-            If True, the first timestep is selected to validate. This increases
+        ignore_time_purge_empty: bool, default None
+            If True, only the first timestep is validated. This increases
             performance for packages with a time dimensions over which changes
-            of cell activity are not expected. Default is False, which means the
-            time dimension is not dropped.
+            of cell activity are not expected. If None, the value of the
+            validation context is of the simulation is used.
 
         Returns
         -------
@@ -1100,6 +1102,9 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             raise ValueError(
                 "splitting of simulations with more (or less) than 1 flow model currently not supported."
             )
+        if ignore_time_purge_empty is None:
+            ignore_time_purge_empty = self._validation_context.ignore_time
+
         transport_models = self.get_models_of_type("gwt6")
         flow_models = self.get_models_of_type("gwf6")
         if not any(flow_models) and not any(transport_models):

--- a/imod/mf6/validation_context.py
+++ b/imod/mf6/validation_context.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from imod.typing import GridDataset
 
 
 @dataclass
@@ -7,3 +8,19 @@ class ValidationContext:
     strict_well_validation: bool = True
     strict_hfb_validation: bool = True
     ignore_time_no_data: bool = False
+
+
+def trim_time_dimension(
+    ds: GridDataset, **kwargs
+) -> GridDataset:
+    """
+    Prepare object for validation, drop time dimension if
+    ignore_time_no_data is set in validation context.
+    """
+    if "validation_context" in kwargs:
+        validation_context = kwargs["validation_context"]
+        if validation_context.ignore_time_no_data:
+            # If ignore_time_no_data is set, we can ignore time dimension
+            if "time" in ds.dims:
+                return ds.isel(time=0)
+    return ds

--- a/imod/mf6/validation_context.py
+++ b/imod/mf6/validation_context.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import cast
 
 from imod.typing import GridDataset
 
@@ -8,7 +9,7 @@ class ValidationContext:
     validate: bool = True
     strict_well_validation: bool = True
     strict_hfb_validation: bool = True
-    ignore_time_no_data: bool = False
+    ignore_time: bool = False
 
 
 def trim_time_dimension(ds: GridDataset, **kwargs) -> GridDataset:
@@ -17,9 +18,8 @@ def trim_time_dimension(ds: GridDataset, **kwargs) -> GridDataset:
     ignore_time_no_data is set in validation context.
     """
     if "validation_context" in kwargs:
-        validation_context = kwargs["validation_context"]
-        if validation_context.ignore_time_no_data:
+        validation_context = cast(ValidationContext, kwargs["validation_context"])
+        if validation_context.ignore_time:
             # If ignore_time_no_data is set, we can ignore time dimension
-            if "time" in ds.dims:
-                return ds.isel(time=0)
+            return ds.isel(time=0, missing_dims="ignore")
     return ds

--- a/imod/mf6/validation_context.py
+++ b/imod/mf6/validation_context.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 from imod.typing import GridDataset
 
 
@@ -10,9 +11,7 @@ class ValidationContext:
     ignore_time_no_data: bool = False
 
 
-def trim_time_dimension(
-    ds: GridDataset, **kwargs
-) -> GridDataset:
+def trim_time_dimension(ds: GridDataset, **kwargs) -> GridDataset:
     """
     Prepare object for validation, drop time dimension if
     ignore_time_no_data is set in validation context.

--- a/imod/mf6/validation_context.py
+++ b/imod/mf6/validation_context.py
@@ -6,3 +6,4 @@ class ValidationContext:
     validate: bool = True
     strict_well_validation: bool = True
     strict_hfb_validation: bool = True
+    ignore_time_no_data: bool = False

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -635,7 +635,24 @@ class UniqueValuesSchema(BaseSchema):
             )
 
 
-class NoDataSchema(BaseSchema):
+class ObjectPreparationMixin():
+    def trim_time_dimension(
+        self, obj: GridDataArray, **kwargs
+    ) -> GridDataArray:
+        """
+        Prepare object for validation, drop time dimension if
+        ignore_time_no_data is set in validation context.
+        """
+        if "validation_context" in kwargs:
+            validation_context = kwargs["validation_context"]
+            if validation_context.ignore_time_no_data:
+                # If ignore_time_no_data is set, we can ignore time dimension
+                if "time" in obj.dims:
+                    return obj.isel(time=0)
+        return obj
+
+
+class NoDataSchema(BaseSchema, ObjectPreparationMixin):
     def __init__(
         self,
         is_notnull: Union[Callable, Tuple[str, Any]] = notnull,
@@ -653,6 +670,7 @@ class AllNoDataSchema(NoDataSchema):
     """
 
     def validate(self, obj: GridDataArray, **kwargs) -> None:
+        obj = self.trim_time_dimension(obj, **kwargs)
         valid = self.is_notnull(obj)
         if ~valid.any():
             raise ValidationError("all nodata")
@@ -664,12 +682,13 @@ class AnyNoDataSchema(NoDataSchema):
     """
 
     def validate(self, obj: GridDataArray, **kwargs) -> None:
+        obj = self.trim_time_dimension(obj, **kwargs)
         valid = self.is_notnull(obj)
         if ~valid.all():
             raise ValidationError("found a nodata value")
 
 
-class NoDataComparisonSchema(BaseSchema):
+class NoDataComparisonSchema(BaseSchema, ObjectPreparationMixin):
     """
     Base class for IdentityNoDataSchema and AllInsideNoDataSchema.
     """
@@ -706,6 +725,8 @@ class IdentityNoDataSchema(NoDataComparisonSchema):
 
     def validate(self, obj: GridDataArray, **kwargs) -> None:
         other_obj = kwargs[self.other]
+        obj = self.trim_time_dimension(obj, **kwargs)
+        other_obj = self.trim_time_dimension(other_obj, **kwargs)
 
         # Only test if object has all dimensions in other object.
         missing_dims = set(other_obj.dims) - set(obj.dims)
@@ -724,6 +745,9 @@ class AllInsideNoDataSchema(NoDataComparisonSchema):
 
     def validate(self, obj: GridDataArray, **kwargs) -> None:
         other_obj = kwargs[self.other]
+        obj = self.trim_time_dimension(obj, **kwargs)
+        other_obj = self.trim_time_dimension(other_obj, **kwargs)
+        
         valid = self.is_notnull(obj)
         other_valid = self.is_other_notnull(other_obj)
 

--- a/imod/schemata.py
+++ b/imod/schemata.py
@@ -724,7 +724,7 @@ class AllInsideNoDataSchema(NoDataComparisonSchema):
 
     def validate(self, obj: GridDataArray, **kwargs) -> None:
         other_obj = kwargs[self.other]
-        
+
         valid = self.is_notnull(obj)
         other_valid = self.is_other_notnull(other_obj)
 

--- a/imod/tests/test_mf6/test_mf6_drn.py
+++ b/imod/tests/test_mf6/test_mf6_drn.py
@@ -685,6 +685,7 @@ def test_from_imod5_and_cleanup__with_constant(
     # Teardown
     imod5_dataset["drn-2"] = original_drn_2
 
+
 def test_from_imod5__negative_layer(imod5_dataset_periods, tmp_path):
     period_data = imod5_dataset_periods[1]
     imod5_dataset = imod5_dataset_periods[0]

--- a/imod/tests/test_mf6/test_mf6_drn.py
+++ b/imod/tests/test_mf6/test_mf6_drn.py
@@ -682,7 +682,8 @@ def test_from_imod5_and_cleanup__with_constant(
     )
 
     drn_2.cleanup(target_dis)
-
+    # Teardown
+    imod5_dataset["drn-2"] = original_drn_2
 
 def test_from_imod5__negative_layer(imod5_dataset_periods, tmp_path):
     period_data = imod5_dataset_periods[1]
@@ -782,3 +783,8 @@ def test_from_imod5_and_cleanup__negative_layer(imod5_dataset_periods, tmp_path)
     )
 
     drn_negative_layer.cleanup(target_dis)
+
+    assert drn_negative_layer.dataset.identical(drn_reference.dataset)
+
+    # Teardown
+    imod5_dataset["drn-2"] = original_drn_2

--- a/imod/tests/test_mf6/test_mf6_rch.py
+++ b/imod/tests/test_mf6/test_mf6_rch.py
@@ -5,6 +5,7 @@ import textwrap
 from copy import deepcopy
 from datetime import datetime
 
+import dask
 import numpy as np
 import pytest
 import xarray as xr
@@ -15,7 +16,7 @@ from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.typing.grid import is_planar_grid, is_transient_data_grid, nan_like
 from imod.util.regrid import RegridderWeightsCache
-
+from imod.mf6.validation_context import ValidationContext
 
 @pytest.fixture(scope="function")
 def rch_dict():
@@ -278,6 +279,32 @@ def test_scalar():
 
 def test_validate_false():
     imod.mf6.Recharge(rate=0.001, validate=False)
+
+
+@pytest.mark.timeout(10, method="thread")
+def test_ignore_time_validation():
+    # Create a large recharge dataset with a time dimension. This is to test the
+    # performance of the validation when ignore_time_no_data is True.
+    rng = dask.array.random.default_rng()
+    layer = [1, 2, 3]
+    template = imod.util.empty_3d(1.0, 0.0, 1000.0, 1.0, 0.0, 1000.0, layer)
+    idomain = xr.ones_like(template, dtype=np.int32)
+    layer_bottom = xr.DataArray([0.0, -10.0, -20.0], coords={"layer": layer}, dims=["layer"])
+    bottom = layer_bottom * idomain
+    x = rng.random((10000, 3, 1000, 1000), chunks=(1, -1, -1, -1))
+    rate = xr.DataArray(x, coords=idomain.coords, dims=("time", "layer", "y", "x"))
+    rch = imod.mf6.Recharge(
+        rate=rate,
+        validate=False
+    )
+    validation_context = ValidationContext(ignore_time_no_data=True)
+    # Act
+    rch._validate(
+            schemata=rch._write_schemata,
+            idomain=idomain,
+            bottom=bottom,
+            validation_context=validation_context,
+        )
 
 
 def test_write_concentration_period_data(rate_fc, concentration_fc):

--- a/imod/tests/test_mf6/test_mf6_rch.py
+++ b/imod/tests/test_mf6/test_mf6_rch.py
@@ -12,11 +12,12 @@ import xarray as xr
 
 import imod
 from imod.mf6.dis import StructuredDiscretization
+from imod.mf6.validation_context import ValidationContext
 from imod.mf6.write_context import WriteContext
 from imod.schemata import ValidationError
 from imod.typing.grid import is_planar_grid, is_transient_data_grid, nan_like
 from imod.util.regrid import RegridderWeightsCache
-from imod.mf6.validation_context import ValidationContext
+
 
 @pytest.fixture(scope="function")
 def rch_dict():
@@ -289,22 +290,21 @@ def test_ignore_time_validation():
     layer = [1, 2, 3]
     template = imod.util.empty_3d(1.0, 0.0, 1000.0, 1.0, 0.0, 1000.0, layer)
     idomain = xr.ones_like(template, dtype=np.int32)
-    layer_bottom = xr.DataArray([0.0, -10.0, -20.0], coords={"layer": layer}, dims=["layer"])
+    layer_bottom = xr.DataArray(
+        [0.0, -10.0, -20.0], coords={"layer": layer}, dims=["layer"]
+    )
     bottom = layer_bottom * idomain
     x = rng.random((10000, 3, 1000, 1000), chunks=(1, -1, -1, -1))
     rate = xr.DataArray(x, coords=idomain.coords, dims=("time", "layer", "y", "x"))
-    rch = imod.mf6.Recharge(
-        rate=rate,
-        validate=False
-    )
+    rch = imod.mf6.Recharge(rate=rate, validate=False)
     validation_context = ValidationContext(ignore_time_no_data=True)
     # Act
     rch._validate(
-            schemata=rch._write_schemata,
-            idomain=idomain,
-            bottom=bottom,
-            validation_context=validation_context,
-        )
+        schemata=rch._write_schemata,
+        idomain=idomain,
+        bottom=bottom,
+        validation_context=validation_context,
+    )
 
 
 def test_write_concentration_period_data(rate_fc, concentration_fc):

--- a/imod/tests/test_mf6/test_mf6_rch.py
+++ b/imod/tests/test_mf6/test_mf6_rch.py
@@ -297,7 +297,7 @@ def test_ignore_time_validation():
     x = rng.random((10000, 3, 1000, 1000), chunks=(1, -1, -1, -1))
     rate = xr.DataArray(x, coords=idomain.coords, dims=("time", "layer", "y", "x"))
     rch = imod.mf6.Recharge(rate=rate, validate=False)
-    validation_context = ValidationContext(ignore_time_no_data=True)
+    validation_context = ValidationContext(ignore_time=True)
     # Act
     rch._validate(
         schemata=rch._write_schemata,


### PR DESCRIPTION
Fixes #1564

# Description
This extends the ``ValidationContext`` to also include a setting to trim times during validation, just as the option added in #1562 to split. 

I didn't update the changelog, as ``ValidationContext`` isn't part of the public API yet, but I think it'd be useful to do that. Right now users have to set a private attribute:

```
simulation._validation_context.ignore_time = True
``` 

I'll open up a follow-up issue for that. 

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
