### PR TITLE
Issue #1568 quell warnings

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -74,6 +74,7 @@ Fixed
   to be filtered and its ``id`` didn't match the index.
 - Improved performance of :class:`imod.mf6.Modflow6Simulation.split` for
   structured models, as unnecessary masking is avoided.
+- Fixed warning thrown by type dispatcher about ``~GeoDataFrameType``
 
 
 Changed

--- a/imod/tests/fixtures/backward_compatibility_fixture.py
+++ b/imod/tests/fixtures/backward_compatibility_fixture.py
@@ -84,7 +84,7 @@ def imod5_dataset_transient(imod5_dataset):
     return grid_data, period_data
 
 
-period_prj = """\
+period_prj = r"""\
 0001,(BND),1, Boundary Condition
 001,37
 1,2,1,1.0,0.0,-999.99, '.\Database\BND\VERSION_1\IBOUND_L1.IDF' >>> (BND) Boundary Settings (IDF) <<<

--- a/imod/tests/fixtures/imod5_well_data.py
+++ b/imod/tests/fixtures/imod5_well_data.py
@@ -55,8 +55,8 @@ def projectfile_string(tmp_path, time_header="2000-01-01 00:00:00"):
     0001,(WEL),1, Wells,[WRA]
     {time_header}
     001,002
-    1,2, 000,   1.000000    ,   0.000000    ,  -999.9900    ,'{tmp_path}\ipf1.ipf'
-    1,2, 000,   1.000000    ,   0.000000    ,  -999.9900    ,'{tmp_path}\ipf2.ipf'
+    1,2, 000,   1.000000    ,   0.000000    ,  -999.9900    ,'{tmp_path}\\ipf1.ipf'
+    1,2, 000,   1.000000    ,   0.000000    ,  -999.9900    ,'{tmp_path}\\ipf2.ipf'
     """
     )
 

--- a/imod/tests/test_mf6/test_import_prj.py
+++ b/imod/tests/test_mf6/test_import_prj.py
@@ -11,7 +11,7 @@ from imod.logging.loglevel import LogLevel
 
 
 def snippet_constant_kh(factor: float, addition: float, init: float):
-    return dedent(f"""\
+    return dedent(rf"""\
         0001,(KHV),1, Horizontal Permeability
         001,2
         1,1,1,{factor},{addition},{init}   >>> (KHV) Horizontal Permeability (IDF) <<<
@@ -48,7 +48,7 @@ def test_import_constants(tmp_path):
 
 
 def snippet_idf_import_kh(factor: float, addition: float):
-    return dedent(f"""\
+    return dedent(rf"""\
         0001,(KHV),1, Horizontal Permeability
         001,2
         1,1,1,{factor},{addition},-999.99, '.\Database\KHV\VERSION_1\IPEST_KHV_L1.IDF' >>> (KHV) Horizontal Permeability (IDF) <<<
@@ -87,7 +87,7 @@ def test_import_idf(tmp_path):
 def snippet_idf_import_transient(
     factor1: float, addition1: float, factor2: float, addition2: float
 ):
-    return dedent(f"""\
+    return dedent(rf"""\
         0002, (chd), 1, ConstantHead, ['head']
         2018-01-01 00:00:00                  
         001, 001
@@ -119,7 +119,7 @@ def test_import_idf_transient(tmp_path):
 
 
 def snippet_gen_import_hfb(factor: float, addition: float):
-    return dedent(f"""\
+    return dedent(rf"""\
         0001,(HFB),1, Horizontal Flow Barrier
         001,2
         1,2, 003,{factor},{addition},  -999.9900    ,'.\Database\HFB\VERSION_1\IBV2_HOOFDBREUKEN_BX.GEN' >>> (HFB) Horizontal Barrier Flow (GEN) <<<
@@ -144,7 +144,7 @@ def test_import_gen(tmp_path):
 def snippet_gen_import_ipf(
     factor1: float, addition1: float, factor2: float, addition2: float
 ):
-    return dedent(f"""\
+    return dedent(rf"""\
         0001,(WEL),1, Wells
         STEADY-STATE
         001,003
@@ -260,7 +260,7 @@ def test_import_ipf_unique_id_and_logging(tmp_path):
 
 
 def snippet_boundary_condition(factor: float, addition: float):
-    return dedent(f"""\
+    return dedent(rf"""\
         0001,(CHD),1, Constant Head
         STEADY-STATE
         001,2
@@ -295,7 +295,7 @@ def test_import_idf_boundary_condition(tmp_path):
 
 
 def snippet_idf_without_layer_dim(factor: float, addition: float):
-    return dedent(f"""\
+    return dedent(rf"""\
         0001,(RIV),1, Rivers
         STEADY-STATE
         004,001

--- a/imod/tests/test_mf6/test_mf6_logging.py
+++ b/imod/tests/test_mf6/test_mf6_logging.py
@@ -15,7 +15,7 @@ from imod.mf6.write_context import WriteContext
 
 out = StringIO()
 simple_real_number_regexp = (
-    "[0-9]*\.?[0-9]*"  # regexp for a real number without a sign and without exponents
+    r"[0-9]*\.?[0-9]*"  # regexp for a real number without a sign and without exponents
 )
 
 

--- a/imod/typing/__init__.py
+++ b/imod/typing/__init__.py
@@ -37,17 +37,32 @@ class Imod5DataDict(TypedDict, total=False):
     extra: dict[str, list[str]]
 
 
-# Types for optional dependencies.
-if TYPE_CHECKING:
+GEOPANDAS_AVAILABLE = False
+try:
     import geopandas as gpd
+
+    GEOPANDAS_AVAILABLE = True
+except ImportError:
+    pass
+
+SHAPELY_AVAILABLE = False
+try:
     import shapely
 
+    SHAPELY_AVAILABLE = True
+except ImportError:
+    pass
+
+if GEOPANDAS_AVAILABLE:
     GeoDataFrameType: TypeAlias = gpd.GeoDataFrame
     GeoSeriesType: TypeAlias = gpd.GeoSeries
-    PolygonType: TypeAlias = shapely.Polygon
-    LineStringType: TypeAlias = shapely.LineString
 else:
     GeoDataFrameType = TypeVar("GeoDataFrameType")
     GeoSeriesType = TypeVar("GeoSeriesType")
+
+if SHAPELY_AVAILABLE:
+    PolygonType: TypeAlias = shapely.Polygon
+    LineStringType: TypeAlias = shapely.LineString
+else:
     PolygonType = TypeVar("PolygonType")
     LineStringType = TypeVar("LineStringType")

--- a/imod/typing/__init__.py
+++ b/imod/typing/__init__.py
@@ -53,14 +53,14 @@ try:
 except ImportError:
     pass
 
-if GEOPANDAS_AVAILABLE:
+if TYPE_CHECKING or GEOPANDAS_AVAILABLE:
     GeoDataFrameType: TypeAlias = gpd.GeoDataFrame
     GeoSeriesType: TypeAlias = gpd.GeoSeries
 else:
     GeoDataFrameType = TypeVar("GeoDataFrameType")
     GeoSeriesType = TypeVar("GeoSeriesType")
 
-if SHAPELY_AVAILABLE:
+if TYPE_CHECKING or SHAPELY_AVAILABLE:
     PolygonType: TypeAlias = shapely.Polygon
     LineStringType: TypeAlias = shapely.LineString
 else:

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -1,14 +1,29 @@
 import pickle
 import textwrap
 from functools import wraps
-from typing import Any, Callable, Mapping, ParamSpec, Sequence, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Mapping,
+    ParamSpec,
+    Sequence,
+    TypeVar,
+    cast,
+)
 
 import numpy as np
 import xarray as xr
 import xugrid as xu
 from plum import Dispatcher
 
-from imod.typing import GeoDataFrameType, GridDataArray, GridDataset, structured
+from imod.typing import (
+    GeoDataFrameType,
+    GridDataArray,
+    GridDataset,
+    structured,
+)
+from imod.util.imports import MissingOptionalModule
 from imod.util.spatial import _polygonize
 
 # create dispatcher instance to limit scope of typedispatching
@@ -16,6 +31,14 @@ dispatch = Dispatcher()
 
 T = TypeVar("T")
 P = ParamSpec("P")
+
+if TYPE_CHECKING:
+    import geopandas as gpd
+else:
+    try:
+        import geopandas as gpd
+    except ImportError:
+        gpd = MissingOptionalModule("geopandas")
 
 
 @dispatch
@@ -260,8 +283,9 @@ def bounding_polygon(active: xu.UgridDataArray) -> GeoDataFrameType:  # noqa: F8
     active_indices = np.where(active > 0)[0]
     domain_slice = {f"{active.ugrid.grid.face_dimension}": active_indices}
     active_clipped = active.isel(domain_slice, missing_dims="ignore")
-
-    return active_clipped.ugrid.grid.bounding_polygon()
+    polygon = active_clipped.ugrid.grid.bounding_polygon()
+    dummy_value = 0
+    return gpd.GeoDataFrame([dummy_value], geometry=[polygon])
 
 
 @dispatch


### PR DESCRIPTION
Fixes #1568 

# Description
- Quell type dispatcher warning (see below). 
- As the dispatcher checks types at run time, it turned out that ``bounding_polygon`` was not returning a GeoDataFrame, but a shapely Polygon. This is now forced to a geodataframe
- Quell some warnings in the text fixtures about slashes by converting to rawstring or escaping with an extra slash. 

```
\.pixi\envs\interactive\Lib\site-packages\plum\method.py:222: UserWarning: Could not resolve the type hint of `~GeoDataFrameType`. I have ended the resolution here to not make your code break, but some types might not be working correctly. Please open an issue at https://github.com/beartype/plum.
  return_type = resolve_type_hint(sig.return_annotation)
``` 

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
