### PR TITLE
Issue #1570 qgis user acceptance test

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -78,7 +78,8 @@ Fixed
 - Improved performance of :class:`imod.mf6.Modflow6Simulation.split` for
   structured models, as unnecessary masking is avoided.
 - Fixed warning thrown by type dispatcher about ``~GeoDataFrameType``
-
+- Fixed bug where variables in a package with only a ``"layer"`` coordinate
+  could not be regridded or masked.
 
 Changed
 ~~~~~~~

--- a/imod/common/utilities/mask.py
+++ b/imod/common/utilities/mask.py
@@ -84,7 +84,7 @@ def mask_package(package: IPackage, mask: GridDataArray) -> IPackage:
 
 
 def _skip_dataarray(da: GridDataArray) -> bool:
-    if len(da.dims) == 0 or set(da.coords).issubset(["layer"]):
+    if len(da.dims) == 0 or set(da.dims).issubset(["layer", "time"]):
         return True
 
     if is_scalar(da):

--- a/imod/tests/test_mf6/test_mf6_qgis_export.py
+++ b/imod/tests/test_mf6/test_mf6_qgis_export.py
@@ -13,7 +13,7 @@ import imod
 
 @pytest.mark.qgis_export
 def test_mf6_qgis_export__structured(tmp_path):
-    mf6_sim = imod.data.hondsrug_simulation(tmp_path /"unzipped")
+    mf6_sim = imod.data.hondsrug_simulation(tmp_path / "unzipped")
 
     path_dumped = Path(tmp_path) / "hondsrug_MDAL"
     mf6_sim.dump(path_dumped, mdal_compliant=True, crs="EPSG:28992")
@@ -22,7 +22,7 @@ def test_mf6_qgis_export__structured(tmp_path):
 
 @pytest.mark.qgis_export
 def test_mf6_qgis_export__unstructured(tmp_path):
-    mf6_sim = imod.data.hondsrug_simulation(tmp_path /"unzipped")
+    mf6_sim = imod.data.hondsrug_simulation(tmp_path / "unzipped")
     idomain = mf6_sim["GWF"]["dis"]["idomain"]
     grid = xu.UgridDataArray.from_structured2d(idomain)
 

--- a/imod/tests/test_mf6/test_mf6_qgis_export.py
+++ b/imod/tests/test_mf6/test_mf6_qgis_export.py
@@ -1,0 +1,32 @@
+"""
+QGIS user acceptance test, these are pytest-marked with 'qgis_export'.
+
+"""
+
+from pathlib import Path
+
+import pytest
+import xugrid as xu
+
+import imod
+
+
+@pytest.mark.qgis_export
+def test_mf6_qgis_export__structured(tmp_path):
+    mf6_sim = imod.data.hondsrug_simulation(tmp_path /"unzipped")
+
+    path_dumped = Path(tmp_path) / "hondsrug_MDAL"
+    mf6_sim.dump(path_dumped, mdal_compliant=True, crs="EPSG:28992")
+    print(f"Dumped to: {path_dumped}")
+
+
+@pytest.mark.qgis_export
+def test_mf6_qgis_export__unstructured(tmp_path):
+    mf6_sim = imod.data.hondsrug_simulation(tmp_path /"unzipped")
+    idomain = mf6_sim["GWF"]["dis"]["idomain"]
+    grid = xu.UgridDataArray.from_structured2d(idomain)
+
+    mf6_sim_unstructured = mf6_sim.regrid_like("unstructured_model", grid)
+    path_dumped = Path(tmp_path) / "hondsrug_MDAL"
+    mf6_sim_unstructured.dump(path_dumped, mdal_compliant=True, crs="EPSG:28992")
+    print(f"Dumped to: {path_dumped}")

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ unittests_njit = { cmd = [
     "NUMBA_DISABLE_JIT=1",
     "pytest",
     "-n", "auto",
-    "-m", "not example and not user_acceptance and not unittest_jit",
+    "-m", "not example and not user_acceptance and not unittest_jit and not qgis_export",
     "--cache-clear",
     "--verbose",
     "--junitxml=unittest_report.xml",
@@ -57,7 +57,6 @@ user_acceptance = { cmd = [
     "--verbose",
     "--junitxml=user_acceptance_report.xml",
 ], depends-on = ["install"], cwd = "imod/tests", env = { IMOD_DATA_DIR = ".imod_data" } }
-
 examples = { cmd = [
     "pytest",
     "-n", "auto",
@@ -65,6 +64,13 @@ examples = { cmd = [
     "--cache-clear",
     "--verbose",
     "--junitxml=examples_report.xml",
+], depends-on = ["install"], cwd = "imod/tests", env = { IMOD_DATA_DIR = ".imod_data" } }
+qgis_export ={ cmd = [
+    "pytest", "-s",
+    "-m", "qgis_export",
+    "--cache-clear",
+    "--verbose",
+    "--junitxml=qgis_export_report.xml",
 ], depends-on = ["install"], cwd = "imod/tests", env = { IMOD_DATA_DIR = ".imod_data" } }
 
 [dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,8 @@ ignore_missing_imports = true
 markers = [
     "example: marks test as example (deselect with '-m \"not example\"')",
     "user_acceptance: marks user acceptance tests (deselect with '-m \"not user_acceptance\"')",
-    "unittest_jit: marks unit tests that should be jitted (deselect with '-m \"not unittest_jit\"')"
+    "unittest_jit: marks unit tests that should be jitted (deselect with '-m \"not unittest_jit\"')",
+    "qgis_export: marks tests that export to QGIS (deselect with '-m \"not qgis_export\"')",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
Fixes #1570 

# Description

- Adds pixi tasks which write away data a model dump to MDAL. This is part of the [test plan](#1545), to be imported in QGIS and test if this still works. 
- Fixes bug where error was thrown when attempting to regrid or mask a variable with only a layer dimension.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
