### PR TITLE
Consistently use binary instead of 'use_binary' in write methods

### DIFF
--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -346,7 +346,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         modelname: str,
         globaltimes: Union[list[np.datetime64], np.ndarray],
         directory: str | Path,
-        use_binary: bool = True,
+        binary: bool = True,
         use_absolute_paths: bool = False,
         validate: bool = True,
     ):
@@ -365,7 +365,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
             Times of the simulation's stress periods.
         directory: str | Path
             Directory in which the simulation will be written.
-        use_binary: bool = True
+        binary: bool = True
             Whether to write time-dependent input for stress packages as binary
             files, which are smaller in size, or more human-readable text files.
         use_absolute_paths: bool = False
@@ -375,7 +375,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
             write. If True, erronous model input will throw a
             ``ValidationError``.
         """
-        write_context = WriteContext(Path(directory), use_binary, use_absolute_paths)
+        write_context = WriteContext(Path(directory), binary, use_absolute_paths)
         validate_context = ValidationSettings(validate, validate, validate)
 
         status_info = self._write(

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -282,7 +282,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         ----------
         directory: str, pathlib.Path
             Directory to write Modflow 6 simulation to.
-        use_binary: ({True, False}, optional)
+        binary: ({True, False}, optional)
             Whether to write time-dependent input for stress packages as binary
             files, which are smaller in size, or more human-readable text files.
         validate: ({True, False}, optional)


### PR DESCRIPTION
Fixes #1585

# Description
Update docstring and argument in Model.write

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
