### PR TITLE
Fix key error in wells

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -28,6 +28,9 @@ Fixed
 - Issue where regridding lead to excessively large inactive areas.
 - Issue where regridding would lead to very large negative integer values (like
   IDOMAIN) for inactive areas.
+- Issue where :meth:`imod.mf6.Well.from_imod5_data` and
+  :meth:`imod.mf6.LayeredWell.from_imod5_data` would throw a KeyError 0 upon
+  trying to resample timeseries with a non-zero index.
 
 Changed
 ~~~~~~~

--- a/imod/tests/test_mf6/test_utilities/test_resampling.py
+++ b/imod/tests/test_mf6/test_utilities/test_resampling.py
@@ -39,6 +39,25 @@ def test_timeseries_resampling():
     assert new_timeseries.equals(expected_timeseries)
 
 
+def test_timeseries_resampling__index_nonzero_start():
+    # In this test, we resample a timeseries for a coarser output
+    # discretization. The output times are a subset of the input times. The
+    # index of the timeseries has a non-zero start.
+    times = [datetime(1989, 1, i) for i in [1, 3, 4, 5, 6]]
+    rates = [i * 100 for i in range(1, 6)]
+    timeseries = initialize_timeseries(times, rates)
+    timeseries = timeseries.set_index(timeseries.index + 4)
+
+    new_dates = [datetime(1989, 1, 1), datetime(1989, 1, 5), datetime(1989, 1, 6)]
+    new_timeseries = resample_timeseries(timeseries, new_dates)
+
+    expected_times = [datetime(1989, 1, i) for i in [1, 5, 6]]
+    expected_rates = [175.0, 400.0, 500.0]
+    expected_timeseries = initialize_timeseries(expected_times, expected_rates)
+
+    assert new_timeseries.equals(expected_timeseries)
+
+
 def test_timeseries_resampling_2():
     # In this test, we resample a timeseries for a coarser output discretization.
     # The output times are a not a subset of the input times, and they begin earlier.

--- a/imod/util/expand_repetitions.py
+++ b/imod/util/expand_repetitions.py
@@ -111,7 +111,7 @@ def resample_timeseries(
     if time_before_start_input[0]:
         intermediate_df.loc[time_before_start_input, "rate"] = 0.0
         intermediate_df.loc[time_before_start_input, location_columns] = (
-            well_rate.loc[0, location_columns],
+            well_rate.iloc[0][location_columns],
         )
 
     # compute time difference from perious to current row


### PR DESCRIPTION
Fixes #1605 

# Description
Fixes problem when the index of wel_rate (after clipping?) doesn't start at 0. Get first row with an iloc instead of loc

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
