### PR TITLE
Issue #1610 Remove upper limit for mod_id

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -39,6 +39,8 @@ Changed
   :meth:`imod.mf6.NodePropertyFlow.from_imod5_data` now automatically load the
   dataset into memory. This improves performance when loading models with
   multiple topsystem packages.
+- No upper limit anymore for ``mod_id`` in ``mod2svat.inp`` for
+  :class:`imod.msw.CouplerMapping`.
 
 Removed
 ~~~~~~~

--- a/imod/msw/coupler_mapping.py
+++ b/imod/msw/coupler_mapping.py
@@ -22,7 +22,7 @@ class CouplerMapping(MetaSwapPackage):
 
     _file_name = "mod2svat.inp"
     _metadata_dict = {
-        "mod_id": VariableMetaData(10, 1, 9999999, int),
+        "mod_id": VariableMetaData(10, 1, None, int),
         "free": VariableMetaData(2, None, None, str),
         "svat": VariableMetaData(10, 1, 9999999, int),
         "layer": VariableMetaData(5, 0, 9999, int),


### PR DESCRIPTION
Fixes #1610 

# Description
Remove upper bound of mod_id. This is necessary for the LHM model. Hopefully this doesn't result in issues for MetaSWAP... I let @HendrikKok figure that out ;-) .

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
