### PR TITLE
Issue #1601 examples docstring

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -21,6 +21,9 @@ Added
 - Added :meth:`imod.mf6.HorizontalFlowBarrierResistance.snap_to_grid` and
   :meth:`imod.mf6.SingleLayerHorizontalFlowBarrierResistance.snap_to_grid` to
   debug how horizontal flow barriers are snapped to a grid.
+- Added :meth:`imod.mf6.Modflow6Simulation.create_partition_labels` to create
+  partition labels for a MODFLOW 6 simulation from its idomain. This is useful
+  for splitting a simulation into multiple submodels.
 
 Fixed
 ~~~~~
@@ -48,6 +51,11 @@ Changed
   multiple topsystem packages.
 - No upper limit anymore for ``mod_id`` in ``mod2svat.inp`` for
   :class:`imod.msw.CouplerMapping`.
+- :func:`imod.prepare.create_partition_labels` now takes an ``idomain`` grid
+  instead of :class:`imod.mf6.Modflow6Simulation` as first argument. To generate
+  partition labels from a :class:`imod.mf6.Modflow6Simulation` straightaway, use
+  the newly added :meth:`imod.mf6.Modflow6Simulation.create_partition_labels`
+  method instead.
 
 Removed
 ~~~~~~~

--- a/docs/api/mf6.rst
+++ b/docs/api/mf6.rst
@@ -13,6 +13,8 @@ Read Output
     open_cbc
     read_cbc_headers
     open_dvs
+    open_conc
+    read_grb
 
 Model objects & methods
 -----------------------

--- a/docs/api/mf6.rst
+++ b/docs/api/mf6.rst
@@ -42,6 +42,7 @@ Model objects & methods
     Modflow6Simulation.get_exchange_relationships
     Modflow6Simulation.get_models_of_type
     Modflow6Simulation.get_models
+    Modflow6Simulation.create_partition_labels
     GroundwaterFlowModel
     GroundwaterFlowModel.mask_all_packages
     GroundwaterFlowModel.prepare_wel_for_mf6

--- a/examples/mf6/circle_partitioned.py
+++ b/examples/mf6/circle_partitioned.py
@@ -12,16 +12,13 @@ import matplotlib.pyplot as plt
 from example_models import create_circle_simulation
 
 import imod
-from imod.prepare.partition import create_partition_labels
 
 simulation = create_circle_simulation()
 tmp_path = imod.util.temporary_directory()
 simulation.write(tmp_path / "original", False)
 
-idomain = simulation["GWF_1"]["disv"].dataset["idomain"]
-
 number_partitions = 5
-submodel_labels = create_partition_labels(simulation, number_partitions)
+submodel_labels = simulation.create_partition_labels(number_partitions)
 
 # Create a simulation that is split in subdomains according to the label array.
 new_sim = simulation.split(submodel_labels)

--- a/examples/mf6/hondsrug_partitioning.py
+++ b/examples/mf6/hondsrug_partitioning.py
@@ -16,7 +16,6 @@ comparison.
 import matplotlib.pyplot as plt
 
 import imod
-from imod.prepare.partition import create_partition_labels
 
 # %%
 # Obtain the simulation, write it, run it, and plot some heads.
@@ -45,9 +44,8 @@ hds_original.sel(layer=3).isel(time=6).plot(ax=ax)
 ax.set_title("hondsrug original ")
 # %%
 # Now we partition the Hondsrug model
-idomain = gwf_simulation["GWF"].domain
 number_partitions = 16
-submodel_labels = create_partition_labels(gwf_simulation, number_partitions)
+submodel_labels = gwf_simulation.create_partition_labels(number_partitions)
 
 # %%
 # This label array determines how the model will be split. `METIS

--- a/examples/mf6/transport_2d.py
+++ b/examples/mf6/transport_2d.py
@@ -24,7 +24,6 @@ import pandas as pd
 import xarray as xr
 
 import imod
-from imod.prepare.partition import create_partition_labels
 from imod.typing.grid import nan_like, zeros_like
 
 # %%
@@ -188,7 +187,7 @@ simulation.write(modeldir, binary=False)
 # To split the model in 4 partitions, we must create a label array.
 # We use the utility function  ``get_label_array`` for that.
 
-label_array = create_partition_labels(simulation, 4)
+label_array = simulation.create_partition_labels(4)
 fig, ax = plt.subplots()
 label_array.plot(ax=ax)
 

--- a/imod/mf6/gwfgwf.py
+++ b/imod/mf6/gwfgwf.py
@@ -92,6 +92,7 @@ class GWFGWF(ExchangeBase):
         top: Optional[GridDataArray] = None,
         bottom: Optional[GridDataArray] = None,
     ) -> Self:
+        """This package cannot be clipped by a bounding box."""
         raise NotImplementedError("this package cannot be clipped")
 
     def _render(

--- a/imod/mf6/gwfgwt.py
+++ b/imod/mf6/gwfgwt.py
@@ -38,6 +38,7 @@ class GWFGWT(ExchangeBase):
         bottom: Optional[GridDataArray] = None,
     ) -> Self:
         """
-        The GWF-GWT exchange does not have any spatial coordinates that can be clipped.
+        The GWF-GWT exchange does not have any spatial coordinates that can be
+        clipped. Package is deepcopied instead.
         """
         return deepcopy(self)

--- a/imod/mf6/gwtgwt.py
+++ b/imod/mf6/gwtgwt.py
@@ -88,6 +88,7 @@ class GWTGWT(ExchangeBase):
         top: Optional[GridDataArray] = None,
         bottom: Optional[GridDataArray] = None,
     ) -> Self:
+        """This package cannot be clipped by a bounding box."""
         raise NotImplementedError("this package cannot be clipped")
 
     def _render(

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -948,8 +948,8 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
 
         >>> pkg.clip_box(x_max=1000.0)``
 
-        To select x >= 500.0: 
-        
+        To select x >= 500.0:
+
         >>> pkg.clip_box(x_min=500.0)
         """
         new = deepcopy(self)

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -906,33 +906,51 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
         bottom: Optional[GridDataArray] = None,
     ) -> Self:
         """
-        Clip a package by a bounding box (time, layer, y, x).
-
-        Slicing intervals may be half-bounded, by providing None:
-
-        * To select 500.0 <= x <= 1000.0:
-          ``clip_box(x_min=500.0, x_max=1000.0)``.
-        * To select x <= 1000.0: ``clip_box(x_min=None, x_max=1000.0)``
-          or ``clip_box(x_max=1000.0)``.
-        * To select x >= 500.0: ``clip_box(x_min = 500.0, x_max=None.0)``
-          or ``clip_box(x_min=1000.0)``.
+        Clip a barrier by a bounding box (y, x).
 
         Parameters
         ----------
-        time_min: optional
+        time_min: optional, np.datetime64
+            Ignored
         time_max: optional
+            Ignored
         layer_min: optional, int
+            Ignored
         layer_max: optional, int
+            Ignored
         x_min: optional, float
+            Minimum x-coordinate to select.
         x_max: optional, float
+            Maximum x-coordinate to select.
         y_min: optional, float
+            Minimum y-coordinate to select.
         y_max: optional, float
+            Maximum y-coordinate to select.
         top: optional, GridDataArray
+            Ignored
         bottom: optional, GridDataArray
+            Ignored
 
         Returns
         -------
-        sliced : Package
+        clipped : Package
+            A new package that is clipped to the specified bounding box.
+
+        Examples
+        --------
+        Slicing intervals may be half-bounded, by providing None:
+
+        To select 500.0 <= x <= 1000.0:
+
+        >>> pkg.clip_box(x_min=500.0, x_max=1000.0)
+
+        To select x <= 1000.0:
+
+        >>> pkg.clip_box(x_max=1000.0)``
+
+        To select x >= 500.0: 
+        
+        >>> pkg.clip_box(x_min=500.0)
         """
         new = deepcopy(self)
 

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -127,6 +127,65 @@ class GroundwaterFlowModel(Modflow6Model):
         y_max: Optional[float] = None,
         state_for_boundary: Optional[GridDataArray] = None,
     ):
+        """
+        Clip a model by a bounding box (time, layer, y, x).
+
+        Parameters
+        ----------
+        time_min: optional, np.datetime64
+            Start time to select. Data will be forward filled to this date. If
+            time_min is before the start time of the dataset, data is
+            backfilled.
+        time_max: optional
+            End time to select.
+        layer_min: optional, int
+            Minimum layer to select.
+        layer_max: optional, int
+            Maximum layer to select.
+        x_min: optional, float
+            Minimum x-coordinate to select.
+        x_max: optional, float
+            Maximum x-coordinate to select.
+        y_min: optional, float
+            Minimum y-coordinate to select.
+        y_max: optional, float
+            Maximum y-coordinate to select.
+        state_for_boundary : optional, Union[xr.DataArray, xu.UgridDataArray]
+            A grids with states that are used to put as boundary values. This
+            model will get a :class:`imod.mf6.ConstantHead`.
+        
+        Returns
+        -------
+        clipped : GroundwaterFlowModel
+            A new model that is clipped to the specified bounding box.
+
+        Examples
+        --------
+        Slicing intervals may be half-bounded, by providing None:
+
+        To select 500.0 <= x <= 1000.0:
+
+        >>> gwf.clip_box(x_min=500.0, x_max=1000.0)
+
+        To select x <= 1000.0:
+
+        >>> gwf.clip_box(x_max=1000.0)``
+
+        To select x >= 500.0: 
+        
+        >>> gwf.clip_box(x_min=500.0)
+
+        To select a time interval, you can use datetime64:
+
+        >>> gwf.clip_box(time_min=np.datetime64("2020-01-01"), time_max=np.datetime64("2020-12-31"))
+
+        To clip an area and set a boundary condition at the clipped boundary:
+
+        >>> clipped_gwf = gwf.clip_box(
+        ...     x_min=500.0, x_max=1000.0, y_min=500.0, y_max=1000.0, 
+        ...     state_for_boundary=heads
+        ... )
+        """
         clipped = super().clip_box(
             time_min, time_max, layer_min, layer_max, x_min, x_max, y_min, y_max
         )

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -153,7 +153,7 @@ class GroundwaterFlowModel(Modflow6Model):
         state_for_boundary : optional, Union[xr.DataArray, xu.UgridDataArray]
             A grids with states that are used to put as boundary values. This
             model will get a :class:`imod.mf6.ConstantHead`.
-        
+
         Returns
         -------
         clipped : GroundwaterFlowModel
@@ -171,8 +171,8 @@ class GroundwaterFlowModel(Modflow6Model):
 
         >>> gwf.clip_box(x_max=1000.0)``
 
-        To select x >= 500.0: 
-        
+        To select x >= 500.0:
+
         >>> gwf.clip_box(x_min=500.0)
 
         To select a time interval, you can use datetime64:
@@ -182,7 +182,7 @@ class GroundwaterFlowModel(Modflow6Model):
         To clip an area and set a boundary condition at the clipped boundary:
 
         >>> clipped_gwf = gwf.clip_box(
-        ...     x_min=500.0, x_max=1000.0, y_min=500.0, y_max=1000.0, 
+        ...     x_min=500.0, x_max=1000.0, y_min=500.0, y_max=1000.0,
         ...     state_for_boundary=heads
         ... )
         """

--- a/imod/mf6/out/__init__.py
+++ b/imod/mf6/out/__init__.py
@@ -96,6 +96,12 @@ def read_grb(path: FilePath) -> Dict[str, Any]:
     Returns
     -------
     grb_content: Dict[str, Any]
+
+    Examples
+    --------
+    Read the grb file:
+
+    >>> grb_content = imod.mf6.read_grb("my-model.grb")
     """
     with open(path, "rb") as f:
         h1 = _grb_text(f)
@@ -151,6 +157,27 @@ def open_hds(
     Returns
     -------
     head: Union[xr.DataArray, xu.UgridDataArray]
+
+    Examples
+    --------
+    When you completed MODFLOW6 simulation, you can open the head file:
+
+    >>> head = imod.mf6.open_hds("my-model.hds", "my-model.grb")
+
+    This will return a DataArray with the head values for each cell in the
+    model, with dimensions ("time", "layer", "y", "x"). The time coordinate will
+    only be the incremental time steps (1.0, 2.0, ...), unless you provide the
+    ``simulation_start_time`` and ``time_unit`` arguments. This will convert the
+    time coordinate to calendar time, starting from the provided simulation
+    start time:
+
+    >>> head = imod.mf6.open_hds(
+    ...     "my-model.hds",
+    ...     "my-model.grb",
+    ...     simulation_start_time=np.datetime64("2023-01-01T00:00:00"),
+    ...     time_unit="d",
+    ... )
+
     """
     grb_content = read_grb(grb_path)
     grb_content["name"] = "head"
@@ -177,7 +204,7 @@ def open_dvs(
 
     Parameters
     ----------
-    dsv_path: Union[str, pathlib.Path]
+    dvs_path: Union[str, pathlib.Path]
     grb_path: Union[str, pathlib.Path]
     indices: np.ndarray
         The indices to map dvs variable to model nodes
@@ -201,6 +228,27 @@ def open_dvs(
     Returns
     -------
     dvs : Union[xr.DataArray, xu.UgridDataArray]
+
+    Examples
+    --------
+    When you completed MODFLOW6 simulation, you can open the dvs file:
+
+    >>> dvs = imod.mf6.open_dvs("my-model.dvs", "my-model.grb")
+
+    This will return a DataArray with the dvs values for each cell in the
+    model, with dimensions ("time", "layer", "y", "x"). The time coordinate will
+    only be the incremental time steps (1.0, 2.0, ...), unless you provide the
+    ``simulation_start_time`` and ``time_unit`` arguments. This will convert the
+    time coordinate to calendar time, starting from the provided simulation
+    start time:
+
+    >>> dvs = imod.mf6.open_dvs(
+    ...     "my-model.dvs",
+    ...     "my-model.grb",
+    ...     simulation_start_time=np.datetime64("2023-01-01T00:00:00"),
+    ...     time_unit="d",
+    ... )
+
     """
     grb_content = read_grb(grb_path)
     distype = grb_content["distype"]
@@ -249,6 +297,27 @@ def open_conc(
     Returns
     -------
     concentration: Union[xr.DataArray, xu.UgridDataArray]
+
+    Examples
+    --------
+    When you completed MODFLOW6 simulation, you can open the ucn file:
+
+    >>> concentration = imod.mf6.open_conc("my-model.ucn", "my-model.grb")
+
+    This will return a DataArray with the concentration values for each cell in
+    the model, with dimensions ("time", "layer", "y", "x"). The time coordinate
+    will only be the incremental time steps (1.0, 2.0, ...), unless you provide
+    the ``simulation_start_time`` and ``time_unit`` arguments. This will convert
+    the time coordinate to calendar time, starting from the provided simulation
+    start time:
+
+    >>> concentration = imod.mf6.open_conc(
+    ...     "my-model.ucn",
+    ...     "my-model.grb",
+    ...     simulation_start_time=np.datetime64("2023-01-01T00:00:00"),
+    ...     time_unit="d",
+    ... )
+
     """
     grb_content = read_grb(grb_path)
     grb_content["name"] = "concentration"
@@ -376,6 +445,19 @@ def open_cbc(
     >>> drn_budget = cbc_content["drn]
     >>> mean = drn_budget.sel(layer=1).mean("time")
 
+    This will return a DataArray with the drain budget values for each cell in the
+    model, with dimensions ("time", "layer", "y", "x"). The time coordinate will
+    only be the incremental time steps (1.0, 2.0, ...), unless you provide the
+    ``simulation_start_time`` and ``time_unit`` arguments. This will convert the
+    time coordinate to calendar time, starting from the provided simulation
+    start time:
+
+    >>> cbc_content = imod.mf6.open_cbc(
+    ...     "my-model.cbc",
+    ...     "my-model.grb",
+    ...     simulation_start_time=np.datetime64("2023-01-01T00:00:00"),
+    ...     time_unit="d",
+    ... )
     """
     grb_content = read_grb(grb_path)
     distype = grb_content["distype"]

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -393,33 +393,56 @@ class Package(PackageBase, IPackage, abc.ABC):
         """
         Clip a package by a bounding box (time, layer, y, x).
 
-        Slicing intervals may be half-bounded, by providing None:
-
-        * To select 500.0 <= x <= 1000.0:
-          ``clip_box(x_min=500.0, x_max=1000.0)``.
-        * To select x <= 1000.0: ``clip_box(x_min=None, x_max=1000.0)``
-          or ``clip_box(x_max=1000.0)``.
-        * To select x >= 500.0: ``clip_box(x_min = 500.0, x_max=None.0)``
-          or ``clip_box(x_min=1000.0)``.
-
         Parameters
         ----------
-        time_min: optional
+        time_min: optional, np.datetime64
+            Start time to select. Data will be forward filled to this date. If
+            time_min is before the start time of the dataset, data is
+            backfilled.
         time_max: optional
+            End time to select.
         layer_min: optional, int
+            Minimum layer to select.
         layer_max: optional, int
+            Maximum layer to select.
         x_min: optional, float
+            Minimum x-coordinate to select.
         x_max: optional, float
+            Maximum x-coordinate to select.
         y_min: optional, float
+            Minimum y-coordinate to select.
         y_max: optional, float
+            Maximum y-coordinate to select.
         top: optional, GridDataArray
+            Ignored.
         bottom: optional, GridDataArray
-        state_for_boundary: optional, GridDataArray
-
+            Ignored.
 
         Returns
         -------
-        clipped: Package
+        clipped : Package
+            A new package that is clipped to the specified bounding box.
+
+        Examples
+        --------
+        Slicing intervals may be half-bounded, by providing None:
+
+        To select 500.0 <= x <= 1000.0:
+
+        >>> pkg.clip_box(x_min=500.0, x_max=1000.0)
+
+        To select x <= 1000.0:
+
+        >>> pkg.clip_box(x_max=1000.0)``
+
+        To select x >= 500.0: 
+        
+        >>> pkg.clip_box(x_min=500.0)
+
+        To select a time interval, you can use datetime64:
+
+        >>> pkg.clip_box(time_min=np.datetime64("2020-01-01"), time_max=np.datetime64("2020-12-31"))
+
         """
         if not self._is_clipping_supported():
             raise ValueError("this package does not support clipping.")

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -435,8 +435,8 @@ class Package(PackageBase, IPackage, abc.ABC):
 
         >>> pkg.clip_box(x_max=1000.0)``
 
-        To select x >= 500.0: 
-        
+        To select x >= 500.0:
+
         >>> pkg.clip_box(x_min=500.0)
 
         To select a time interval, you can use datetime64:

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -481,7 +481,7 @@ class Package(PackageBase, IPackage, abc.ABC):
         -------
         masked: Package
             The package with part masked.
-        
+
         Examples
         --------
         To mask a package with an idomain-like array. For example, to create a

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -474,13 +474,25 @@ class Package(PackageBase, IPackage, abc.ABC):
         Parameters
         ----------
         mask: xr.DataArray, xu.UgridDataArray of ints
-            idomain-like integer array. >0 sets cells to active, 0 sets cells to inactive,
-            <0 sets cells to vertical passthrough
+            idomain-like integer array. >0 sets cells to active, 0 sets cells to
+            inactive, <0 sets cells to vertical passthrough
 
         Returns
         -------
         masked: Package
             The package with part masked.
+        
+        Examples
+        --------
+        To mask a package with an idomain-like array. For example, to create a
+        package with the first 10 rows and columns masked, create the mask first:
+
+        >>> mask = xr.ones_like(idomain, dtype=int)
+        >>> mask[0:10, 0:10] = 0
+
+        Then call mask:
+
+        >>> masked_pkg = pkg.mask(mask)
         """
         result = cast(IPackage, deepcopy(self))
         remove_expanded_auxiliary_variables_from_dataset(result)
@@ -520,6 +532,13 @@ class Package(PackageBase, IPackage, abc.ABC):
             specialization class of BaseRegridder) and function name (str) this
             dictionary can be used to override the default mapping method.
 
+        Returns
+        -------
+        Package
+            A package with the same options as this package, and with all the
+            data-arrays regridded to another discretization, similar to the one used
+            in input argument "target_grid"
+
         Examples
         --------
         To regrid the npf package with a non-default method for the k-field,
@@ -528,12 +547,6 @@ class Package(PackageBase, IPackage, abc.ABC):
         >>> regridder_types = imod.mf6.regrid.NodePropertyFlowRegridMethod(k=(imod.RegridderType.OVERLAP, "mean"))
         >>> regrid_cache = imod.util.regrid.RegridderWeightsCache()
         >>> new_npf = npf.regrid_like(like, regrid_cache, regridder_types)
-
-        Returns
-        -------
-        A package with the same options as this package, and with all the
-        data-arrays regridded to another discretization, similar to the one used
-        in input argument "target_grid"
         """
         try:
             result = deepcopy(self)

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1291,9 +1291,9 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         validate: bool = True,
     ) -> "Modflow6Simulation":
         """
-        This method creates a new simulation object. The models contained in the new simulation are regridded versions
-        of the models in the input object (this).
-        Time discretization and solver settings are copied.
+        This method creates a new simulation object. The models contained in the
+        new simulation are regridded versions of the models in the input object
+        (this). Time discretization and solver settings are copied.
 
         Parameters
         ----------
@@ -1307,6 +1307,16 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         Returns
         -------
         a new simulation object with regridded models
+
+        Examples
+        --------
+        >>> target_grid = imod.util.empty_2d(
+        ...     dx=5.0, xmin=500.0, xmax=1000.0, dy=5.0, ymin=500.0, ymax=1000.0
+        ... )
+        >>> regridded_sim = simulation.regrid_like(
+        ...     regridded_simulation_name="regridded_sim",
+        ...     target_grid=target_grid,
+        ... )
         """
 
         return _regrid_like(self, regridded_simulation_name, target_grid, validate)

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -292,11 +292,11 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             ``ValidationError``.
         use_absolute_paths: ({True, False}, optional)
             True if all paths written to the mf6 inputfiles should be absolute.
-        
+
         Examples
         --------
         Write the simulation to a directory:
-        
+
         >>> simulation.write("path/to/simulation")
 
         If you continue to run into ValidationErrors, you can disable the validation

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1474,7 +1474,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
     def mask_all_models(
         self,
         mask: GridDataArray,
-    ):
+    ) -> None:
         """
         This function applies a mask to all models in a simulation, provided they use
         the same discretization. The  method parameter "mask" is an idomain-like array.
@@ -1488,6 +1488,16 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         mask: xr.DataArray, xu.UgridDataArray of ints
             idomain-like integer array. >0 sets cells to active, 0 sets cells to inactive,
             <0 sets cells to vertical passthrough
+        
+        Examples
+        --------
+        To mask all models in a simulation, you can use the following code:
+        
+        >>> mf6_sim.mask_all_models(new_idomain)
+
+        This masks the model inplace and updates the packages accordingly. The
+        mask should be an idomain-like array, i.e. it should have the same shape
+        as the model and contain integer values.
         """
         _mask_all_models(self, mask)
 

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1068,30 +1068,65 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         """
         Clip a simulation by a bounding box (time, layer, y, x).
 
-        Slicing intervals may be half-bounded, by providing None:
-
-        * To select 500.0 <= x <= 1000.0:
-          ``clip_box(x_min=500.0, x_max=1000.0)``.
-        * To select x <= 1000.0: ``clip_box(x_min=None, x_max=1000.0)``
-          or ``clip_box(x_max=1000.0)``.
-        * To select x >= 500.0: ``clip_box(x_min = 500.0, x_max=None.0)``
-          or ``clip_box(x_min=1000.0)``.
-
         Parameters
         ----------
-        time_min: optional
+        time_min: optional, np.datetime64
+            Start time to select. Data will be forward filled to this date. If
+            time_min is before the start time of the dataset, data is
+            backfilled.
         time_max: optional
+            End time to select.
         layer_min: optional, int
+            Minimum layer to select.
         layer_max: optional, int
+            Maximum layer to select.
         x_min: optional, float
+            Minimum x-coordinate to select.
         x_max: optional, float
+            Maximum x-coordinate to select.
         y_min: optional, float
+            Minimum y-coordinate to select.
         y_max: optional, float
-        states_for_boundary : optional, Dict[pkg_name:str, boundary_values:Union[xr.DataArray, xu.UgridDataArray]]
-
+            Maximum y-coordinate to select.
+        states_for_boundary : optional, Dict[str, Union[xr.DataArray, xu.UgridDataArray]]
+            A dictionary with model names as keys and grids with states that are
+            used to put as boundary values.
+            :class:`imod.mf6.GroundwaterFlowModel` will get a
+            :class:`imod.mf6.ConstantHead`,
+            :class:`imod.mf6.GroundwaterTransportModel` will get a
+            :class:`imod.mf6.ConstantConcentration` package.
+        
         Returns
         -------
         clipped : Simulation
+
+        Examples
+        --------
+        Slicing intervals may be half-bounded, by providing None:
+
+        To select 500.0 <= x <= 1000.0:
+
+        >>> mf6_sim.clip_box(x_min=500.0, x_max=1000.0)
+
+        To select x <= 1000.0:
+
+        >>> mf6_sim.clip_box(x_max=1000.0)``
+
+        To select x >= 500.0: 
+        
+        >>> mf6_sim.clip_box(x_min=500.0)
+
+        To select a time interval, you can use datetime64:
+
+        >>> mf6_sim.clip_box(time_min=np.datetime64("2020-01-01"), time_max=np.datetime64("2020-12-31"))
+
+        To clip an area and set a boundary condition at the clipped boundary:
+
+        >>> states_for_boundary = {"GWF6_model_name": heads}
+        >>> clipped_sim = mf6_sim.clip_box(
+        ...     x_min=500.0, x_max=1000.0, y_min=500.0, y_max=1000.0, 
+        ...     states_for_boundary=states_for_boundary
+        ... )
         """
 
         if self.is_split():

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -910,6 +910,27 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         crs: Any, optional
             Anything accepted by rasterio.crs.CRS.from_user_input
             Requires ``rioxarray`` installed.
+        
+        Examples
+        --------
+        Dump simulation to directory:
+
+        >>> mf6_sim.dump("path/to/directory")
+
+        You can load the dumped simulation back with:
+
+        >>> loaded_sim = Modflow6Simulation.from_file("path/to/directory/simulation_name.toml")
+
+        If you keep on getting ValidationErrors, you can set
+        ``validate=False`` to skip validation, but this is not recommended.
+
+        >>> mf6_sim.dump("path/to/directory", validate=False)
+
+        You can then fix the issues later after loading the simulation in a
+        later stage. If you want to dump the simulation in a form that is nicely
+        loaded into QGIS, you can set ``mdal_compliant=True``:
+
+        >>> mf6_sim.dump("path/to/directory", mdal_compliant=True, crs="EPSG:4326")
         """
         directory = pathlib.Path(directory)
         directory.mkdir(parents=True, exist_ok=True)
@@ -961,6 +982,16 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         -------
         Modflow6Simulation
             Modflow6Simulation object with models and packages loaded from
+
+        Examples
+        --------
+        Dump simulation to directory:
+
+        >>> mf6_sim.dump("path/to/directory")
+
+        You can load the dumped simulation back with:
+
+        >>> loaded_sim = Modflow6Simulation.from_file("path/to/directory/simulation_name.toml")
         """
         classes = {
             item_cls.__name__: item_cls

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -49,11 +49,11 @@ from imod.mf6.package import Package
 from imod.mf6.ssm import SourceSinkMixing
 from imod.mf6.validation_settings import ValidationSettings
 from imod.mf6.write_context import WriteContext
+from imod.prepare.partition import create_partition_labels
 from imod.prepare.topsystem.default_allocation_methods import (
     SimulationAllocationOptions,
     SimulationDistributingOptions,
 )
-from imod.prepare.partition import create_partition_labels
 from imod.schemata import ValidationError
 from imod.typing import GridDataArray, GridDataset
 from imod.typing.grid import (
@@ -911,7 +911,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         crs: Any, optional
             Anything accepted by rasterio.crs.CRS.from_user_input
             Requires ``rioxarray`` installed.
-        
+
         Examples
         --------
         Dump simulation to directory:
@@ -1127,7 +1127,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             :class:`imod.mf6.ConstantHead`,
             :class:`imod.mf6.GroundwaterTransportModel` will get a
             :class:`imod.mf6.ConstantConcentration` package.
-        
+
         Returns
         -------
         clipped : Simulation
@@ -1144,8 +1144,8 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
 
         >>> mf6_sim.clip_box(x_max=1000.0)``
 
-        To select x >= 500.0: 
-        
+        To select x >= 500.0:
+
         >>> mf6_sim.clip_box(x_min=500.0)
 
         To select a time interval, you can use datetime64:
@@ -1156,7 +1156,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
 
         >>> states_for_boundary = {"GWF6_model_name": heads}
         >>> clipped_sim = mf6_sim.clip_box(
-        ...     x_min=500.0, x_max=1000.0, y_min=500.0, y_max=1000.0, 
+        ...     x_min=500.0, x_max=1000.0, y_min=500.0, y_max=1000.0,
         ...     states_for_boundary=states_for_boundary
         ... )
         """
@@ -1231,7 +1231,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             be positive integers. If not provided, active cells (idomain > 0)
             are summed across layers and passed on as weights. If None, the
             idomain is used to compute weights.
-        
+
         Returns
         -------
         xarray.DataArray or xu.UgridDataArray
@@ -1266,7 +1266,6 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         idomain = flowmodel.domain
         return create_partition_labels(idomain, npartitions, weights=weights)
 
-
     @standard_log_decorator()
     def split(
         self,
@@ -1295,7 +1294,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         -------
         Modflow6Simulation
             A new simulation containing all the split models and packages
-        
+
         Examples
         --------
         >>> submodel_labels = mf6_sim.create_partition_labels(n_partitions=4)
@@ -1594,11 +1593,11 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         mask: xr.DataArray, xu.UgridDataArray of ints
             idomain-like integer array. >0 sets cells to active, 0 sets cells to inactive,
             <0 sets cells to vertical passthrough
-        
+
         Examples
         --------
         To mask all models in a simulation, you can use the following code:
-        
+
         >>> mf6_sim.mask_all_models(new_idomain)
 
         This masks the model inplace and updates the packages accordingly. The

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -292,6 +292,17 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
             ``ValidationError``.
         use_absolute_paths: ({True, False}, optional)
             True if all paths written to the mf6 inputfiles should be absolute.
+        
+        Examples
+        --------
+        Write the simulation to a directory:
+        
+        >>> simulation.write("path/to/simulation")
+
+        If you continue to run into ValidationErrors, you can disable the validation
+        by setting the ``validate`` argument to ``False``. This is not recommended:
+
+        >>> simulation.write("path/to/simulation", validate=False)
         """
         # create write context
         write_context = WriteContext(directory, binary, use_absolute_paths)

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -926,39 +926,62 @@ class Well(GridAgnosticWell):
         bottom: Optional[GridDataArray] = None,
     ) -> Self:
         """
-        Clip a package by a bounding box (time, layer, y, x).
-
-        The well package doesn't use the layer attribute to describe its depth and length.
-        Instead, it uses the screen_top and screen_bottom parameters which corresponds with
-        the z-coordinates of the top and bottom of the well. To go from a layer_min and
-        layer_max to z-values used for clipping the well a top and bottom array have to be
-        provided as well.
-
-        Slicing intervals may be half-bounded, by providing None:
-
-        * To select 500.0 <= x <= 1000.0:
-          ``clip_box(x_min=500.0, x_max=1000.0)``.
-        * To select x <= 1000.0: ``clip_box(x_min=None, x_max=1000.0)``
-          or ``clip_box(x_max=1000.0)``.
-        * To select x >= 500.0: ``clip_box(x_min = 500.0, x_max=None.0)``
-          or ``clip_box(x_min=1000.0)``.
+        Clip a well package by a bounding box (time, layer, y, x).
 
         Parameters
         ----------
-        time_min: optional
+        time_min: optional, np.datetime64
+            Start time to select. Data will be forward filled to this date. If
+            time_min is before the start time of the dataset, data is
+            backfilled.
         time_max: optional
+            End time to select.
         layer_min: optional, int
+            Ignored.
         layer_max: optional, int
+            Ignored.
         x_min: optional, float
+            Minimum x-coordinate to select.
         x_max: optional, float
+            Maximum x-coordinate to select.
         y_min: optional, float
+            Minimum y-coordinate to select.
         y_max: optional, float
+            Maximum y-coordinate to select.
         top: optional, GridDataArray
+            Grid of top used to clip well screen tops.
         bottom: optional, GridDataArray
+            Grid of bottom used to clip well screen bottoms.
 
         Returns
         -------
-        sliced : Package
+        clipped : Well
+            A new package that is clipped to the specified bounding box.
+
+        Examples
+        --------
+        Slicing intervals may be half-bounded, by providing None:
+
+        To select 500.0 <= x <= 1000.0:
+
+        >>> pkg.clip_box(x_min=500.0, x_max=1000.0)
+
+        To select x <= 1000.0:
+
+        >>> pkg.clip_box(x_max=1000.0)``
+
+        To select x >= 500.0: 
+        
+        >>> pkg.clip_box(x_min=500.0)
+
+        To select a time interval, you can use datetime64:
+
+        >>> pkg.clip_box(time_min=np.datetime64("2020-01-01"), time_max=np.datetime64("2020-12-31"))
+
+        To clip well screens:
+
+        >>> pkg.clip_box(top=top_grid, bottom=bottom_grid)
+
         """
         if (layer_max or layer_min) and (top is None or bottom is None):
             raise ValueError(
@@ -1288,33 +1311,58 @@ class LayeredWell(GridAgnosticWell):
         bottom: Optional[GridDataArray] = None,
     ) -> Self:
         """
-        Clip a package by a bounding box (time, layer, y, x).
-
-        Slicing intervals may be half-bounded, by providing None:
-
-        * To select 500.0 <= x <= 1000.0:
-          ``clip_box(x_min=500.0, x_max=1000.0)``.
-        * To select x <= 1000.0: ``clip_box(x_min=None, x_max=1000.0)``
-          or ``clip_box(x_max=1000.0)``.
-        * To select x >= 500.0: ``clip_box(x_min = 500.0, x_max=None.0)``
-          or ``clip_box(x_min=1000.0)``.
+        Clip a well package by a bounding box (time, layer, y, x).
 
         Parameters
         ----------
-        time_min: optional
+        time_min: optional, np.datetime64
+            Start time to select. Data will be forward filled to this date. If
+            time_min is before the start time of the dataset, data is
+            backfilled.
         time_max: optional
+            End time to select.
         layer_min: optional, int
+            Minimum layer to select.
         layer_max: optional, int
+            Maximum layer to select.
         x_min: optional, float
+            Minimum x-coordinate to select.
         x_max: optional, float
+            Maximum x-coordinate to select.
         y_min: optional, float
+            Minimum y-coordinate to select.
         y_max: optional, float
+            Maximum y-coordinate to select.
         top: optional, GridDataArray
+            Ignored.
         bottom: optional, GridDataArray
+            Ignored.
 
         Returns
         -------
-        sliced : Package
+        clipped : Well
+            A new package that is clipped to the specified bounding box.
+
+        Examples
+        --------
+        Slicing intervals may be half-bounded, by providing None:
+
+        To select 500.0 <= x <= 1000.0:
+
+        >>> pkg.clip_box(x_min=500.0, x_max=1000.0)
+
+        To select x <= 1000.0:
+
+        >>> pkg.clip_box(x_max=1000.0)``
+
+        To select x >= 500.0: 
+        
+        >>> pkg.clip_box(x_min=500.0)
+
+        To select a time interval, you can use datetime64:
+
+        >>> pkg.clip_box(time_min=np.datetime64("2020-01-01"), time_max=np.datetime64("2020-12-31"))
+
         """
         # The super method will select in the time dimension without issues.
         new = super().clip_box(time_min=time_min, time_max=time_max)

--- a/imod/mf6/wel.py
+++ b/imod/mf6/wel.py
@@ -970,8 +970,8 @@ class Well(GridAgnosticWell):
 
         >>> pkg.clip_box(x_max=1000.0)``
 
-        To select x >= 500.0: 
-        
+        To select x >= 500.0:
+
         >>> pkg.clip_box(x_min=500.0)
 
         To select a time interval, you can use datetime64:
@@ -1355,8 +1355,8 @@ class LayeredWell(GridAgnosticWell):
 
         >>> pkg.clip_box(x_max=1000.0)``
 
-        To select x >= 500.0: 
-        
+        To select x >= 500.0:
+
         >>> pkg.clip_box(x_min=500.0)
 
         To select a time interval, you can use datetime64:

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -195,8 +195,8 @@ class MeteoMapping(MetaSwapPackage):
 
         >>> pkg.clip_box(x_max=1000.0)``
 
-        To select x >= 500.0: 
-        
+        To select x >= 500.0:
+
         >>> pkg.clip_box(x_min=500.0)
 
         To select a time interval, you can use datetime64:

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -159,30 +159,50 @@ class MeteoMapping(MetaSwapPackage):
         y_max: Optional[float] = None,
     ):
         """
-        Clip a package by a bounding box (time, layer, y, x).
-
-        Slicing intervals may be half-bounded, by providing None:
-
-        * To select 500.0 <= x <= 1000.0:
-          ``clip_box(x_min=500.0, x_max=1000.0)``.
-        * To select x <= 1000.0: ``clip_box(x_min=None, x_max=1000.0)``
-          or ``clip_box(x_max=1000.0)``.
-        * To select x >= 500.0: ``clip_box(x_min = 500.0, x_max=None.0)``
-          or ``clip_box(x_min=1000.0)``.
+        Clip a package by a bounding box (time, y, x).
 
         Parameters
         ----------
-        time_min: optional
+        time_min: optional, np.datetime64
+            Start time to select. Data will be forward filled to this date. If
+            time_min is before the start time of the dataset, data is
+            backfilled.
         time_max: optional
+            End time to select.
         x_min: optional, float
+            Minimum x-coordinate to select.
         x_max: optional, float
+            Maximum x-coordinate to select.
         y_min: optional, float
+            Minimum y-coordinate to select.
         y_max: optional, float
+            Maximum y-coordinate to select.
 
         Returns
         -------
-        clipped: Package
-            A new package with the clipped data.
+        clipped : Package
+            A new package that is clipped to the specified bounding box.
+
+        Examples
+        --------
+        Slicing intervals may be half-bounded, by providing None:
+
+        To select 500.0 <= x <= 1000.0:
+
+        >>> pkg.clip_box(x_min=500.0, x_max=1000.0)
+
+        To select x <= 1000.0:
+
+        >>> pkg.clip_box(x_max=1000.0)``
+
+        To select x >= 500.0: 
+        
+        >>> pkg.clip_box(x_min=500.0)
+
+        To select a time interval, you can use datetime64:
+
+        >>> pkg.clip_box(time_min=np.datetime64("2020-01-01"), time_max=np.datetime64("2020-12-31"))
+
         """
         selection = self.meteo.to_dataset(name="meteo")  # Force to dataset
         selection = clip_time_slice(selection, time_min=time_min, time_max=time_max)

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -377,28 +377,48 @@ class MetaSwapModel(Model):
         ``mete_grid.inp`` copied by :class:`imod.msw.MeteoGridCopy` would be
         computed.
 
-        Slicing intervals may be half-bounded, by providing None:
-
-        * To select 500.0 <= x <= 1000.0:
-          ``clip_box(x_min=500.0, x_max=1000.0)``.
-        * To select x <= 1000.0: ``clip_box(x_min=None, x_max=1000.0)``
-          or ``clip_box(x_max=1000.0)``.
-        * To select x >= 500.0: ``clip_box(x_min = 500.0, x_max=None.0)``
-          or ``clip_box(x_min=1000.0)``.
-
         Parameters
         ----------
-        time_min: optional
+        time_min: optional, np.datetime64
+            Start time to select. Data will be forward filled to this date. If
+            time_min is before the start time of the dataset, data is
+            backfilled.
         time_max: optional
+            End time to select.
         x_min: optional, float
+            Minimum x-coordinate to select.
         x_max: optional, float
+            Maximum x-coordinate to select.
         y_min: optional, float
+            Minimum y-coordinate to select.
         y_max: optional, float
+            Maximum y-coordinate to select.
 
         Returns
         -------
-        MetaSwapModel
-            Clipped model.
+        clipped : MetaSwapModel
+            A new model that is clipped to the specified bounding box.
+
+        Examples
+        --------
+        Slicing intervals may be half-bounded, by providing None:
+
+        To select 500.0 <= x <= 1000.0:
+
+        >>> msw_model.clip_box(x_min=500.0, x_max=1000.0)
+
+        To select x <= 1000.0:
+
+        >>> msw_model.clip_box(x_max=1000.0)``
+
+        To select x >= 500.0: 
+        
+        >>> msw_model.clip_box(x_min=500.0)
+
+        To select a time interval, you can use datetime64:
+
+        >>> msw_model.clip_box(time_min=np.datetime64("2020-01-01"), time_max=np.datetime64("2020-12-31"))
+
         """
         settings = deepcopy(self.simulation_settings)
         unsa_svat_path = settings.pop("unsa_svat_path")

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -411,8 +411,8 @@ class MetaSwapModel(Model):
 
         >>> msw_model.clip_box(x_max=1000.0)``
 
-        To select x >= 500.0: 
-        
+        To select x >= 500.0:
+
         >>> msw_model.clip_box(x_min=500.0)
 
         To select a time interval, you can use datetime64:

--- a/imod/msw/pkgbase.py
+++ b/imod/msw/pkgbase.py
@@ -279,29 +279,50 @@ class MetaSwapPackage(abc.ABC):
         y_max: Optional[float] = None,
     ) -> "MetaSwapPackage":
         """
-        Clip a package by a bounding box (time, layer, y, x).
-
-        Slicing intervals may be half-bounded, by providing None:
-
-        * To select 500.0 <= x <= 1000.0:
-          ``clip_box(x_min=500.0, x_max=1000.0)``.
-        * To select x <= 1000.0: ``clip_box(x_min=None, x_max=1000.0)``
-          or ``clip_box(x_max=1000.0)``.
-        * To select x >= 500.0: ``clip_box(x_min = 500.0, x_max=None.0)``
-          or ``clip_box(x_min=1000.0)``.
+        Clip a package by a bounding box (time, y, x).
 
         Parameters
         ----------
-        time_min: optional
+        time_min: optional, np.datetime64
+            Start time to select. Data will be forward filled to this date. If
+            time_min is before the start time of the dataset, data is
+            backfilled.
         time_max: optional
+            End time to select.
         x_min: optional, float
+            Minimum x-coordinate to select.
         x_max: optional, float
+            Maximum x-coordinate to select.
         y_min: optional, float
+            Minimum y-coordinate to select.
         y_max: optional, float
+            Maximum y-coordinate to select.
 
         Returns
         -------
-        clipped: Package
+        clipped : Package
+            A new package that is clipped to the specified bounding box.
+
+        Examples
+        --------
+        Slicing intervals may be half-bounded, by providing None:
+
+        To select 500.0 <= x <= 1000.0:
+
+        >>> pkg.clip_box(x_min=500.0, x_max=1000.0)
+
+        To select x <= 1000.0:
+
+        >>> pkg.clip_box(x_max=1000.0)``
+
+        To select x >= 500.0: 
+        
+        >>> pkg.clip_box(x_min=500.0)
+
+        To select a time interval, you can use datetime64:
+
+        >>> pkg.clip_box(time_min=np.datetime64("2020-01-01"), time_max=np.datetime64("2020-12-31"))
+
         """
         if not self._is_clipping_supported():
             raise ValueError("this package does not support clipping.")

--- a/imod/msw/pkgbase.py
+++ b/imod/msw/pkgbase.py
@@ -315,8 +315,8 @@ class MetaSwapPackage(abc.ABC):
 
         >>> pkg.clip_box(x_max=1000.0)``
 
-        To select x >= 500.0: 
-        
+        To select x >= 500.0:
+
         >>> pkg.clip_box(x_min=500.0)
 
         To select a time interval, you can use datetime64:

--- a/imod/prepare/partition.py
+++ b/imod/prepare/partition.py
@@ -83,7 +83,7 @@ def create_partition_labels(
         A label array with the same size as the top layer of idomain, where each
         element is the partition number to which the column of gridblocks at that
         location belongs.
-    
+
     Examples
     --------
     Create partition labels for a simulation:

--- a/imod/tests/test_mf6/test_mf6_gwfgwf.py
+++ b/imod/tests/test_mf6/test_mf6_gwfgwf.py
@@ -8,6 +8,7 @@ import xarray as xr
 
 import imod
 
+
 def remove_comment_lines(textblock: str) -> str:
     """
     Removes the comment lines from the gwfgwf file content, we don't want the tests to be sensitive to the

--- a/imod/tests/test_mf6/test_mf6_gwfgwf.py
+++ b/imod/tests/test_mf6/test_mf6_gwfgwf.py
@@ -7,8 +7,6 @@ import pytest
 import xarray as xr
 
 import imod
-from imod.prepare.partition import create_partition_labels
-
 
 def remove_comment_lines(textblock: str) -> str:
     """
@@ -138,12 +136,14 @@ class TestGwfgwf:
 
 
 @pytest.mark.parametrize("newton_option", [False, True])
-def test_option_newton_propagated(circle_model, newton_option, tmp_path):
+def test_option_newton_propagated(
+    circle_model: imod.mf6.Modflow6Simulation, newton_option: bool, tmp_path
+):
     # set newton option on original model
     circle_model["GWF_1"].set_newton(newton_option)
 
     # split original model
-    label_array = create_partition_labels(circle_model, 3)
+    label_array = circle_model.create_partition_labels(3)
     split_simulation = circle_model.split(label_array)
 
     # check that the created exchagnes have the same newton option
@@ -154,12 +154,14 @@ def test_option_newton_propagated(circle_model, newton_option, tmp_path):
 
 
 @pytest.mark.parametrize("xt3d_option", [False, True])
-def test_option_xt3d_propagated(circle_model, xt3d_option, tmp_path):
+def test_option_xt3d_propagated(
+    circle_model: imod.mf6.Modflow6Simulation, xt3d_option: bool, tmp_path
+):
     # set newton option on original model
     circle_model["GWF_1"]["npf"].set_xt3d_option(xt3d_option, is_rhs=xt3d_option)
 
     # split original model
-    label_array = create_partition_labels(circle_model, 3)
+    label_array = circle_model.create_partition_labels(3)
     split_simulation = circle_model.split(label_array)
 
     # check that the created exchanges have the same newton option
@@ -170,12 +172,14 @@ def test_option_xt3d_propagated(circle_model, xt3d_option, tmp_path):
 
 
 @pytest.mark.parametrize("variablecv_option", [False, True])
-def test_option_variablecv_propagated(circle_model, variablecv_option: bool, tmp_path):
+def test_option_variablecv_propagated(
+    circle_model: imod.mf6.Modflow6Simulation, variablecv_option: bool, tmp_path
+):
     # set variablecv option on original model
     circle_model["GWF_1"]["npf"]["variable_vertical_conductance"] = variablecv_option
 
     # split original model
-    label_array = create_partition_labels(circle_model, 3)
+    label_array = circle_model.create_partition_labels(3)
     split_simulation = circle_model.split(label_array)
 
     # check that the created exchanges have the same variablecv option
@@ -186,13 +190,15 @@ def test_option_variablecv_propagated(circle_model, variablecv_option: bool, tmp
 
 
 @pytest.mark.parametrize("dewatered_option", [False, True])
-def test_option_dewatered_propagated(circle_model, dewatered_option: bool, tmp_path):
+def test_option_dewatered_propagated(
+    circle_model: imod.mf6.Modflow6Simulation, dewatered_option: bool, tmp_path
+):
     # set dewatered option on original model
     circle_model["GWF_1"]["npf"]["variable_vertical_conductance"] = True
     circle_model["GWF_1"]["npf"]["dewatered"] = dewatered_option
 
     # split original model
-    label_array = create_partition_labels(circle_model, 3)
+    label_array = circle_model.create_partition_labels(3)
     split_simulation = circle_model.split(label_array)
 
     # check that the created exchanges have the same dewatered option
@@ -203,13 +209,15 @@ def test_option_dewatered_propagated(circle_model, dewatered_option: bool, tmp_p
 
 
 @pytest.mark.parametrize("budget_option", [False, True])
-def test_save_flows_propagated(circle_model, budget_option: bool, tmp_path):
+def test_save_flows_propagated(
+    circle_model: imod.mf6.Modflow6Simulation, budget_option: bool, tmp_path
+):
     # set budget option on original model
     if not budget_option:
         circle_model["GWF_1"]["oc"].dataset["save_budget"] = None
 
     # split original model
-    label_array = create_partition_labels(circle_model, 3)
+    label_array = circle_model.create_partition_labels(3)
     split_simulation = circle_model.split(label_array)
 
     # check that the created exchanges have the same dewatered option

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partition_generation.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partition_generation.py
@@ -2,7 +2,6 @@ import numpy as np
 import xarray as xr
 import xugrid as xu
 
-from imod.prepare.partition import create_partition_labels
 from imod.mf6 import Modflow6Simulation
 
 

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partition_generation.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partition_generation.py
@@ -3,11 +3,12 @@ import xarray as xr
 import xugrid as xu
 
 from imod.prepare.partition import create_partition_labels
+from imod.mf6 import Modflow6Simulation
 
 
-def test_partition_2d_unstructured(circle_model):
+def test_partition_2d_unstructured(circle_model: Modflow6Simulation):
     for nr_partitions in range(1, 20):
-        label_array = create_partition_labels(circle_model, nr_partitions)
+        label_array = circle_model.create_partition_labels(nr_partitions)
         assert isinstance(label_array, xu.UgridDataArray)
         # check that the labes up to nr_partitions -1 appear in the label array, and not any others
         unique, counts = np.unique(label_array, return_counts=True)
@@ -21,11 +22,11 @@ def test_partition_2d_unstructured(circle_model):
         assert label_array.name == "label"
 
 
-def test_partition_2d_unstructured_with_weights(circle_model):
+def test_partition_2d_unstructured_with_weights(circle_model: Modflow6Simulation):
     weights = circle_model["GWF_1"].domain.isel(layer=0).copy()
     weights[:50] = 10
     for nr_partitions in range(2, 20):
-        label_array = create_partition_labels(circle_model, nr_partitions, weights)
+        label_array = circle_model.create_partition_labels(nr_partitions, weights)
         assert isinstance(label_array, xu.UgridDataArray)
         # check that the labes up to nr_partitions -1 appear in the label array, and not any others
         unique, counts = np.unique(label_array, return_counts=True)
@@ -39,7 +40,7 @@ def test_partition_2d_unstructured_with_weights(circle_model):
         assert label_array.name == "label"
 
 
-def test_partition_2d_structured(twri_model):
+def test_partition_2d_structured(twri_model: Modflow6Simulation):
     # We skip a few partition numbers which would give an error. This would
     # happen if the number of partitions in the x or y direction would result in
     # less then 3 gridblocks per partition. For example if we ask for 7
@@ -49,7 +50,7 @@ def test_partition_2d_structured(twri_model):
     # split as 2 and 4 partitions on x and y and would work.
     partition_numbers = [1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 15, 16, 20]
     for nr_partitions in partition_numbers:
-        label_array = create_partition_labels(twri_model, nr_partitions)
+        label_array = twri_model.create_partition_labels(nr_partitions)
         assert isinstance(label_array, xr.DataArray)
         unique, counts = np.unique(label_array, return_counts=True)
         # Check that the labes up to nr_partitions -1 appear in the label array, and not any others
@@ -63,7 +64,7 @@ def test_partition_2d_structured(twri_model):
         assert label_array.name == "label"
 
 
-def test_partition_2d_structured_with_weights(twri_model):
+def test_partition_2d_structured_with_weights(twri_model: Modflow6Simulation):
     # We skip a few partition numbers which would give an error. This would
     # happen if the number of partitions in the x or y direction would result in
     # less then 3 gridblocks per partition. For example if we ask for 7
@@ -75,7 +76,7 @@ def test_partition_2d_structured_with_weights(twri_model):
     weights[:5, :5] = 10
     partition_numbers = [2, 3, 4, 5, 6, 8, 9, 10, 12, 15, 16, 20]
     for nr_partitions in partition_numbers:
-        label_array = create_partition_labels(twri_model, nr_partitions, weights)
+        label_array = twri_model.create_partition_labels(nr_partitions, weights)
         assert isinstance(label_array, xr.DataArray)
         unique, counts = np.unique(label_array, return_counts=True)
         # Check that the labes up to nr_partitions -1 appear in the label array, and not any others


### PR DESCRIPTION
Fixes #1601

# Description
- Add example Modflow6Simulation methods
- Refactor: change argument type of ``imod.prepare.create_partition_labels``, and add ``imod.mf6.Modflow6Simulation.create_partition_labels``. This disentangles the ``prepare`` module more from the ``mf6`` module, as now the ``imod.prepare.create_partition_labels`` function doesn't need to be aware of Modflow6Simulation objects.

@phaehnel this change probably breaks your script:

To fix it, change:

```
labels = imod.prepare.create_partition_labels(mf6_sim, n_partitions)
```

to:

```
labels = mf6_sim.create_partition_labels(n_partitions)
```

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [x] **If feature added**: Added feature to API documentation
