### PR TITLE
Issue #1593 fix bug where SourceSinkMixing.from_flow_model throws error when the HFB package is added

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -41,6 +41,9 @@ Fixed
   :class:`imod.mf6.SingleLayerHorizontalFlowBarrierResistance` and other HFB
   packages would have resistances that were double the expected value with
   xugrid >= 0.14.2
+- Fixed bug where :meth:`imod.mf6.SourceSinkMixing.from_flow_model` would return
+  an error upon adding a package which cannot have a ``concentration``, such as 
+  :class:`imod.mf6.HorizontalFlowBarrierResistance`.
 
 Changed
 ~~~~~~~


### PR DESCRIPTION
Fixes #1593

# Description
Properly check whether a package is a concentration package for the SSM package

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
