### PR TITLE
Extend docstring with more examples

### DIFF
--- a/imod/visualize/cross_sections.py
+++ b/imod/visualize/cross_sections.py
@@ -197,6 +197,18 @@ def cross_section(
 
     >>> kwargs_aquitards = {"hatch": "/", "edgecolor": "k"}
     >>> imod.visualize.cross_section(da, colors, levels, aquitards=aquitards, kwargs_aquitards)
+
+    To turn off the colorbar:
+
+    >>> kwargs_colorbar = {"plot_colorbar": False}
+    >>> imod.visualize.cross_section(da, colors, levels, kwargs_colorbar=kwargs_colorbar)
+
+    To turn off the white triangles in the colorbar if values exceed the minimum
+    or maximum levels:
+
+    >>> kwargs_colorbar = {"whiten_triangles": False}
+    >>> imod.visualize.cross_section(da, colors, levels, kwargs_colorbar=kwargs_colorbar)
+
     """
     da = da.copy(deep=False)
     if aquitards is not None:


### PR DESCRIPTION
Fixes #1635

# Description
Extend the docstring with some examples to turn off the colorbar and the white triangles in it.

# Checklist
- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
