### PR TITLE
Issue #1632 add ATS pkg

### DIFF
--- a/examples/mf6/circle_transport.py
+++ b/examples/mf6/circle_transport.py
@@ -198,11 +198,12 @@ simulation.create_time_discretization(additional_times=simtimes)
 # %%
 #
 # We want to use adaptive time stepping to ensure stable results. We set the
-# initial time step to 0.001 year, the minimum time step to 0.0001 year, and the
-# maximum time step to 1 year. We will set the ``ats_percel`` in the Advection
-# package in the next section to let MODFLOW 6 compute an appropriate time step
-# based on the velocity field: A solute parcel should not travel more than one
-# cell in a time step.
+# initial time step to 0.1 day, the minimum time step to 0.1 day, and the
+# maximum time step to 50 days. The multiplier is set to 2.0 so that consecutive
+# timesteps will be increased by a factor of 2. We will set the ``ats_percel``
+# in the Advection package in the next section to let MODFLOW 6 compute an
+# appropriate time step based on the velocity field: A solute parcel should not
+# travel more than one cell in a time step.
 
 simulation["ats"] = imod.mf6.AdaptiveTimeStepping(
     dt_init=1e-1,
@@ -259,8 +260,7 @@ transport_model["dsp"] = imod.mf6.Dispersion(
     xt3d_off=False,
     xt3d_rhs=False,
 )
-# transport_model["adv"] = imod.mf6.AdvectionTVD(ats_percel=0.5)
-transport_model["adv"] = imod.mf6.AdvectionTVD()
+transport_model["adv"] = imod.mf6.AdvectionTVD(ats_percel=0.5)
 transport_model["mst"] = imod.mf6.MobileStorageTransfer(porosity)
 
 # %%

--- a/imod/mf6/__init__.py
+++ b/imod/mf6/__init__.py
@@ -4,6 +4,7 @@ Create a Modflow 6 model.
 
 from imod.mf6.adv import AdvectionCentral, AdvectionTVD, AdvectionUpstream
 from imod.mf6.api_package import ApiPackage
+from imod.mf6.ats import AdaptiveTimeStepping
 from imod.mf6.buy import Buoyancy
 from imod.mf6.chd import ConstantHead
 from imod.mf6.cnc import ConstantConcentration

--- a/imod/mf6/adv.py
+++ b/imod/mf6/adv.py
@@ -75,8 +75,8 @@ class AdvectionUpstream(Advection):
 
     def __init__(self, ats_percel: Optional[float] = None, validate: bool = True):
         dict_dataset = {"scheme": "upstream", "ats_percel": ats_percel}
-        self._validate_init_schemata(validate)
         super().__init__(dict_dataset)
+        self._validate_init_schemata(validate)
 
 
 class AdvectionCentral(Advection):

--- a/imod/mf6/adv.py
+++ b/imod/mf6/adv.py
@@ -57,7 +57,7 @@ class AdvectionUpstream(Advection):
         of the time step. ``ats_percel`` must be greater than zero. If a value
         of zero is specified for ``ats_percel`` the program will automatically
         reset it to an internal no data value to indicate that time steps should
-        not be subject to this constraint.
+        not be subject to this constraint. Requires MODFLOW 6.6.0 or higher.
     """
 
     def __init__(self, ats_percel: Optional[float] = None):
@@ -89,7 +89,7 @@ class AdvectionCentral(Advection):
         of the time step. ``ats_percel`` must be greater than zero. If a value
         of zero is specified for ``ats_percel`` the program will automatically
         reset it to an internal no data value to indicate that time steps should
-        not be subject to this constraint.
+        not be subject to this constraint. Requires MODFLOW 6.6.0 or higher.
     """
 
     def __init__(self, ats_percel: Optional[float] = None):
@@ -116,7 +116,7 @@ class AdvectionTVD(Advection):
         of the time step. ``ats_percel`` must be greater than zero. If a value
         of zero is specified for ``ats_percel`` the program will automatically
         reset it to an internal no data value to indicate that time steps should
-        not be subject to this constraint.
+        not be subject to this constraint. Requires MODFLOW 6.6.0 or higher.
     """
 
     def __init__(self, ats_percel: Optional[float] = None):

--- a/imod/mf6/adv.py
+++ b/imod/mf6/adv.py
@@ -12,13 +12,24 @@ robust alternative.
 from copy import deepcopy
 from typing import Optional
 
+import numpy as np
+
 from imod.common.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.package import Package
+from imod.schemata import AllValueSchema, DimsSchema, DTypeSchema
 
 
 class Advection(Package, IRegridPackage):
     _pkg_id = "adv"
     _template = Package._initialize_template(_pkg_id)
+
+    _init_schemata = {
+        "ats_percel": [
+            DimsSchema(),
+            DTypeSchema(np.floating),
+            AllValueSchema(">", 0.0),
+        ],
+    }
 
     def _render(self, directory, pkgname, globaltimes, binary):
         render_dict = {}
@@ -58,10 +69,13 @@ class AdvectionUpstream(Advection):
         of zero is specified for ``ats_percel`` the program will automatically
         reset it to an internal no data value to indicate that time steps should
         not be subject to this constraint. Requires MODFLOW 6.6.0 or higher.
+    validate: bool, optional
+        Validate the package upon initialization. Defaults to True.
     """
 
-    def __init__(self, ats_percel: Optional[float] = None):
+    def __init__(self, ats_percel: Optional[float] = None, validate: bool = True):
         dict_dataset = {"scheme": "upstream", "ats_percel": ats_percel}
+        self._validate_init_schemata(validate)
         super().__init__(dict_dataset)
 
 
@@ -90,11 +104,14 @@ class AdvectionCentral(Advection):
         of zero is specified for ``ats_percel`` the program will automatically
         reset it to an internal no data value to indicate that time steps should
         not be subject to this constraint. Requires MODFLOW 6.6.0 or higher.
+    validate: bool, optional
+        Validate the package upon initialization. Defaults to True.
     """
 
-    def __init__(self, ats_percel: Optional[float] = None):
+    def __init__(self, ats_percel: Optional[float] = None, validate: bool = True):
         dict_dataset = {"scheme": "central", "ats_percel": ats_percel}
         super().__init__(dict_dataset)
+        self._validate_init_schemata(validate)
 
 
 class AdvectionTVD(Advection):
@@ -117,8 +134,11 @@ class AdvectionTVD(Advection):
         of zero is specified for ``ats_percel`` the program will automatically
         reset it to an internal no data value to indicate that time steps should
         not be subject to this constraint. Requires MODFLOW 6.6.0 or higher.
+    validate: bool, optional
+        Validate the package upon initialization. Defaults to True.
     """
 
-    def __init__(self, ats_percel: Optional[float] = None):
+    def __init__(self, ats_percel: Optional[float] = None, validate: bool = True):
         dict_dataset = {"scheme": "TVD", "ats_percel": ats_percel}
         super().__init__(dict_dataset)
+        self._validate_init_schemata(validate)

--- a/imod/mf6/adv.py
+++ b/imod/mf6/adv.py
@@ -10,6 +10,7 @@ robust alternative.
 """
 
 from copy import deepcopy
+from typing import Optional
 
 from imod.common.interfaces.iregridpackage import IRegridPackage
 from imod.mf6.package import Package
@@ -18,10 +19,6 @@ from imod.mf6.package import Package
 class Advection(Package, IRegridPackage):
     _pkg_id = "adv"
     _template = Package._initialize_template(_pkg_id)
-
-    def __init__(self, scheme: str):
-        dict_dataset = {"scheme": scheme}
-        super().__init__(dict_dataset)
 
     def _render(self, directory, pkgname, globaltimes, binary):
         scheme = self.dataset["scheme"].item()
@@ -40,15 +37,27 @@ class AdvectionUpstream(Advection):
     The upstream weighting (first order upwind) scheme sets the concentration
     at the cellface between two adjacent cells equal to the concentration in
     the cell where the flow comes from. It surpresses oscillations.
-    Note: all constructor arguments will be ignored
+
+    Parameters
+    ----------
+    ats_percel: float, optional
+        Fractional cell distance submitted by the ADV Package to the
+        AdaptiveTimeStepping (ATS) package. If ``ats_percel`` is specified and
+        the ATS Package is active, a time step calculation will be made for each
+        cell based on flow through the cell and cell properties. The largest
+        time step will be calculated such that the advective fractional cell
+        distance (``ats_percel``) is not exceeded for any active cell in the
+        grid. This time-step constraint will be submitted to the ATS Package,
+        perhaps with constraints submitted by other packages, in the calculation
+        of the time step. ``ats_percel`` must be greater than zero. If a value
+        of zero is specified for ``ats_percel`` the program will automatically
+        reset it to an internal no data value to indicate that time steps should
+        not be subject to this constraint.
     """
 
-    def __init__(self, scheme: str = "upstream"):
-        if not scheme == "upstream":
-            raise ValueError(
-                "error in scheme parameter. Should be 'upstream' if present."
-            )
-        super().__init__(scheme="upstream")
+    def __init__(self, ats_percel: Optional[float] = None):
+        dict_dataset = {"scheme": "upstream", "ats_percel": ats_percel}
+        super().__init__(dict_dataset)
 
 
 class AdvectionCentral(Advection):
@@ -60,25 +69,51 @@ class AdvectionCentral(Advection):
     grids without equal spacing between connected cells, it is retained here
     for consistency with nomenclature used by other MODFLOW-based transport
     programs, such as MT3D.
-    Note: all constructor arguments will be ignored
+
+    Parameters
+    ----------
+    ats_percel: float, optional
+        Fractional cell distance submitted by the ADV Package to the
+        AdaptiveTimeStepping (ATS) package. If ``ats_percel`` is specified and
+        the ATS Package is active, a time step calculation will be made for each
+        cell based on flow through the cell and cell properties. The largest
+        time step will be calculated such that the advective fractional cell
+        distance (``ats_percel``) is not exceeded for any active cell in the
+        grid. This time-step constraint will be submitted to the ATS Package,
+        perhaps with constraints submitted by other packages, in the calculation
+        of the time step. ``ats_percel`` must be greater than zero. If a value
+        of zero is specified for ``ats_percel`` the program will automatically
+        reset it to an internal no data value to indicate that time steps should
+        not be subject to this constraint.
     """
 
-    def __init__(self, scheme: str = "central"):
-        if not scheme == "central":
-            raise ValueError(
-                "error in scheme parameter. Should be 'central' if present."
-            )
-        super().__init__(scheme="central")
+    def __init__(self, ats_percel: Optional[float] = None):
+        dict_dataset = {"scheme": "central", "ats_percel": ats_percel}
+        super().__init__(dict_dataset)
 
 
 class AdvectionTVD(Advection):
     """
     An implicit second order TVD scheme. More expensive than upstream
     weighting but more robust.
-    Note: all constructor arguments will be ignored
+
+    Parameters
+    ----------
+    ats_percel: float, optional
+        Fractional cell distance submitted by the ADV Package to the
+        AdaptiveTimeStepping (ATS) package. If ``ats_percel`` is specified and
+        the ATS Package is active, a time step calculation will be made for each
+        cell based on flow through the cell and cell properties. The largest
+        time step will be calculated such that the advective fractional cell
+        distance (``ats_percel``) is not exceeded for any active cell in the
+        grid. This time-step constraint will be submitted to the ATS Package,
+        perhaps with constraints submitted by other packages, in the calculation
+        of the time step. ``ats_percel`` must be greater than zero. If a value
+        of zero is specified for ``ats_percel`` the program will automatically
+        reset it to an internal no data value to indicate that time steps should
+        not be subject to this constraint.
     """
 
-    def __init__(self, scheme: str = "TVD"):
-        if not scheme == "TVD":
-            raise ValueError("error in scheme parameter. Should be 'TVD' if present.")
-        super().__init__(scheme="TVD")
+    def __init__(self, ats_percel: Optional[float] = None):
+        dict_dataset = {"scheme": "TVD", "ats_percel": ats_percel}
+        super().__init__(dict_dataset)

--- a/imod/mf6/adv.py
+++ b/imod/mf6/adv.py
@@ -21,8 +21,13 @@ class Advection(Package, IRegridPackage):
     _template = Package._initialize_template(_pkg_id)
 
     def _render(self, directory, pkgname, globaltimes, binary):
-        scheme = self.dataset["scheme"].item()
-        return self._template.render({"scheme": scheme})
+        render_dict = {}
+        render_dict["scheme"] = self.dataset["scheme"].item()
+        if "ats_percel" in self.dataset and self._valid(
+            self.dataset["ats_percel"].item()
+        ):
+            render_dict["ats_percel"] = self.dataset["ats_percel"].item()
+        return self._template.render(render_dict)
 
     def mask(self, _) -> Package:
         """

--- a/imod/mf6/ats.py
+++ b/imod/mf6/ats.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from imod.mf6.package import Package
-from imod.schemata import DimsSchema, DTypeSchema, AllValueSchema
+from imod.schemata import AllValueSchema, DimsSchema, DTypeSchema
 
 
 class AdaptiveTimeStepping(Package):
@@ -56,7 +56,13 @@ class AdaptiveTimeStepping(Package):
     _keyword_map = {}
     _template = Package._initialize_template(_pkg_id)
 
-    _period_data = ("dt_init", "dt_min", "dt_max", "dt_multiplier", "dt_fail_multiplier")
+    _period_data = (
+        "dt_init",
+        "dt_min",
+        "dt_max",
+        "dt_multiplier",
+        "dt_fail_multiplier",
+    )
     _init_schemata = {
         "dt_init": [DimsSchema("time"), DTypeSchema(np.floating)],
         "dt_min": [DimsSchema("time"), DTypeSchema(np.floating)],
@@ -72,7 +78,7 @@ class AdaptiveTimeStepping(Package):
     }
 
     _write_schemata = {
-        "dt_init": [AllValueSchema(">=", 0.0)], 
+        "dt_init": [AllValueSchema(">=", 0.0)],
         "dt_min": [AllValueSchema("<", "dt_max"), AllValueSchema(">", 0.0)],
         "dt_multiplier": [AllValueSchema("==", 0.0) | AllValueSchema(">=", 1.0)],
     }

--- a/imod/mf6/ats.py
+++ b/imod/mf6/ats.py
@@ -87,7 +87,7 @@ class AdaptiveTimeStepping(Package):
     _init_schemata = {
         "dt_init": [DimsSchema("time") | DimsSchema(), DTypeSchema(np.floating)],
         "dt_min": [DimsSchema("time") | DimsSchema(), DTypeSchema(np.floating)],
-        "dt_max": [DimsSchema("time"), DTypeSchema(np.floating)],
+        "dt_max": [DimsSchema("time") | DimsSchema(), DTypeSchema(np.floating)],
         "dt_multiplier": [
             DimsSchema("time") | DimsSchema(),
             DTypeSchema(np.floating),

--- a/imod/mf6/ats.py
+++ b/imod/mf6/ats.py
@@ -135,15 +135,17 @@ class AdaptiveTimeStepping(Package):
         one = np.int64(1)
         if "time" in self.dataset:  # one of bin_ds has time
             package_times = self.dataset.coords["time"].values
+            maxats = len(package_times)
             starts = np.searchsorted(globaltimes, package_times) + one
             for i, start in enumerate(starts):
                 data = self.dataset.sel(time=package_times[i])
                 _assign_data_to_perioddata(perioddata, self._period_data, start, data)
         else:
             _assign_data_to_perioddata(perioddata, self._period_data, one, self.dataset)
+            maxats = 1
 
         d: dict[str, int | _PeriodDataType] = {}
-        d["maxats"] = len(package_times)
+        d["maxats"] = maxats
         d["perioddata"] = perioddata
         return d
 

--- a/imod/mf6/ats.py
+++ b/imod/mf6/ats.py
@@ -1,0 +1,118 @@
+import numpy as np
+
+from imod.mf6.package import Package
+from imod.schemata import DimsSchema, DTypeSchema, AllValueSchema
+
+
+class AdaptiveTimeStepping(Package):
+    """
+    Adaptive Time Stepping (ATS) Package for MODFLOW 6.
+
+    This package allows for adaptive time stepping in the simulation, adjusting
+    the time step size based on model convergence and stability criteria.
+
+    Parameters
+    ----------
+    dt_init: xr.DataArray of floats
+        Initial time step length, ``dt0`` in MODFLOW 6. If zero, then the final time
+        step from the previous stress period will be used as the initial time
+        step.
+    dt_min: xr.DataArray of floats
+        Minimum allowed time length size. This value must be greater than zero
+        and less than dtmax. dtmin must be a small value in order to ensure that
+        simulation times end at the end of stress periods and the end of the
+        simulation. A small value, such as 1.e-5, is recommended.
+    dt_max: xr.DataArray of floats
+        Maximum allowed time step length. This value must be greater than dtmin.
+    dt_multiplier: xr.DataArray of floats
+        Multiplier for the time step length, ``dtadj`` in MODFLOW6. If the
+        number of outer solver iterations are less than the product of the
+        maximum number of outer iterations (OUTER_MAXIMUM) and
+        ATS_OUTER_MAXIMUM_FRACTION (an optional variable in the IMS input file
+        with a default value of 1/3), then the time step length is multiplied by
+        ``dt_multiplier``. If the number of outer solver iterations are greater
+        than the product of the maximum number of outer iterations and 1.0 minus
+        ATS_OUTER_MAXIMUM_FRACTION, then the time step length is divided by
+        ``dt_multiplier``. ``dt_multiplier`` must be zero, one, or greater than
+        one. If ``dt_multiplier`` is zero or one, then it has no effect on the
+        simulation. A value between 2.0 and 5.0 can be used as an initial
+        estimate.
+    dt_fail_multiplier: xr.DataArray of floats
+        Divisor of the time step length when a time step fails to converge. If
+        there is solver failure, then the time step will be tried again with a
+        shorter time step length calculated as the previous time step length
+        divided by dt_fail_multiplier. dt_fail_multiplier must be zero, one, or
+        greater than one. If dt_fail_multiplier is zero or one, then time steps
+        will not be retried with shorter lengths. In this case, the program will
+        terminate with an error, or it will continue of the CONTINUE option is
+        set in the simulation name file. Initial tests with this variable should
+        be set to 5.0 or larger to determine if convergence can be achieved.
+    validate: {True, False}
+        Flag to indicate whether the package should be validated upon
+        initialization. Defaults to True.
+    """
+
+    _pkg_id = "ats"
+    _keyword_map = {}
+    _template = Package._initialize_template(_pkg_id)
+
+    _period_data = ("dt_init", "dt_min", "dt_max", "dt_multiplier", "dt_fail_multiplier")
+    _init_schemata = {
+        "dt_init": [DimsSchema("time"), DTypeSchema(np.floating)],
+        "dt_min": [DimsSchema("time"), DTypeSchema(np.floating)],
+        "dt_max": [DimsSchema("time"), DTypeSchema(np.floating)],
+        "dt_multiplier": [
+            DimsSchema("time"),
+            DTypeSchema(np.floating),
+        ],
+        "dt_fail_multiplier": [
+            DimsSchema("time"),
+            DTypeSchema(np.floating),
+        ],
+    }
+
+    _write_schemata = {
+        "dt_init": [AllValueSchema(">=", 0.0)], 
+        "dt_min": [AllValueSchema("<", "dt_max"), AllValueSchema(">", 0.0)],
+        "dt_multiplier": [AllValueSchema("==", 0.0) | AllValueSchema(">=", 1.0)],
+    }
+
+    def __init__(
+        self, dt_init, dt_min, dt_max, dt_multiplier, dt_fail_multiplier, validate=True
+    ):
+        dict_dataset = {
+            "dt_init": dt_init,
+            "dt_min": dt_min,
+            "dt_max": dt_max,
+            "dt_multiplier": dt_multiplier,
+            "dt_fail_multiplier": dt_fail_multiplier,
+        }
+        super().__init__(dict_dataset)
+        self._validate_init_schemata(validate)
+
+    def _render(self, directory, pkgname, globaltimes, binary):
+        perioddata: dict[np.int64, str] = {}
+        # Force to np.int64 for mypy and numpy >= 2.2.4
+        one = np.int64(1)
+        if "time" in self.dataset:  # one of bin_ds has time
+            package_times = self.dataset.coords["time"].values
+            starts = np.searchsorted(globaltimes, package_times) + one
+            for start in starts:
+                data = self.dataset.sel(time=package_times[start - one])
+                perioddata[start] = [data[key].values[()] for key in self._period_data]
+
+        d = {}
+        d["maxats"] = len(package_times)
+        d["perioddata"] = perioddata
+        return self._template.render(d)
+
+    def _write(self, pkgname, globaltimes, write_context):
+        ats_content = self._render(
+            write_context.write_directory,
+            pkgname,
+            globaltimes,
+            write_context.use_binary,
+        )
+        timedis_path = write_context.write_directory / f"{pkgname}.ats"
+        with open(timedis_path, "w") as f:
+            f.write(ats_content)

--- a/imod/mf6/ats.py
+++ b/imod/mf6/ats.py
@@ -1,11 +1,12 @@
-from typing import TypeAlias
+import pathlib
+from typing import Any, Dict, TypeAlias, Union
 
 import numpy as np
 
 from imod.mf6.package import Package
 from imod.mf6.write_context import WriteContext
 from imod.schemata import AllValueSchema, DimsSchema, DTypeSchema
-from imod.typing import GridDataset, Union
+from imod.typing import GridDataset
 
 _PeriodDataType: TypeAlias = dict[np.int64, list]
 _PeriodDataVarNames: TypeAlias = tuple[str, str, str, str, str]
@@ -122,7 +123,13 @@ class AdaptiveTimeStepping(Package):
         super().__init__(dict_dataset)
         self._validate_init_schemata(validate)
 
-    def _render(self, directory, pkgname, globaltimes, binary):
+    def _get_render_dictionary(
+        self,
+        directory: pathlib.Path,
+        pkgname: str,
+        globaltimes: Union[list[np.datetime64], np.ndarray],
+        binary: bool,
+    ) -> Dict[str, Any]:
         perioddata: _PeriodDataType = {}
         # Force to np.int64 for mypy and numpy >= 2.2.4
         one = np.int64(1)
@@ -138,7 +145,7 @@ class AdaptiveTimeStepping(Package):
         d: dict[str, int | _PeriodDataType] = {}
         d["maxats"] = len(package_times)
         d["perioddata"] = perioddata
-        return self._template.render(d)
+        return d
 
     def _validate(self, schemata: dict, **kwargs):
         # Insert additional kwargs

--- a/imod/mf6/ats.py
+++ b/imod/mf6/ats.py
@@ -103,14 +103,21 @@ class AdaptiveTimeStepping(Package):
         if "time" in self.dataset:  # one of bin_ds has time
             package_times = self.dataset.coords["time"].values
             starts = np.searchsorted(globaltimes, package_times) + one
-            for start in starts:
-                data = self.dataset.sel(time=package_times[start - one])
+            for i, start in enumerate(starts):
+                data = self.dataset.sel(time=package_times[i])
                 perioddata[start] = [data[key].values[()] for key in self._period_data]
 
         d = {}
         d["maxats"] = len(package_times)
         d["perioddata"] = perioddata
         return self._template.render(d)
+
+    def _validate(self, schemata, **kwargs):
+        # Insert additional kwargs
+        kwargs["dt_max"] = self["dt_max"]
+        errors = super()._validate(schemata, **kwargs)
+
+        return errors
 
     def _write(self, pkgname, globaltimes, write_context):
         ats_content = self._render(

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -302,7 +302,7 @@ class Package(PackageBase, IPackage, abc.ABC):
         pkgname: str,
         globaltimes: Union[list[np.datetime64], np.ndarray],
         write_context: WriteContext,
-    ):
+    ) -> None:
         directory = write_context.write_directory
         binary = write_context.use_binary
         self._write_blockfile(pkgname, globaltimes, write_context)

--- a/imod/mf6/package.py
+++ b/imod/mf6/package.py
@@ -48,6 +48,7 @@ from imod.mf6.auxiliary_variables import (
 from imod.mf6.pkgbase import (
     EXCHANGE_PACKAGES,
     TRANSPORT_PACKAGES,
+    UTIL_PACKAGES,
     PackageBase,
 )
 from imod.mf6.validation_settings import ValidationSettings, trim_time_dimension
@@ -110,6 +111,8 @@ class Package(PackageBase, IPackage, abc.ABC):
             fname = f"gwt-{pkg_id}.j2"
         elif pkg_id in EXCHANGE_PACKAGES:
             fname = f"exg-{pkg_id}.j2"
+        elif pkg_id in UTIL_PACKAGES:
+            fname = f"utl-{pkg_id}.j2"
         elif pkg_id == "api":
             fname = f"{pkg_id}.j2"
         else:

--- a/imod/mf6/pkgbase.py
+++ b/imod/mf6/pkgbase.py
@@ -21,6 +21,7 @@ TRANSPORT_PACKAGES = ("adv", "dsp", "ssm", "mst", "ist", "src")
 EXCHANGE_PACKAGES = ("gwfgwf", "gwfgwt", "gwtgwt")
 UTIL_PACKAGES = ("ats", "hpc")
 
+
 def _is_scalar_nan(da: GridDataArray):
     """
     Test if is_scalar_nan, carefully avoid loading grids in memory

--- a/imod/mf6/pkgbase.py
+++ b/imod/mf6/pkgbase.py
@@ -19,7 +19,7 @@ from imod.typing.grid import (
 
 TRANSPORT_PACKAGES = ("adv", "dsp", "ssm", "mst", "ist", "src")
 EXCHANGE_PACKAGES = ("gwfgwf", "gwfgwt", "gwtgwt")
-
+UTIL_PACKAGES = ("ats", "hpc")
 
 def _is_scalar_nan(da: GridDataArray):
     """

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -159,7 +159,11 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         Get package key that belongs to a certain pkg_id, since the keys are
         user specified.
         """
-        key = [pkgname for pkgname, pkg in self.items() if pkg._pkg_id == pkg_id]
+        key = [
+            pkgname
+            for pkgname, pkg in self.items()
+            if isinstance(pkg, Package) and (pkg._pkg_id == pkg_id)
+        ]
         nkey = len(key)
         if nkey > 1:
             raise ValueError(f"Multiple instances of {key} detected")

--- a/imod/mf6/timedis.py
+++ b/imod/mf6/timedis.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from imod.logging import init_log_decorator
 from imod.mf6.package import Package
+from imod.mf6.write_context import WriteContext
 from imod.schemata import DimsSchema, DTypeSchema
 
 
@@ -117,6 +118,14 @@ class TimeDiscretization(Package):
                 f"{self.__class__.__name__} package. "
                 f"Got {da.dims}. Can be at max ('time', )."
             )
+
+    def _set_ats_filename(self, ats_pkgname: str, write_context: WriteContext):
+        ats_path = write_context.get_formatted_write_directory / f"{ats_pkgname}.ats"
+        self.dataset["ats_filename"] = ats_path
+
+    def _clear_ats_filename(self):
+        if "ats_filename" in self.dataset.keys():
+            del self.dataset["ats_filename"]
 
     def _write(self, pkgname, globaltimes, write_context):
         timedis_content = self._render(

--- a/imod/mf6/timedis.py
+++ b/imod/mf6/timedis.py
@@ -120,7 +120,7 @@ class TimeDiscretization(Package):
             )
 
     def _set_ats_filename(self, ats_pkgname: str, write_context: WriteContext):
-        ats_path = write_context.get_formatted_write_directory / f"{ats_pkgname}.ats"
+        ats_path = write_context.get_formatted_write_directory() / f"{ats_pkgname}.ats"
         self.dataset["ats_filename"] = ats_path
 
     def _clear_ats_filename(self):

--- a/imod/mf6/timedis.py
+++ b/imod/mf6/timedis.py
@@ -78,6 +78,8 @@ class TimeDiscretization(Package):
             "time_units": "days",
             "start_date_time": start_date_time,
         }
+        if "ats_filename" in self.dataset:
+            d["ats_filename"] = self.dataset["ats_filename"].item()
         timestep_duration = self.dataset["timestep_duration"]
         n_timesteps = self.dataset["n_timesteps"]
         timestep_multiplier = self.dataset["timestep_multiplier"]

--- a/imod/templates/mf6/gwt-adv.j2
+++ b/imod/templates/mf6/gwt-adv.j2
@@ -1,3 +1,5 @@
 begin options
   scheme {{scheme}}
+{%- if ats_percel is defined %}  ats_percel {{ats_percel}}
+{% endif -%}
 end options

--- a/imod/templates/mf6/gwt-adv.j2
+++ b/imod/templates/mf6/gwt-adv.j2
@@ -1,5 +1,5 @@
 begin options
   scheme {{scheme}}
-{%- if ats_percel is defined %}  ats_percel {{ats_percel}}
+{% if ats_percel is defined %}  ats_percel {{ats_percel}}
 {% endif -%}
 end options

--- a/imod/templates/mf6/sim-tdis.j2
+++ b/imod/templates/mf6/sim-tdis.j2
@@ -1,7 +1,9 @@
 begin options
 {% if time_units is defined %}  time_units {{time_units}}
 {% endif %}
-{%- if start_date_time is defined %}  start_date_time {{start_date_time}}
+{% if start_date_time is defined %}  start_date_time {{start_date_time}}
+{% endif %}
+{%- if ats_filename is defined %}  ats6 filein {{ats_filename}}
 {% endif -%}
 end options
 

--- a/imod/templates/mf6/sln-ims.j2
+++ b/imod/templates/mf6/sln-ims.j2
@@ -1,9 +1,9 @@
 begin options
 {% if print_option is defined %}  print_option {{print_option}}
 {% endif %}
-{%- if outer_csvfile is defined %}  outer_csvfile fileout {{outer_csvfile}}
+{%- if outer_csvfile is defined %}  csv_outer_output fileout {{outer_csvfile}}
 {% endif %}
-{%- if inner_csvfile is defined %}  inner_csvfile fileout {{inner_csvfile}}
+{%- if inner_csvfile is defined %}  csv_inner_output fileout {{inner_csvfile}}
 {% endif %}
 {%- if no_ptc is defined %}  no_ptc {{no_ptc}}
 {% endif -%}

--- a/imod/templates/mf6/utl-ats.j2
+++ b/imod/templates/mf6/utl-ats.j2
@@ -1,0 +1,8 @@
+begin dimensions
+  maxats {{maxats}}
+end dimensions
+
+begin perioddata
+{% for start, period_list in perioddata.items() %}  {{start}} {{period_list|join(" ")}}
+{% endfor -%}
+end perioddata

--- a/imod/tests/fixtures/package_instance_creation.py
+++ b/imod/tests/fixtures/package_instance_creation.py
@@ -219,7 +219,7 @@ UNSTRUCTURED_GRID_PACKAGES = [create_vertices_discretization()] + [
 ]
 
 GRIDLESS_PACKAGES = [
-    imod.mf6.adv.Advection("upstream"),
+    imod.mf6.AdvectionUpstream(),
     imod.mf6.Buoyancy(
         reference_density=1000.0,
         reference_concentration=[4.0, 25.0],

--- a/imod/tests/test_mf6/test_mf6_adv.py
+++ b/imod/tests/test_mf6/test_mf6_adv.py
@@ -1,8 +1,10 @@
 import pathlib
 
 import numpy as np
+import pytest
 
 import imod
+from imod.schemata import ValidationError
 
 
 def test_advection_upstream():
@@ -39,3 +41,13 @@ def test_advection_ats_percel():
     actual = a._render(directory, "adv", globaltimes, True)
     expected = "begin options\n  scheme TVD\n  ats_percel 0.5\nend options"
     assert actual == expected
+
+
+def test_advection_ats_percel_invalid():
+    """Test that invalid ats_percel values raise ValidationError."""
+    with pytest.raises(ValidationError):
+        imod.mf6.AdvectionTVD(ats_percel=1)
+    with pytest.raises(ValidationError):
+        imod.mf6.AdvectionTVD(ats_percel=-0.1)
+    with pytest.raises(ValidationError):
+        imod.mf6.AdvectionTVD(ats_percel=0.0)

--- a/imod/tests/test_mf6/test_mf6_adv.py
+++ b/imod/tests/test_mf6/test_mf6_adv.py
@@ -30,3 +30,12 @@ def test_advection_TVD():
     actual = a._render(directory, "adv", globaltimes, True)
     expected = "begin options\n  scheme TVD\nend options"
     assert actual == expected
+
+
+def test_advection_ats_percel():
+    directory = pathlib.Path("mymodel")
+    globaltimes = [np.datetime64("2000-01-01")]
+    a = imod.mf6.AdvectionTVD(ats_percel=0.5)
+    actual = a._render(directory, "adv", globaltimes, True)
+    expected = "begin options\n  scheme TVD\n  ats_percel 0.5\nend options"
+    assert actual == expected

--- a/imod/tests/test_mf6/test_mf6_ats.py
+++ b/imod/tests/test_mf6/test_mf6_ats.py
@@ -30,6 +30,7 @@ def ats_dict():
         "dt_fail_multiplier": _to_time_da(np.array([2.0, 3.0])),
     }
 
+
 def test_render_defaults(ats_dict):
     """Render with default values for dt_multiplier and dt_fail_multiplier"""
     globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
@@ -108,12 +109,12 @@ def test_render_mixed(ats_dict):
 def test_render_constants():
     """Render with all constant values"""
     ats_dict = {
-            "dt_init": 2.0,
-            "dt_min": 1.0,
-            "dt_max": 4.0,
-            "dt_multiplier": 2.0,
-            "dt_fail_multiplier": 3.0,
-        }
+        "dt_init": 2.0,
+        "dt_min": 1.0,
+        "dt_max": 4.0,
+        "dt_multiplier": 2.0,
+        "dt_fail_multiplier": 3.0,
+    }
 
     globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
 
@@ -134,6 +135,7 @@ def test_render_constants():
     assert isinstance(rendered, str)
     assert rendered == expected
 
+
 def test_validate_init_schemata(ats_dict):
     # Test that the validation of the init schemata works correctly
     ats = AdaptiveTimeStepping(validate=False, **ats_dict)
@@ -141,7 +143,11 @@ def test_validate_init_schemata(ats_dict):
 
     ats_dict_copy = ats_dict.copy()
     ats_dict_copy.pop("dt_init")  # Remove dt_init to trigger validation error
-    erronous_dt_init = xr.DataArray([3.0], coords={"wrong_name": [np.datetime64("2023-01-02")]}, dims=("wrong_name",))
+    erronous_dt_init = xr.DataArray(
+        [3.0],
+        coords={"wrong_name": [np.datetime64("2023-01-02")]},
+        dims=("wrong_name",),
+    )
     with pytest.raises(ValidationError, match="dt_init"):
         AdaptiveTimeStepping(validate=True, dt_init=erronous_dt_init, **ats_dict_copy)
 

--- a/imod/tests/test_mf6/test_mf6_ats.py
+++ b/imod/tests/test_mf6/test_mf6_ats.py
@@ -1,0 +1,43 @@
+from imod.mf6.ats import AdaptiveTimeStepping
+import xarray as xr
+import numpy as np
+import pandas as pd
+from textwrap import dedent
+
+
+def _to_time_da(data):
+    periods = len(data)
+    coords = {"time": pd.date_range("2023-01-01", periods=periods, freq="D")}
+    dims = ("time",)
+    return xr.DataArray(
+        data,
+        coords=coords,
+        dims=dims,
+    )
+
+def test_render():
+    globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
+
+    ats = AdaptiveTimeStepping(
+    dt_init = _to_time_da(np.array([1.0, 2.0])),
+    dt_min = _to_time_da(np.array([0.5, 1.0])),
+    dt_max = _to_time_da(np.array([2.0, 4.0])),
+    dt_multiplier = _to_time_da(np.array([1.5, 2.0])),
+    dt_fail_multiplier = _to_time_da(np.array([2.0, 3.0])),
+    )
+
+    rendered = ats._render("test_dir", "test_pkg", globaltimes, False)
+    
+    expected = dedent("""\
+        begin dimensions
+          maxats 2
+        end dimensions
+
+        begin perioddata
+          1 1.0 0.5 2.0 1.5 2.0
+          2 2.0 1.0 4.0 2.0 3.0
+        end perioddata
+        """)
+    
+    assert isinstance(rendered, str)
+    assert rendered == expected

--- a/imod/tests/test_mf6/test_mf6_ats.py
+++ b/imod/tests/test_mf6/test_mf6_ats.py
@@ -1,8 +1,10 @@
-from imod.mf6.ats import AdaptiveTimeStepping
-import xarray as xr
+from textwrap import dedent
+
 import numpy as np
 import pandas as pd
-from textwrap import dedent
+import xarray as xr
+
+from imod.mf6.ats import AdaptiveTimeStepping
 
 
 def _to_time_da(data):
@@ -15,19 +17,20 @@ def _to_time_da(data):
         dims=dims,
     )
 
+
 def test_render():
     globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
 
     ats = AdaptiveTimeStepping(
-    dt_init = _to_time_da(np.array([1.0, 2.0])),
-    dt_min = _to_time_da(np.array([0.5, 1.0])),
-    dt_max = _to_time_da(np.array([2.0, 4.0])),
-    dt_multiplier = _to_time_da(np.array([1.5, 2.0])),
-    dt_fail_multiplier = _to_time_da(np.array([2.0, 3.0])),
+        dt_init=_to_time_da(np.array([1.0, 2.0])),
+        dt_min=_to_time_da(np.array([0.5, 1.0])),
+        dt_max=_to_time_da(np.array([2.0, 4.0])),
+        dt_multiplier=_to_time_da(np.array([1.5, 2.0])),
+        dt_fail_multiplier=_to_time_da(np.array([2.0, 3.0])),
     )
 
     rendered = ats._render("test_dir", "test_pkg", globaltimes, False)
-    
+
     expected = dedent("""\
         begin dimensions
           maxats 2
@@ -38,6 +41,6 @@ def test_render():
           2 2.0 1.0 4.0 2.0 3.0
         end perioddata
         """)
-    
+
     assert isinstance(rendered, str)
     assert rendered == expected

--- a/imod/tests/test_mf6/test_mf6_ats.py
+++ b/imod/tests/test_mf6/test_mf6_ats.py
@@ -38,7 +38,7 @@ def test_render_defaults(ats_dict):
     ats_dict.pop("dt_multiplier")
     ats_dict.pop("dt_fail_multiplier")
 
-    ats = AdaptiveTimeStepping(validate=False, **ats_dict)
+    ats = AdaptiveTimeStepping(validate=True, **ats_dict)
 
     rendered = ats._render("test_dir", "test_pkg", globaltimes, False)
 
@@ -61,7 +61,7 @@ def test_render_all_transient(ats_dict):
     """Render with all transient values"""
     globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
 
-    ats = AdaptiveTimeStepping(validate=False, **ats_dict)
+    ats = AdaptiveTimeStepping(validate=True, **ats_dict)
 
     rendered = ats._render("test_dir", "test_pkg", globaltimes, False)
 
@@ -87,7 +87,7 @@ def test_render_mixed(ats_dict):
     ats_dict["dt_multiplier"] = 1.0
     ats_dict["dt_fail_multiplier"] = 0.5
 
-    ats = AdaptiveTimeStepping(validate=False, **ats_dict)
+    ats = AdaptiveTimeStepping(validate=True, **ats_dict)
 
     rendered = ats._render("test_dir", "test_pkg", globaltimes, False)
 
@@ -118,7 +118,7 @@ def test_render_constants():
 
     globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
 
-    ats = AdaptiveTimeStepping(validate=False, **ats_dict)
+    ats = AdaptiveTimeStepping(validate=True, **ats_dict)
 
     rendered = ats._render("test_dir", "test_pkg", globaltimes, False)
 

--- a/imod/tests/test_mf6/test_mf6_ats.py
+++ b/imod/tests/test_mf6/test_mf6_ats.py
@@ -2,14 +2,15 @@ from textwrap import dedent
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 from imod.mf6.ats import AdaptiveTimeStepping
-
+from imod.schemata import ValidationError
 
 def _to_time_da(data):
     periods = len(data)
-    coords = {"time": pd.date_range("2023-01-01", periods=periods, freq="D")}
+    coords = {"time": pd.date_range("2023-01-02", periods=periods, freq="2D")}
     dims = ("time",)
     return xr.DataArray(
         data,
@@ -17,16 +18,23 @@ def _to_time_da(data):
         dims=dims,
     )
 
+@pytest.fixture(scope = "function")
+def ats_dict():
+    return {
+        "dt_init": _to_time_da(np.array([1.0, 2.0])),
+        "dt_min": _to_time_da(np.array([0.5, 1.0])),
+        "dt_max": _to_time_da(np.array([2.0, 4.0])),
+        "dt_multiplier": _to_time_da(np.array([1.5, 2.0])),
+        "dt_fail_multiplier": _to_time_da(np.array([2.0, 3.0])),
+    }
 
-def test_render():
+
+
+def test_render(ats_dict):
     globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
 
     ats = AdaptiveTimeStepping(
-        dt_init=_to_time_da(np.array([1.0, 2.0])),
-        dt_min=_to_time_da(np.array([0.5, 1.0])),
-        dt_max=_to_time_da(np.array([2.0, 4.0])),
-        dt_multiplier=_to_time_da(np.array([1.5, 2.0])),
-        dt_fail_multiplier=_to_time_da(np.array([2.0, 3.0])),
+        validate=False, **ats_dict
     )
 
     rendered = ats._render("test_dir", "test_pkg", globaltimes, False)
@@ -37,10 +45,45 @@ def test_render():
         end dimensions
 
         begin perioddata
-          1 1.0 0.5 2.0 1.5 2.0
-          2 2.0 1.0 4.0 2.0 3.0
+          2 1.0 0.5 2.0 1.5 2.0
+          4 2.0 1.0 4.0 2.0 3.0
         end perioddata
         """)
 
     assert isinstance(rendered, str)
     assert rendered == expected
+
+
+def test_validate_init_schemata(ats_dict):
+    # Test that the validation of the init schemata works correctly
+    ats = AdaptiveTimeStepping(
+        validate=False, **ats_dict
+    )
+    assert ats._validate_init_schemata(validate=True) is None
+
+    ats_dict_copy = ats_dict.copy()
+    ats_dict_copy.pop("dt_init")  # Remove dt_init to trigger validation error
+    with pytest.raises(ValidationError, match="dt_init"):
+        AdaptiveTimeStepping(validate=True, dt_init=xr.DataArray(3.0), **ats_dict_copy)
+    
+    with pytest.raises(ValidationError, match="dt_init"):
+        AdaptiveTimeStepping(validate=True, dt_init=_to_time_da(np.array([2, 3])), **ats_dict_copy)
+
+def test_validate_write_schemata(ats_dict):
+    # Test that the validation of the write schemata works correctly
+    ats_dict = ats_dict.copy()
+    ats_dict["dt_init"] = _to_time_da(np.array([-1.0, 2.0]))
+    ats_dict["dt_min"] = _to_time_da(np.array([-0.9, -0.9]))
+    ats_dict["dt_max"] = _to_time_da(np.array([-1.0, -1.0]))
+    ats_dict["dt_multiplier"] = _to_time_da(np.array([0.5, 0.5]))
+
+    ats = AdaptiveTimeStepping(
+        validate=False, **ats_dict
+    )
+
+    errors = ats._validate(ats._write_schemata)
+
+    assert len(errors) == 3
+    expected_keys = {"dt_init", "dt_min", "dt_multiplier"}
+    assert len(set(errors.keys()) - expected_keys) == 0
+    assert len(errors["dt_min"]) == 2

--- a/imod/tests/test_mf6/test_mf6_ats.py
+++ b/imod/tests/test_mf6/test_mf6_ats.py
@@ -33,7 +33,7 @@ def ats_dict():
 
 def test_render_defaults(ats_dict):
     """Render with default values for dt_multiplier and dt_fail_multiplier"""
-    globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
+    globaltimes = pd.date_range("2023-01-01", periods=5, freq="D")
 
     ats_dict.pop("dt_multiplier")
     ats_dict.pop("dt_fail_multiplier")
@@ -44,12 +44,15 @@ def test_render_defaults(ats_dict):
 
     expected = dedent("""\
         begin dimensions
-          maxats 2
+          maxats 5
         end dimensions
 
         begin perioddata
+          1 1.0 0.5 2.0 0.0 0.0
           2 1.0 0.5 2.0 0.0 0.0
+          3 1.0 0.5 2.0 0.0 0.0
           4 2.0 1.0 4.0 0.0 0.0
+          5 2.0 1.0 4.0 0.0 0.0
         end perioddata
         """)
 
@@ -59,7 +62,7 @@ def test_render_defaults(ats_dict):
 
 def test_render_all_transient(ats_dict):
     """Render with all transient values"""
-    globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
+    globaltimes = pd.date_range("2023-01-01", periods=5, freq="D")
 
     ats = AdaptiveTimeStepping(validate=True, **ats_dict)
 
@@ -67,12 +70,15 @@ def test_render_all_transient(ats_dict):
 
     expected = dedent("""\
         begin dimensions
-          maxats 2
+          maxats 5
         end dimensions
 
         begin perioddata
+          1 1.0 0.5 2.0 1.5 2.0
           2 1.0 0.5 2.0 1.5 2.0
+          3 1.0 0.5 2.0 1.5 2.0
           4 2.0 1.0 4.0 2.0 3.0
+          5 2.0 1.0 4.0 2.0 3.0
         end perioddata
         """)
 
@@ -82,7 +88,7 @@ def test_render_all_transient(ats_dict):
 
 def test_render_mixed(ats_dict):
     """Render with mixed constant and transient values"""
-    globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
+    globaltimes = pd.date_range("2023-01-01", periods=5, freq="D")
 
     ats_dict["dt_multiplier"] = 1.0
     ats_dict["dt_fail_multiplier"] = 0.5
@@ -93,12 +99,15 @@ def test_render_mixed(ats_dict):
 
     expected = dedent("""\
         begin dimensions
-          maxats 2
+          maxats 5
         end dimensions
 
         begin perioddata
+          1 1.0 0.5 2.0 1.0 0.5
           2 1.0 0.5 2.0 1.0 0.5
+          3 1.0 0.5 2.0 1.0 0.5
           4 2.0 1.0 4.0 1.0 0.5
+          5 2.0 1.0 4.0 1.0 0.5
         end perioddata
         """)
 
@@ -116,7 +125,7 @@ def test_render_constants():
         "dt_fail_multiplier": 3.0,
     }
 
-    globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
+    globaltimes = pd.date_range("2023-01-01", periods=5, freq="D")
 
     ats = AdaptiveTimeStepping(validate=True, **ats_dict)
 
@@ -124,11 +133,15 @@ def test_render_constants():
 
     expected = dedent("""\
         begin dimensions
-          maxats 1
+          maxats 5
         end dimensions
 
         begin perioddata
           1 2.0 1.0 4.0 2.0 3.0
+          2 2.0 1.0 4.0 2.0 3.0
+          3 2.0 1.0 4.0 2.0 3.0
+          4 2.0 1.0 4.0 2.0 3.0
+          5 2.0 1.0 4.0 2.0 3.0
         end perioddata
         """)
 

--- a/imod/tests/test_mf6/test_mf6_ats.py
+++ b/imod/tests/test_mf6/test_mf6_ats.py
@@ -8,6 +8,7 @@ import xarray as xr
 from imod.mf6.ats import AdaptiveTimeStepping
 from imod.schemata import ValidationError
 
+
 def _to_time_da(data):
     periods = len(data)
     coords = {"time": pd.date_range("2023-01-02", periods=periods, freq="2D")}
@@ -18,7 +19,8 @@ def _to_time_da(data):
         dims=dims,
     )
 
-@pytest.fixture(scope = "function")
+
+@pytest.fixture(scope="function")
 def ats_dict():
     return {
         "dt_init": _to_time_da(np.array([1.0, 2.0])),
@@ -29,13 +31,10 @@ def ats_dict():
     }
 
 
-
 def test_render(ats_dict):
     globaltimes = pd.date_range("2023-01-01", periods=10, freq="D")
 
-    ats = AdaptiveTimeStepping(
-        validate=False, **ats_dict
-    )
+    ats = AdaptiveTimeStepping(validate=False, **ats_dict)
 
     rendered = ats._render("test_dir", "test_pkg", globaltimes, False)
 
@@ -56,18 +55,19 @@ def test_render(ats_dict):
 
 def test_validate_init_schemata(ats_dict):
     # Test that the validation of the init schemata works correctly
-    ats = AdaptiveTimeStepping(
-        validate=False, **ats_dict
-    )
+    ats = AdaptiveTimeStepping(validate=False, **ats_dict)
     assert ats._validate_init_schemata(validate=True) is None
 
     ats_dict_copy = ats_dict.copy()
     ats_dict_copy.pop("dt_init")  # Remove dt_init to trigger validation error
     with pytest.raises(ValidationError, match="dt_init"):
         AdaptiveTimeStepping(validate=True, dt_init=xr.DataArray(3.0), **ats_dict_copy)
-    
+
     with pytest.raises(ValidationError, match="dt_init"):
-        AdaptiveTimeStepping(validate=True, dt_init=_to_time_da(np.array([2, 3])), **ats_dict_copy)
+        AdaptiveTimeStepping(
+            validate=True, dt_init=_to_time_da(np.array([2, 3])), **ats_dict_copy
+        )
+
 
 def test_validate_write_schemata(ats_dict):
     # Test that the validation of the write schemata works correctly
@@ -77,9 +77,7 @@ def test_validate_write_schemata(ats_dict):
     ats_dict["dt_max"] = _to_time_da(np.array([-1.0, -1.0]))
     ats_dict["dt_multiplier"] = _to_time_da(np.array([0.5, 0.5]))
 
-    ats = AdaptiveTimeStepping(
-        validate=False, **ats_dict
-    )
+    ats = AdaptiveTimeStepping(validate=False, **ats_dict)
 
     errors = ats._validate(ats._write_schemata)
 

--- a/imod/tests/test_mf6/test_mf6_timedis.py
+++ b/imod/tests/test_mf6/test_mf6_timedis.py
@@ -77,3 +77,32 @@ def test_validate_false():
         timestep_multiplier=1.1,
         validate=False,
     )
+
+
+def test_set_ats_filename():
+    timestep_duration = xr.DataArray(
+        data=[0.001, 7.0, 365.0],
+        coords={"time": pd.date_range("2000-01-01", "2000-01-03")},
+        dims=["time"],
+    )
+    timedis = imod.mf6.TimeDiscretization(
+        timestep_duration, n_timesteps=2, timestep_multiplier=1.1
+    )
+    timedis._set_ats_filename("my_ats", imod.mf6.WriteContext("."))
+    assert "ats_filename" in timedis.dataset
+    assert timedis.dataset["ats_filename"].item().name == "my_ats.ats"
+
+
+def test_clear_ats_filename():
+    timestep_duration = xr.DataArray(
+        data=[0.001, 7.0, 365.0],
+        coords={"time": pd.date_range("2000-01-01", "2000-01-03")},
+        dims=["time"],
+    )
+    timedis = imod.mf6.TimeDiscretization(
+        timestep_duration, n_timesteps=2, timestep_multiplier=1.1
+    )
+    timedis.dataset["ats_filename"] = "some_file.ats"
+    assert "ats_filename" in timedis.dataset
+    timedis._clear_ats_filename()
+    assert "ats_filename" not in timedis.dataset


### PR DESCRIPTION
Fixes #1632

# Description
Add ATS package. I found out that MODFLOW6 doesn't automatically forward fill stress period data for the UTL-ATS package. I guess because it is an utility? I therefore implemented forward filling, as I deem that expected behavior.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [x] **If feature added**: Added/extended example
- [x] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
