### PR TITLE
Issue #1617 too strict riv stage validation

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -64,7 +64,7 @@ Changed
   partition labels from a :class:`imod.mf6.Modflow6Simulation` straightaway, use
   the newly added :meth:`imod.mf6.Modflow6Simulation.create_partition_labels`
   method instead.
-- :class:`imod.mf6.River` now ignore cells with ``icelltype == 0`` when
+- :class:`imod.mf6.River` now ignore confined cells (``icelltype == 0``) when
   validating whether the river bottom elevation is below the model bottom
   elevation.
 

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -64,6 +64,9 @@ Changed
   partition labels from a :class:`imod.mf6.Modflow6Simulation` straightaway, use
   the newly added :meth:`imod.mf6.Modflow6Simulation.create_partition_labels`
   method instead.
+- :class:`imod.mf6.River` now ignore cells with ``icelltype == 0`` when
+  validating whether the river bottom elevation is below the model bottom
+  elevation.
 
 Removed
 ~~~~~~~

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -335,6 +335,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         self,
         model_name: str = "",
         validation_context: Optional[ValidationSettings] = None,
+        **kwargs,
     ) -> StatusInfoBase:
         """
         Validate model.
@@ -346,6 +347,8 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
         validation_context: ValidationSettings, optional
             Validation settings, which can be used to control the validation
             process. If not provided, defaults to ValidationSettings(validate=True).
+        **kwargs: dict
+            Additional keyword arguments passed to Package._validate
 
         Returns
         -------
@@ -392,6 +395,7 @@ class Modflow6Model(collections.UserDict, IModel, abc.ABC):
                 idomain=idomain,
                 bottom=bottom,
                 validation_context=validation_context,
+                **kwargs,
             )
             if len(pkg_errors) > 0:
                 footer = SUGGESTION_TEXT if pkg_has_cleanup(pkg) else None

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -247,7 +247,7 @@ class River(TopSystemBoundaryCondition, IRegridPackage):
         "bottom_elevation": [
             IdentityNoDataSchema("stage"),
             # Check river bottom above layer bottom, else Modflow throws error.
-            AllValueSchema(">=", "bottom", ignore=("icelltype", "<=", 0)),
+            AllValueSchema(">=", "bottom", ignore=("icelltype", "==", 0)),
         ],
         "concentration": [IdentityNoDataSchema("stage"), AllValueSchema(">=", 0.0)],
     }

--- a/imod/mf6/riv.py
+++ b/imod/mf6/riv.py
@@ -247,7 +247,7 @@ class River(TopSystemBoundaryCondition, IRegridPackage):
         "bottom_elevation": [
             IdentityNoDataSchema("stage"),
             # Check river bottom above layer bottom, else Modflow throws error.
-            AllValueSchema(">=", "bottom"),
+            AllValueSchema(">=", "bottom", ignore=("icelltype", "<=", 0)),
         ],
         "concentration": [IdentityNoDataSchema("stage"), AllValueSchema(">=", 0.0)],
     }

--- a/imod/tests/test_mf6/test_mf6_riv.py
+++ b/imod/tests/test_mf6/test_mf6_riv.py
@@ -194,7 +194,7 @@ def test_all_nan(riv_data, dis_data):
 
     river = imod.mf6.River(**riv_data)
 
-    errors = river._validate(river._write_schemata, **dis_data)
+    errors = river._validate(river._write_schemata, icelltype=1.0, **dis_data)
 
     assert len(errors) == 1
     assert "stage" in errors.keys()
@@ -205,7 +205,7 @@ def test_validate_inconsistent_nan(riv_data, dis_data):
     riv_data["stage"][..., 2] = np.nan
     river = imod.mf6.River(**riv_data)
 
-    errors = river._validate(river._write_schemata, **dis_data)
+    errors = river._validate(river._write_schemata, icelltype=1.0, **dis_data)
 
     assert len(errors) == 2
     assert "bottom_elevation" in errors.keys()
@@ -220,7 +220,7 @@ def test_cleanup_inconsistent_nan(riv_data, dis_data):
     dis_pkg = TYPE_DIS_PKG[type_grid](**dis_data)
 
     river.cleanup(dis_pkg)
-    errors = river._validate(river._write_schemata, **dis_data)
+    errors = river._validate(river._write_schemata, icelltype=1.0, **dis_data)
 
     assert len(errors) == 0
 
@@ -233,7 +233,7 @@ def test_layer_as_coord_in_active_cells(riv_data, dis_data):
 
     dis_data["idomain"][1, ...] = 0
 
-    errors = river._validate(river._write_schemata, **dis_data)
+    errors = river._validate(river._write_schemata, icelltype=1.0, **dis_data)
 
     assert len(errors) == 0
 
@@ -245,7 +245,7 @@ def test_layer_as_coord_in_inactive_cells(riv_data, dis_data):
 
     dis_data["idomain"][0, ...] = 0
 
-    errors = river._validate(river._write_schemata, **dis_data)
+    errors = river._validate(river._write_schemata, icelltype=1.0, **dis_data)
 
     assert len(errors) == 1
 
@@ -310,7 +310,7 @@ def test_validate_zero_conductance(riv_data, dis_data):
 
     river = imod.mf6.River(**riv_data)
 
-    errors = river._validate(river._write_schemata, **dis_data)
+    errors = river._validate(river._write_schemata, icelltype=0.0, **dis_data)
 
     assert len(errors) == 1
     for var, var_errors in errors.items():
@@ -329,7 +329,7 @@ def test_cleanup_zero_conductance(riv_data, dis_data):
     river = imod.mf6.River(**riv_data)
     river.cleanup(dis_pkg)
 
-    errors = river._validate(river._write_schemata, **dis_data)
+    errors = river._validate(river._write_schemata, icelltype=0.0, **dis_data)
     assert len(errors) == 0
 
 
@@ -343,7 +343,7 @@ def test_validate_bottom_above_stage(riv_data, dis_data):
 
     river = imod.mf6.River(**riv_data)
 
-    errors = river._validate(river._write_schemata, **dis_data)
+    errors = river._validate(river._write_schemata, icelltype=0.0, **dis_data)
 
     assert len(errors) == 1
     assert "stage" in errors.keys()
@@ -362,7 +362,7 @@ def test_cleanup_bottom_above_stage(riv_data, dis_data):
     river = imod.mf6.River(**riv_data)
     river.cleanup(dis_pkg)
 
-    errors = river._validate(river._write_schemata, **dis_data)
+    errors = river._validate(river._write_schemata, icelltype=0.0, **dis_data)
 
     assert len(errors) == 0
     assert river.dataset["bottom_elevation"].equals(river.dataset["stage"])
@@ -375,12 +375,18 @@ def test_check_riv_bottom_above_dis_bottom(riv_data, dis_data):
     """
 
     river = imod.mf6.River(**riv_data)
+    # Verify no errors initially
+    errors = river._validate(river._write_schemata, icelltype=0.0, **dis_data)
+    assert len(errors) == 0
 
-    river._validate(river._write_schemata, **dis_data)
-
+    # Adapt dis bottom to be above river bottom
     dis_data["bottom"] += 2.0
 
-    errors = river._validate(river._write_schemata, **dis_data)
+    # Should not error if icelltype <= 0
+    errors = river._validate(river._write_schemata, icelltype=0.0, **dis_data)
+    assert len(errors) == 0
+    # Error if icelltype > 0
+    errors = river._validate(river._write_schemata, icelltype=1.0, **dis_data)
 
     assert len(errors) == 1
     for var, var_errors in errors.items():
@@ -395,13 +401,13 @@ def test_check_boundary_outside_active_domain(riv_data, dis_data):
 
     river = imod.mf6.River(**riv_data)
 
-    errors = river._validate(river._write_schemata, **dis_data)
+    errors = river._validate(river._write_schemata, icelltype=0.0, **dis_data)
 
     assert len(errors) == 0
 
     dis_data["idomain"][..., 0] = 0
 
-    errors = river._validate(river._write_schemata, **dis_data)
+    errors = river._validate(river._write_schemata, icelltype=0.0, **dis_data)
 
     assert len(errors) == 1
 
@@ -619,6 +625,7 @@ def test_import_river_from_imod5(imod5_dataset, tmp_path):
 
     errors = riv._validate(
         imod.mf6.River._write_schemata,
+        icelltype=1.0,
         idomain=target_dis.dataset["idomain"],
         bottom=target_dis.dataset["bottom"],
     )
@@ -688,6 +695,7 @@ def test_import_river_from_imod5__negative_layer(imod5_dataset, tmp_path):
         imod.mf6.River._write_schemata,
         idomain=target_dis.dataset["idomain"],
         bottom=target_dis.dataset["bottom"],
+        icelltype=1.0,
     )
     assert len(errors) == 0
     errors = drn._validate(
@@ -818,6 +826,7 @@ def test_import_river_from_imod5__period_data(imod5_dataset_periods, tmp_path):
         imod.mf6.River._write_schemata,
         idomain=target_dis.dataset["idomain"],
         bottom=target_dis.dataset["bottom"],
+        icelltype=1.0,
     )
     assert len(errors) == 0
 


### PR DESCRIPTION
Fixes #1617

# Description
Changes the following:

- Ignore confined cells (icelltype == 0) when validating whether the river bottom elevation is below the model bottom.
- Refactor: Add **kwargs to Modflow6Model.validate signature, so that transport and flow models can provide additional variables for the package validation.

@HendrikKok suggested using the ``convertible`` option in the Storage package, but I think ``icelltype`` is better, as it is possbile to create steady-state unconfined MODFLOW6 simulations without a STO package (though iMOD Python requires a STO package). 

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
