### PR TITLE
Issue #1600 edge case empty exchanges

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -19,6 +19,14 @@ Changed
   validating whether the river bottom elevation is below the model bottom
   elevation.
 
+Fixed
+~~~~~
+
+- Fixed bug where :meth:`imod.mf6.Modflow6Simulation.split` could result in
+  empty exchanges being present in the ``split_exchanges`` package list, when
+  two models were isolated by inactive cells from each other. These empty
+  exchanges are now removed.
+
 [1.0.0rc6] - 2025-08-28
 -----------------------
 

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1510,7 +1510,7 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         for ex in self["split_exchanges"]:
             for i in [1, 2]:
                 self._filter_inactive_cells_exchange_domain(ex, i)
-            
+
             # Remove exchange if no cells are left
             if ex.dataset.sizes["index"] == 0:
                 self["split_exchanges"].remove(ex)

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1510,6 +1510,10 @@ class Modflow6Simulation(collections.UserDict, ISimulation):
         for ex in self["split_exchanges"]:
             for i in [1, 2]:
                 self._filter_inactive_cells_exchange_domain(ex, i)
+            
+            # Remove exchange if no cells are left
+            if ex.dataset.sizes["index"] == 0:
+                self["split_exchanges"].remove(ex)
 
     def _filter_inactive_cells_exchange_domain(self, ex: GWFGWF, i: int) -> None:
         """Filters inactive cells from one exchange domain inplace"""

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -623,7 +623,9 @@ def test_partitioning_structured_hfb(
     np.testing.assert_allclose(head["head"].values, original_head.values, rtol=1e-3)
 
 
-@parametrize_with_cases("partition_array", cases=PartitionArrayCases, prefix="case_four_")
+@parametrize_with_cases(
+    "partition_array", cases=PartitionArrayCases, prefix="case_four_"
+)
 def test_partitioning_structured__disconnected_models(
     tmp_path: Path,
     transient_twri_model: Modflow6Simulation,
@@ -634,7 +636,7 @@ def test_partitioning_structured__disconnected_models(
     # Isolate models from each other. There shouldn't be exchanges between these
     # models.
     new_idomain = simulation["GWF_1"]["dis"].dataset["idomain"].copy()
-    new_idomain[:, 7, :8] = 0
+    new_idomain[:, 7, :7] = 0
     simulation.mask_all_models(new_idomain)
 
     # Run the original example, so without partitioning, and save the simulation
@@ -657,11 +659,18 @@ def test_partitioning_structured__disconnected_models(
     head = split_simulation.open_head()
     _ = split_simulation.open_flow_budget()
 
-
-    modelnames = split_simulation.get_models_of_type("gwf6").keys()
-    unique_partitions = np.unique(partition_array)
-    assert len(modelnames) == (len(unique_partitions) - 2)
-
+    # Check that one exchange has been removed, as the models are disconnected.
+    assert len(split_simulation["split_exchanges"]) == 3
+    varnames = ["model_name_1", "model_name_2"]
+    modelnames = [
+        [exch[key].item() for key in varnames]
+        for exch in split_simulation["split_exchanges"]
+    ]
+    assert sorted(modelnames) == [
+        ["GWF_1_0", "GWF_1_1"],
+        ["GWF_1_1", "GWF_1_3"],
+        ["GWF_1_2", "GWF_1_3"],
+    ]
 
     # Compare the head result of the original simulation with the result of the
     # partitioned simulation.

--- a/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
+++ b/imod/tests/test_mf6/test_multimodel/test_mf6_partitioning_structured.py
@@ -621,3 +621,50 @@ def test_partitioning_structured_hfb(
     # Compare the head result of the original simulation with the result of the
     # partitioned simulation.
     np.testing.assert_allclose(head["head"].values, original_head.values, rtol=1e-3)
+
+
+@parametrize_with_cases("partition_array", cases=PartitionArrayCases, prefix="case_four_")
+def test_partitioning_structured__disconnected_models(
+    tmp_path: Path,
+    transient_twri_model: Modflow6Simulation,
+    partition_array: xr.DataArray,
+):
+    simulation = transient_twri_model
+
+    # Isolate models from each other. There shouldn't be exchanges between these
+    # models.
+    new_idomain = simulation["GWF_1"]["dis"].dataset["idomain"].copy()
+    new_idomain[:, 7, :8] = 0
+    simulation.mask_all_models(new_idomain)
+
+    # Run the original example, so without partitioning, and save the simulation
+    # results.
+    original_dir = tmp_path / "original"
+    simulation.write(original_dir, binary=False)
+    simulation.run()
+
+    original_head = imod.mf6.open_hds(
+        original_dir / "GWF_1/GWF_1.hds",
+        original_dir / "GWF_1/dis.dis.grb",
+    )
+
+    # Partition the simulation, run it, and save the (merged) results
+    split_simulation = simulation.split(partition_array)
+
+    split_simulation.write(tmp_path, binary=False)
+    split_simulation.run()
+
+    head = split_simulation.open_head()
+    _ = split_simulation.open_flow_budget()
+
+
+    modelnames = split_simulation.get_models_of_type("gwf6").keys()
+    unique_partitions = np.unique(partition_array)
+    assert len(modelnames) == (len(unique_partitions) - 2)
+
+
+    # Compare the head result of the original simulation with the result of the
+    # partitioned simulation.
+    np.testing.assert_allclose(
+        head["head"].values, original_head.values, rtol=1e-4, atol=1e-4
+    )


### PR DESCRIPTION
Fixes #1600

# Description
Remove empty exchanges. This could occur when two adjacent submodels are isolated from each other by inactive cells.

# Checklist

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
