### PR TITLE
Issue #1656 Removed dsp package from mandatory packages in model_gwt.py

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -23,6 +23,8 @@ Changed
   :func:`imod.select.get_lower_active_cells`, and
   :func:`imod.select.get_lower_active_layer_number` from :mod:`imod.prepare`. to
   :mod:`imod.select`.
+- :class:`imod.mf6.Dispersion` now is not a required package for
+  :class:`imod.mf6.GroundwaterTransportModel` anymore.
 
 Removed
 ~~~~~~~

--- a/imod/mf6/model_gwt.py
+++ b/imod/mf6/model_gwt.py
@@ -34,7 +34,7 @@ class GroundwaterTransportModel(Modflow6Model):
         the file specified with "BUDGET FILEOUT" in Output Control.
     """
 
-    _mandatory_packages = ("mst", "dsp", "oc", "ic")
+    _mandatory_packages = ("mst", "oc", "ic")
     _model_id = "gwt6"
     _template = Modflow6Model._initialize_template("gwt-nam.j2")
     _boundary_state_pkg_type = ConstantConcentration


### PR DESCRIPTION
Fixes #1656

# Description
Remove dsp package from mandatory packages for the transport model.

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
