### PR TITLE
Issue #825 Flip y in docs/faq/how-do-i/modification.rst

### DIFF
--- a/docs/faq/how-do-i/modification.rst
+++ b/docs/faq/how-do-i/modification.rst
@@ -165,7 +165,18 @@ integer or float), use ``.item()``:
 .. code-block:: python
    
     single_value = da.mean().item()
- 
+
+Flip the y-coordinates
+~~~~~~~~~~~~~~~~~~~~~~
+
+Xarray sorts coordinates in ascending order in some methods (see ``align``
+example below), which you need to correct afterwards. We want y to be
+descending. The most efficient way to do this:
+
+.. code-block:: python
+
+    da = da.reindex(y=da.y[::-1])
+
 Increase the extent of a raster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -174,6 +185,11 @@ Use another raster with appropriate extent, and use ``align``:
 .. code-block:: python
 
     small_aligned, big_aligned = xr.align(small, big, join="outer")
+    # Flip y-coordinates. Xarray sorts coordinates in ascending order.
+    # We want y to be descending.
+    y_descending = big_aligned.y[::-1]
+    small_aligned = small_aligned.reindex(y=y_descending)
+    big_aligned = big_aligned.reindex(y=y_descending)
     
 Make sure the cell size is the same, or the result will be non-equidistant.
 


### PR DESCRIPTION
Fixes #825

# Description
I think documenting how to flip y-coords fixes most of the trouble @JaccoHoogewoud had. In my experience, xarray flips y coords quite often, so it is good to have documented somewhere how to workaround this.