### PR TITLE
Issue #996 Add Weekly CI job that runs the acceptance tests

### DIFF
--- a/.teamcity/Templates/AcceptanceTestsTemplate.kt
+++ b/.teamcity/Templates/AcceptanceTestsTemplate.kt
@@ -1,0 +1,46 @@
+package Templates
+
+import jetbrains.buildServer.configs.kotlin.DslContext
+import jetbrains.buildServer.configs.kotlin.Template
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
+
+object AcceptanceTestsTemplate : Template({
+    name = "AcceptanceTestsTemplate"
+
+    allowExternalStatus = true
+
+    vcs {
+        root(DslContext.settingsRoot, "+:. => imod-python")
+        cleanCheckout = true
+    }
+
+
+    params {
+        param("env.access_key", "%credentialsJSON:2978988a-493b-44ed-9fcb-6cd6d2c2c673%")
+        param("env.secret_access_key", "%credentialsJSON:409a55c0-b2e7-438c-98dd-f0404b83cabb%")
+    }
+
+
+    steps {
+        script {
+            name = "Run acceptance tests"
+            id = "Run_acceptance_tests"
+            workingDir = "imod-python"
+            scriptContent = """
+                SET PATH=%%PATH%%;%system.teamcity.build.checkoutDir%\modflow6
+                
+                pixi run --environment user-acceptance --frozen dvc remote modify --local minio access_key_id %env.access_key%
+                pixi run --environment user-acceptance --frozen dvc remote modify --local minio secret_access_key %env.secret_access_key%
+                
+                pixi run --environment user-acceptance --frozen user_acceptance
+            """.trimIndent()
+            formatStderrAsError = true
+            dockerImage = "%DockerContainer%:%DockerVersion%"
+            dockerImagePlatform = ScriptBuildStep.ImagePlatform.Windows
+            dockerRunParameters = """--cpus=8 --memory=32g"""
+            dockerPull = false
+        }
+    }
+
+})

--- a/.teamcity/_Self/MainProject.kt
+++ b/.teamcity/_Self/MainProject.kt
@@ -4,6 +4,7 @@ import Deploy.DeployProject
 import Nightly.NightlyProject
 import Pixi.PixiProject
 import Templates.*
+import Weekly.WeeklyProject
 import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.buildFeatures.pullRequests
@@ -63,6 +64,7 @@ object MainProject : Project({
 
     subProject(DeployProject)
     subProject(NightlyProject)
+    subProject(WeeklyProject)
     subProject(PixiProject)
 })
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -177,14 +177,14 @@ dvc-s3 = "*"
 
 [feature.user-acceptance.tasks]
 pull_data = "dvc pull --remote minio"
-fetch_lhm = {cmd = "7z x LHM_transient.zip -oLHM_transient -y", depends-on = ["pull_data"], cwd = "imod/tests/user_acceptance_data"}
+fetch_lhm = {cmd = "7z x LHM_transient.zip -o. -y", depends-on = ["pull_data"], cwd = "imod/tests/user_acceptance_data"}
 user_acceptance = { cmd = [
     "pytest",
     "-m", "user_acceptance",
     "--cache-clear",
     "--verbose",
     "--junitxml=user_acceptance_report.xml",
-], depends-on = ["install"], cwd = "imod/tests", env = { USER_ACCEPTANCE_DIR = "user_acceptance_data"} }
+], depends-on = ["install", "fetch_lhm"], cwd = "imod/tests", env = { USER_ACCEPTANCE_DIR = "user_acceptance_data"} }
 run_imod5 = {cmd = ["prepare_mf6_transient_imod5.bat"], cwd = "imod/tests/user_acceptance_data/LHM_transient/scripts_imod-5"}
 qgis_export ={ cmd = [
     "pytest", "-s",


### PR DESCRIPTION
Fixes #988

# Description
This commit adds a weekly job that runs the acceptance tests.
A main "Test" job is created that is triggered every sunday. This job triggers its dependencies.
For now that is only the "acceptance tests" job. However any future weekly jobs can be attached to it.
I would also make sense to eventually put the "Pixi update" under this job as that is a weekly job as well

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
