### PR TITLE
Issue #1675 Add empty Docker Dev CI project

### DIFF
--- a/.teamcity/Docker/DockerDevProject.kt
+++ b/.teamcity/Docker/DockerDevProject.kt
@@ -5,12 +5,13 @@ import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.PublishMode
 
 object DockerProject  : Project({
-    name = "Docker"
+    name = "Docker dev project"
 
-    buildType(DeployDockerImage)
+    buildType(DeployDockerDevImage)
 })
 
-object DeployDockerImage : BuildType({
+object DeployDockerDevImage : BuildType({
+    name = "Deploy docker dev image"
 
     enablePersonalBuilds = false
     type = Type.DEPLOYMENT

--- a/.teamcity/Docker/DockerProject.kt
+++ b/.teamcity/Docker/DockerProject.kt
@@ -1,0 +1,20 @@
+package Docker
+
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.PublishMode
+
+object DockerProject  : Project({
+    name = "Docker"
+
+    buildType(DeployDockerImage)
+})
+
+object DeployDockerImage : BuildType({
+
+    enablePersonalBuilds = false
+    type = Type.DEPLOYMENT
+    maxRunningBuilds = 1
+    publishArtifacts = PublishMode.SUCCESSFUL
+
+})

--- a/.teamcity/_Self/MainProject.kt
+++ b/.teamcity/_Self/MainProject.kt
@@ -1,6 +1,7 @@
 package _Self
 
 import Deploy.DeployProject
+import Docker.DockerProject
 import Nightly.NightlyProject
 import Pixi.PixiProject
 import Templates.*
@@ -64,6 +65,7 @@ object MainProject : Project({
     subProject(DeployProject)
     subProject(NightlyProject)
     subProject(PixiProject)
+    subProject(DockerProject)
 })
 
 object Lint : BuildType({


### PR DESCRIPTION
Fixes #1675

# Description
This PR adds an empty Docker Dev project to the CI as part of #1221.
This allows us to trigger the build from the main story and test the pipeline

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
