### PR TITLE
Issue #1704 This commit changes the way source files are included for mypy analyses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ module = [
     "rasterio.*",
     "xugrid.*",
     # Stubs available, but too much work to fix right now
+    "dateutil.*",
     "geopandas.*",
     "pandas.*",
     "scipy.*",


### PR DESCRIPTION
Fixes #1704

# Description
This commit reverts the way source files are picked for myoy analysis.
The old way is to explicitly include the modules and files we want to analyse.
However the downside of this is that when a new module is added we can easily forget to include it.
With the new changes the can no longer happen.

Another benefit is that it makes it clear which modules we are not analyzing and if that is correct.
For instance we do not include at the `common` and `visualize` modules which we probably should

Furthermore i cleaned up the section were we ignore imports to external packages.
I sorted the packages by 'no stubs available' and 'stubs available but not used yet'

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
