### PR TITLE
Update pixi version to v0.59.0

### DIFF
--- a/.teamcity/Dockerfile/Dockerfile
+++ b/.teamcity/Dockerfile/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/server:ltsc2022
 LABEL maintainer="sunny.titus@deltares.nl"
 
-ARG PIXI_VERSION=v0.39.2
+ARG PIXI_VERSION=v0.59.0
 
 ## Setup user
 USER "NT Authority\System"

--- a/.teamcity/_Self/MainProject.kt
+++ b/.teamcity/_Self/MainProject.kt
@@ -19,7 +19,7 @@ import jetbrains.buildServer.configs.kotlin.triggers.vcs
 object MainProject : Project({
     params {
         param("DockerContainer", "containers.deltares.nl/hydrology_product_line_imod/windows-pixi")
-        param("DockerVersion", "v0.39.2")
+        param("DockerVersion", "v0.59.0")
     }
 
     buildType(Lint)

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "imod-python"
 version = "1.0.0rc7"
 description = "Make massive MODFLOW models"


### PR DESCRIPTION
Fixes #1709

# Description
This PR upgrades pixi to version 0.59.0  in the dev container.
This version of pixi contains an important bug fix that resolves a high severity issue in one of its dependencies:
[CVE-2025-62518](https://nvd.nist.gov/vuln/detail/CVE-2025-62518) (aka TARmageddon)


# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [ ] Links to correct issue
- [ ] Update changelog, if changes affect users
- [ ] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
