### PR TITLE
Set compat='no_conflicts' explicitly

### DIFF
--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -621,7 +621,7 @@ def _create_dataarray(
         dav = _create_dataarray_from_values(values_valid, headers_values, dim=dim)
         dap.name = "tmp"
         dav.name = "tmp"
-        da = xr.merge((dap, dav), join="outer")["tmp"]
+        da = xr.merge((dap, dav), join="outer", compat="no_conflicts")["tmp"]
     elif paths_valid:
         # Only paths provided
         da = _create_dataarray_from_paths(paths_valid, headers_paths, dim=dim)

--- a/imod/mf6/gwfgwf.py
+++ b/imod/mf6/gwfgwf.py
@@ -54,9 +54,9 @@ class GWFGWF(ExchangeBase):
 
         auxiliary_variables = [var for var in [angldegx, cdist] if var is not None]
         if auxiliary_variables:
-            self.dataset["auxiliary_data"] = xr.merge(auxiliary_variables).to_array(
-                name="auxiliary_data"
-            )
+            self.dataset["auxiliary_data"] = xr.merge(
+                auxiliary_variables, compat="no_conflicts"
+            ).to_array(name="auxiliary_data")
             expand_transient_auxiliary_variables(self)
 
     def set_options(

--- a/imod/mf6/gwtgwt.py
+++ b/imod/mf6/gwtgwt.py
@@ -58,9 +58,9 @@ class GWTGWT(ExchangeBase):
 
         auxiliary_variables = [var for var in [angldegx, cdist] if var is not None]
         if auxiliary_variables:
-            self.dataset["auxiliary_data"] = xr.merge(auxiliary_variables).to_array(
-                name="auxiliary_data"
-            )
+            self.dataset["auxiliary_data"] = xr.merge(
+                auxiliary_variables, compat="no_conflicts"
+            ).to_array(name="auxiliary_data")
             expand_transient_auxiliary_variables(self)
 
     def set_options(

--- a/imod/mf6/hfb.py
+++ b/imod/mf6/hfb.py
@@ -522,7 +522,10 @@ class HorizontalFlowBarrierBase(BoundaryCondition, ILineDataPackage):
     def line_data(self, value: GeoDataFrameType) -> None:
         variables_for_gdf = self._get_variable_names_for_gdf()
         self.dataset = self.dataset.merge(
-            value.to_xarray(), overwrite_vars=variables_for_gdf, join="right"
+            value.to_xarray(),
+            overwrite_vars=variables_for_gdf,
+            join="right",
+            compat="no_conflicts",
         )
 
     def _render(self, directory, pkgname, globaltimes, binary):

--- a/imod/typing/grid.py
+++ b/imod/typing/grid.py
@@ -186,7 +186,7 @@ def merge(
     objects: Sequence[GridDataArray | GridDataset], *args, **kwargs
 ) -> GridDataset:
     return _type_dispatch_functions_on_grid_sequence(
-        objects, xu.merge, xr.merge, *args, **kwargs
+        objects, xu.merge, xr.merge, *args, compat="no_conflicts", **kwargs
     )
 
 
@@ -263,7 +263,12 @@ def merge_with_dictionary(
     **kwargs,
 ):
     return _type_dispatch_functions_on_dict(
-        variables_to_merge, merge_unstructured_dataset, xr.merge, *args, **kwargs
+        variables_to_merge,
+        merge_unstructured_dataset,
+        xr.merge,
+        *args,
+        compat="no_conflicts",
+        **kwargs,
     )
 
 

--- a/imod/typing/structured.py
+++ b/imod/typing/structured.py
@@ -245,7 +245,7 @@ def merge_partitions(
         merged_ls = []
         for key in unique_keys:
             merged_ls.append(_merge_partitions([da[key] for da in das]).rename(key))
-        return xr.merge(merged_ls)
+        return xr.merge(merged_ls, compat="no_conflicts")
     elif isinstance(first_item, xr.DataArray):
         # Store name to rename after concatenation
         name = first_item.name


### PR DESCRIPTION
Fixes #1796

# Description
Explicitly set compat='no_conflicts' to quell a noisy warning thrown repeatedly, as we call xr.merge a lot. This is the current default of xarray.

We can later reconsider if this should be "override" in some cases. This would increase performance, at the risk of providing unexpected results when incorrect data is provided. We'd have to profile this on a heavy case (e.g. our user acceptance test) to see if it increases performance. 

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
