### PR TITLE
Issue #1831 provide custom name for Modflow6Simulation.from_imod5_data

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -20,7 +20,8 @@ Added
 - Added :meth:`imod.msw.MetaSwapModel.split` to split MetaSWAP models.
 - Added :meth:`imod.mf6.HorizontalFlowBarrierResistance.from_imod5_data` to load
   barriers from 3D GEN files. 
-
+- Added ``name`` argument to:meth:`imod.mf6.Modflow6Simulation.from_imod5_data`
+  to provide custom name to imported simulation and model.
 
 Fixed
 ~~~~~

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1857,7 +1857,13 @@ class Modflow6Simulation(collections.UserDict[str, Any], ISimulation):
         >>>     imod5_data, period_data, times, regridder_types=regridder_types, target_grid=target_grid
         >>> )
 
+        Provide custom name to the simulation and model:
 
+        >>> mf6_sim = imod.mf6.Modflow6Simulation.from_imod5_data(
+        >>>     imod5_data, period_data, times, name="custom"
+        >>> )
+        >>> print(mf6_sim.name)  # prints "custom_simulation"
+        >>> gwf_model = mf6_sim["custom_model"]
         """
         if allocation_options is None:
             allocation_options = SimulationAllocationOptions()

--- a/imod/mf6/simulation.py
+++ b/imod/mf6/simulation.py
@@ -1752,6 +1752,7 @@ class Modflow6Simulation(collections.UserDict[str, Any], ISimulation):
         distributing_options: Optional[SimulationDistributingOptions] = None,
         regridder_types: Optional[dict[str, DataclassType]] = None,
         target_grid: Optional[GridDataArray] = None,
+        name: str = "imported",
     ) -> "Modflow6Simulation":
         """
         Imports a GroundwaterFlowModel (GWF) from the data in an iMOD5 project
@@ -1799,6 +1800,9 @@ class Modflow6Simulation(collections.UserDict[str, Any], ISimulation):
         target_grid: GridDataArray, optional
             the target grid to which the data should be regridded. If not
             provided, the first grid of the BND package is used as target grid.
+        name: str, optional
+            name that will be used as a prefix for the simulation and model
+            names. Default is "imported".
 
         Returns
         -------
@@ -1866,8 +1870,9 @@ class Modflow6Simulation(collections.UserDict[str, Any], ISimulation):
             strict_well_validation=False,
             strict_hfb_validation=False,
         )
+        simulation_name = f"{name}_simulation"
         simulation = Modflow6Simulation(
-            "imported_simulation", validation_settings=validation_settings
+            simulation_name, validation_settings=validation_settings
         )
 
         # import GWF model,
@@ -1880,11 +1885,12 @@ class Modflow6Simulation(collections.UserDict[str, Any], ISimulation):
             regridder_types,
             target_grid,
         )
-        simulation["imported_model"] = gwf_model
+        gwf_modelname = f"{name}_model"
+        simulation[gwf_modelname] = gwf_model
 
         # generate ims package
         solution = SolutionPresetModerate(
-            ["imported_model"],
+            [gwf_modelname],
             print_option="all",
         )
         simulation["ims"] = solution

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -611,6 +611,22 @@ def test_import_from_imod5(imod5_dataset, tmp_path):
 
 
 @pytest.mark.unittest_jit
+def test_import_from_imod5__custom_name(imod5_dataset):
+    imod5_data = imod5_dataset[0]
+    period_data = imod5_dataset[1]
+
+    datelist = pd.date_range(start="1/1/1989", end="1/3/1989", freq="D")
+    simulation = Modflow6Simulation.from_imod5_data(
+        imod5_data,
+        period_data,
+        datelist,
+        name="custom",
+    )
+    assert "custom_simulation" in simulation.name
+    assert "custom_model" in simulation.keys()
+
+
+@pytest.mark.unittest_jit
 def test_from_imod5__has_cap_data(imod5_dataset):
     imod5_data = deepcopy(imod5_dataset[0])
     period_data = imod5_dataset[1]
@@ -669,8 +685,6 @@ def test_import_from_imod5__correct_well_type(imod5_dataset):
     original_wel_layer = imod5_data["wel-WELLS_L3"]["layer"]
     imod5_data["wel-WELLS_L3"]["layer"] = [0] * len(original_wel_layer)
     # Other arrangement
-    default_simulation_allocation_options = SimulationAllocationOptions
-    default_simulation_distributing_options = SimulationDistributingOptions
     datelist = pd.date_range(start="1/1/1989", end="1/1/2013", freq="W")
 
     # Act
@@ -678,8 +692,6 @@ def test_import_from_imod5__correct_well_type(imod5_dataset):
         imod5_data,
         period_data,
         datelist,
-        default_simulation_allocation_options,
-        default_simulation_distributing_options,
     )
     # Set layer back to right value (before AssertionError might be thrown)
     imod5_data["wel-WELLS_L3"]["layer"] = original_wel_layer


### PR DESCRIPTION
Fixes #1831 

# Description
Add ``name`` argument to ``Modflow6Simulation.from_imod5_data``. 

# Checklist
- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [x] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
