### PR TITLE
Avoid divide-by-zero for zero-thickness layers in well rate distribution (fixes #1836)

### DIFF
--- a/imod/prepare/wells.py
+++ b/imod/prepare/wells.py
@@ -87,7 +87,14 @@ def compute_penetration_mismatch_factor(
         np.minimum(well_bounds[:, 1], layer_bounds[:, 1])
         + np.maximum(well_bounds[:, 0], layer_bounds[:, 0])
     ) / 2
-    return 1.0 - np.abs(Z_c - F_c) / (0.5 * D)
+    # Zero-thickness layers (D == 0) have no overlap with any filter and are
+    # discarded downstream. Guard the division so those cells do not trigger a
+    # spurious "divide by zero" / "invalid value" RuntimeWarning (which raises
+    # under -W error) and do not produce NaN factors.
+    ratio = np.divide(
+        np.abs(Z_c - F_c), 0.5 * D, out=np.zeros_like(D, dtype=np.float64), where=D != 0
+    )
+    return 1.0 - ratio
 
 
 def compute_overlap_and_correction_factor(

--- a/imod/tests/test_prepare/test_assign_wells.py
+++ b/imod/tests/test_prepare/test_assign_wells.py
@@ -79,20 +79,33 @@ def test_compute_overlap():
     assert np.allclose(correction_actual, expected_correction)
 
 
-def test_compute_penetration_mismatch_factor_zero_thickness():
+def test_compute_penetration_mismatch_factor__zero_layer_thickness():
     # Zero-thickness layers (top == bottom) used to trigger a divide-by-zero in
     # the penetration mismatch factor, emitting a RuntimeWarning (which raises
     # under -W error) and producing NaN factors.
     layer_bounds = np.array([[0.0, 10.0], [10.0, 10.0], [10.0, 20.0]])
-    well_bounds = np.array([[2.0, 8.0], [10.0, 10.0], [12.0, 18.0]])
+    well_bounds = np.array([[2.0, 10.0], [2.0, 10.0], [12.0, 18.0]])
 
     with np.errstate(divide="raise", invalid="raise"):
         factor = prepwel.compute_penetration_mismatch_factor(well_bounds, layer_bounds)
 
     assert np.all(np.isfinite(factor))
     # the values for the non-degenerate layers are unchanged
-    assert np.allclose(factor[[0, 2]], [1.0, 1.0])
+    assert np.allclose(factor, [0.8, 1.0, 1.0])
 
+def test_compute_penetration_mismatch_factor__zero_mismatch_thickness():
+    # Zero-thickness layers (top == bottom) plus a zero mismatch factor used to
+    # trigger a invalid value in the penetration mismatch factor, emitting a
+    # RuntimeWarning (which raises under -W error) and producing NaN factors.
+    layer_bounds = np.array([[0.0, 10.0], [10.0, 10.0], [10.0, 20.0]])
+    well_bounds = np.array([[2.0, 10.0], [10.0, 10.0], [12.0, 18.0]])
+
+    with np.errstate(divide="raise", invalid="raise"):
+        factor = prepwel.compute_penetration_mismatch_factor(well_bounds, layer_bounds)
+
+    assert np.all(np.isfinite(factor))
+    # the values for the non-degenerate layers are unchanged
+    assert np.allclose(factor, [0.8, 1.0, 1.0])
 
 class AssignWellCases:
     def case_mix_wells(self):

--- a/imod/tests/test_prepare/test_assign_wells.py
+++ b/imod/tests/test_prepare/test_assign_wells.py
@@ -93,6 +93,7 @@ def test_compute_penetration_mismatch_factor__zero_layer_thickness():
     # the values for the non-degenerate layers are unchanged
     assert np.allclose(factor, [0.8, 1.0, 1.0])
 
+
 def test_compute_penetration_mismatch_factor__zero_mismatch_thickness():
     # Zero-thickness layers (top == bottom) plus a zero mismatch factor used to
     # trigger a invalid value in the penetration mismatch factor, emitting a
@@ -106,6 +107,7 @@ def test_compute_penetration_mismatch_factor__zero_mismatch_thickness():
     assert np.all(np.isfinite(factor))
     # the values for the non-degenerate layers are unchanged
     assert np.allclose(factor, [0.8, 1.0, 1.0])
+
 
 class AssignWellCases:
     def case_mix_wells(self):

--- a/imod/tests/test_prepare/test_assign_wells.py
+++ b/imod/tests/test_prepare/test_assign_wells.py
@@ -79,6 +79,21 @@ def test_compute_overlap():
     assert np.allclose(correction_actual, expected_correction)
 
 
+def test_compute_penetration_mismatch_factor_zero_thickness():
+    # Zero-thickness layers (top == bottom) used to trigger a divide-by-zero in
+    # the penetration mismatch factor, emitting a RuntimeWarning (which raises
+    # under -W error) and producing NaN factors.
+    layer_bounds = np.array([[0.0, 10.0], [10.0, 10.0], [10.0, 20.0]])
+    well_bounds = np.array([[2.0, 8.0], [10.0, 10.0], [12.0, 18.0]])
+
+    with np.errstate(divide="raise", invalid="raise"):
+        factor = prepwel.compute_penetration_mismatch_factor(well_bounds, layer_bounds)
+
+    assert np.all(np.isfinite(factor))
+    # the values for the non-degenerate layers are unchanged
+    assert np.allclose(factor[[0, 2]], [1.0, 1.0])
+
+
 class AssignWellCases:
     def case_mix_wells(self):
         # This is a testcase where NOT all the wells are in the domain, but most


### PR DESCRIPTION
### Summary

When distributing well rates, `compute_penetration_mismatch_factor` evaluates
the iMOD5 correction factor

```
F = 1 - |Zc - Fc| / (0.5 * D)
```

where `D = top - bottom` is the layer thickness. For **zero-thickness** model
cells (`top == bottom`, common in layered models) this divides by zero, which:

- emits `RuntimeWarning: divide by zero / invalid value encountered in divide`
  (the noisy warnings reported in #1836), and
- **raises** under `-W error` / `np.errstate(invalid="raise")`, and
- produces `NaN` correction factors for those cells.

```python
import numpy as np
from imod.prepare.wells import compute_penetration_mismatch_factor
layer_bounds = np.array([[0.0, 10.0], [10.0, 10.0], [10.0, 20.0]])  # middle layer D=0
well_bounds  = np.array([[2.0, 8.0],  [10.0, 10.0], [12.0, 18.0]])
compute_penetration_mismatch_factor(well_bounds, layer_bounds)
# RuntimeWarning: invalid value encountered in divide  ->  array([ 1., nan,  1.])
```

### Fix

Zero-thickness layers have no overlap with any filter and are discarded
downstream (`overlap > minimum_thickness` filtering), so the factor value for
those cells is irrelevant. Guard the division with
`np.divide(..., where=D != 0)` so degenerate cells get a finite value (no
warning, no NaN). Values for non-degenerate layers are unchanged.

### Verification

Added `test_compute_penetration_mismatch_factor_zero_thickness` to
`imod/tests/test_prepare/test_assign_wells.py`, which runs the factor under
`np.errstate(divide="raise", invalid="raise")` and asserts the result is finite.
It fails on `master` (`FloatingPointError ... divide`) and passes with this
change. The existing `test_assign_wells.py` suite (13 tests) still passes.

Fixes #1836.
