### PR TITLE
Issue #1858 Reading mete_grid.inp crashes on empty lines

### DIFF
--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -50,7 +50,7 @@ def open_first_meteo_grid(mete_grid_path: str | Path, column_nr: int) -> xr.Data
     potential_paths = []
     for line in lines:
         cols = line.strip().split(",")
-        if len(cols) > column_nr:                       # Check if column exists, if not: skip
+        if len(cols) > column_nr:  # Check if column exists, if not: skip
             potential_path = cols[column_nr].replace('"', "")
             potential_paths.append(potential_path)
             if _is_parsable_and_existing_path(potential_path, mete_grid_path):

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -50,10 +50,11 @@ def open_first_meteo_grid(mete_grid_path: str | Path, column_nr: int) -> xr.Data
     potential_paths = []
     for line in lines:
         cols = line.strip().split(",")
-        if len(cols) > column_nr:
-            potential_paths.append(cols[column_nr].replace('"', ""))
-            if _is_parsable_and_existing_path(potential_paths[-1], mete_grid_path):
-                resolved_path = mete_grid_path / ".." / Path(potential_paths[-1])
+        if len(cols) > column_nr:                       # Check if column exists, if not: skip
+            potential_path = cols[column_nr].replace('"', "")
+            potential_paths.append(potential_path)
+            if _is_parsable_and_existing_path(potential_path, mete_grid_path):
+                resolved_path = mete_grid_path / ".." / Path(potential_path)
                 return imod.rasterio.open(resolved_path)
 
     error_message = dedent(f"""    

--- a/imod/msw/meteo_mapping.py
+++ b/imod/msw/meteo_mapping.py
@@ -47,11 +47,14 @@ def open_first_meteo_grid(mete_grid_path: str | Path, column_nr: int) -> xr.Data
     with open(mete_grid_path, "r") as f:
         lines = f.readlines()
 
-    potential_paths = [line.split(",")[column_nr].replace('"', "") for line in lines]
-    for potential_path in potential_paths:
-        if _is_parsable_and_existing_path(potential_path, mete_grid_path):
-            resolved_path = mete_grid_path / ".." / Path(potential_path)
-            return imod.rasterio.open(resolved_path)
+    potential_paths = []
+    for line in lines:
+        cols = line.strip().split(",")
+        if len(cols) > column_nr:
+            potential_paths.append(cols[column_nr].replace('"', ""))
+            if _is_parsable_and_existing_path(potential_paths[-1], mete_grid_path):
+                resolved_path = mete_grid_path / ".." / Path(potential_paths[-1])
+                return imod.rasterio.open(resolved_path)
 
     error_message = dedent(f"""    
     Did not find parsable path to existing .ASC file in column {column_nr}. Got

--- a/imod/tests/test_msw/test_meteo_grid.py
+++ b/imod/tests/test_msw/test_meteo_grid.py
@@ -11,6 +11,7 @@ import xarray as xr
 from numpy.testing import assert_equal
 
 from imod.msw import MeteoGrid, MeteoGridCopy
+from imod.msw.meteo_mapping import open_first_meteo_grid
 from imod.util.regrid import RegridderWeightsCache
 
 
@@ -21,7 +22,7 @@ def test_meteo_grid_init(meteo_grids):
     assert meteo_grids.dataset["evapotranspiration"].dims == ("time",)
 
 
-def test_meteo_grid_write(meteo_grids):
+def test_meteo_grid_write_read(meteo_grids):
     meteo_grid = MeteoGrid(*meteo_grids)
 
     with tempfile.TemporaryDirectory() as output_dir:
@@ -32,6 +33,19 @@ def test_meteo_grid_write(meteo_grids):
             output_dir / "mete_grid.inp", header=None, quoting=csv.QUOTE_NONE
         )
         gridnames = sorted([file.name for file in output_dir.glob("meteo_grids/*.asc")])
+
+        # test reading as well : roundtrip
+        with open(output_dir / "mete_grid.inp") as fin:
+            lines = fin.readlines()
+        lines.insert(
+            -1, " "
+        )  # add an empty line to test robustness of the parser to empty lines
+        lines.append(" ")
+        with open(output_dir / "mete_grid.inp", "w") as fout:
+            fout.writelines(lines)
+        open_first_meteo_grid(
+            output_dir / "mete_grid.inp", 2
+        )  # only test parsing of the mete_grid.inp file
 
     expected_paths = [
         '"meteo_grids' + os.path.sep + 'precipitation_20000101000000.asc"',


### PR DESCRIPTION
Included reading of the mete_grid.inp in the existing write test:
test_meteo_grid_write_read

Fixes #1858 
Crash on empty line in mete_grid.inp file

# Description
<!---
Included reading of the mete_grid.inp in the existing write test:
test_meteo_grid_write_read from test_meteo_grid_write
improved the robustness of the parsing of mete_grid.inp lines by first
checking whether the requested field (columnr) exists in the parsed line.
Avoids the crash mentioned in the corresponding issue.
-->

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [*] Links to correct issue
- [-] Update changelog, if changes affect users
- [*] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [*] Unit tests were added
- [-] **If feature added**: Added/extended example
- [-] **If feature added**: Added feature to API documentation
- [-] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
