### PR TITLE
Issue #1857 error on empty line prj

### DIFF
--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -451,6 +451,8 @@ def _parse_block(lines: _LineIterator, content: Dict[str, Any]) -> None:
     while key is None and not lines.finished:
         n, key, active = _parse_blockheader(lines)
 
+    if key is None:
+        return
     try:
         if key in KEYS:
             if n != 1:

--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -484,7 +484,9 @@ def _parse_block(lines: _LineIterator, content: Dict[str, Any]) -> None:
             )
 
     except Exception as e:
-        raise type(e)(f"{e}\nError occurred for keyword: {key}")
+        raise type(e)(
+            f"{e}\nError occurred for keyword: {key} in line {lines.count + 1}"
+        )
 
     if blockcontent is not None and active is not None:
         blockcontent["active"] = active

--- a/imod/tests/test_formats/test_prj.py
+++ b/imod/tests/test_formats/test_prj.py
@@ -118,6 +118,7 @@ PRJ_TEMPLATE = textwrap.dedent(
     "benzene",1
     "chloride",2
 
+
     """
 )
 

--- a/imod/tests/test_formats/test_prj.py
+++ b/imod/tests/test_formats/test_prj.py
@@ -94,6 +94,8 @@ PRJ_TEMPLATE = textwrap.dedent(
         1,2, 000, 100000.0, 1.0, -999.9900 ,"{basepath}/first.gen"
         1,2, 000, 100000.0, 1.0, -999.9900 ,"{basepath}/second.gen"
 
+
+
     0001,(PCG),1, Precondition Conjugate-Gradient,[]
         MXITER=  500
         ITER1=   25


### PR DESCRIPTION
Fixes #1857 

# Description
<!---
Project files ending on an empty line tend to crash upon reading.
Fixed
-->

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [*] Links to correct issue
- [-] Update changelog, if changes affect users
- [*] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [*] Unit tests were added  --> modified existing input prj for read unittest, added line
- [-] **If feature added**: Added/extended example
- [-] **If feature added**: Added feature to API documentation
- [-] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
