### PR TITLE
Issue #366: make mask method available to MetaSWAP model class

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -22,6 +22,8 @@ Added
   barriers from 3D GEN files. 
 - Added ``name`` argument to:meth:`imod.mf6.Modflow6Simulation.from_imod5_data`
   to provide custom name to imported simulation and model.
+- Added :meth:`imod.msw.MetaSwapModel.mask_all_packages` to mask all packages of
+  a MetaSWAP model.
 
 Fixed
 ~~~~~

--- a/docs/api/msw.rst
+++ b/docs/api/msw.rst
@@ -14,6 +14,7 @@ Model objects & methods
     MetaSwapModel.dump
     MetaSwapModel.from_imod5_data
     MetaSwapModel.regrid_like
+    MetaSwapModel.mask_all_packages
     MetaSwapModel.clip_box
     MetaSwapModel.get_pkgkey
 

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -525,19 +525,14 @@ class MetaSwapModel(Model, IDict):
         be presented as an idomain-like integer array that has 0 (inactive) or
         <0 (vertical passthrough) values in filtered cells and >0 in active
         cells.
-        Masking will overwrite idomain with the mask where the mask is <=0.
-        Where the mask is >0, the original value of idomain will be kept. Masking
-        will update the packages accordingly, blanking their input where needed,
-        and is therefore not a reversible operation.
 
         Parameters
         ----------
-        mask: xr.DataArray, xu.UgridDataArray of ints
-            idomain-like integer array. >0 sets cells to active, 0 sets cells to inactive,
-            <0 sets cells to vertical passthrough
-        ignore_time_purge_empty: bool, default False
-            Whether to ignore time dimension when purging empty packages. Can
-            improve performance when masking models with many time steps.
+        msw_active: MetaSwapActive, dictionary of xr.DataArray
+            idomain-like integers. >0 sets cells to active, 0 sets cells to inactive,
+            all: applies to all packages without a subunit dimension
+            subunit: applies to all packages with a subunit dimension on a per-subunit basis 
+                     (mask has a subunit dimension)
         """
 
         for pkg in self.values():

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -23,9 +23,9 @@ from imod.common.utilities.regrid import regrid_imod5_cap_data
 from imod.common.utilities.version import prepend_content_with_version_info
 from imod.mf6.dis import StructuredDiscretization
 from imod.mf6.mf6_wel_adapter import Mf6Wel
+from imod.msw import GridData
 from imod.msw.copy_files import FileCopier
 from imod.msw.coupler_mapping import CouplerMapping
-from imod.msw.grid_data import GridData
 from imod.msw.idf_mapping import IdfMapping
 from imod.msw.infiltration import Infiltration
 from imod.msw.initial_conditions import (
@@ -52,7 +52,11 @@ from imod.msw.utilities.common import find_in_file_list
 from imod.msw.utilities.imod5_converter import (
     has_active_scaling_factor,
 )
-from imod.msw.utilities.mask import mask_and_broadcast_cap_data
+from imod.msw.utilities.mask import (
+    MetaSwapActive,
+    mask_and_broadcast_cap_data,
+    mask_and_broadcast_pkg_data,
+)
 from imod.msw.utilities.parse import read_para_sim
 from imod.msw.vegetation import AnnualCropFactors
 from imod.typing import GridDataArray, Imod5DataDict
@@ -510,6 +514,41 @@ class MetaSwapModel(Model, IDict):
             regridded_model[mod2svat_name] = CouplerMapping()
 
         return regridded_model
+
+    def mask_all_packages(
+        self,
+        msw_active: MetaSwapActive,
+        #       ignore_time_purge_empty: bool = False,
+    ):
+        """
+        This function applies a mask to all packages in a model. The mask must
+        be presented as an idomain-like integer array that has 0 (inactive) or
+        <0 (vertical passthrough) values in filtered cells and >0 in active
+        cells.
+        Masking will overwrite idomain with the mask where the mask is <=0.
+        Where the mask is >0, the original value of idomain will be kept. Masking
+        will update the packages accordingly, blanking their input where needed,
+        and is therefore not a reversible operation.
+
+        Parameters
+        ----------
+        mask: xr.DataArray, xu.UgridDataArray of ints
+            idomain-like integer array. >0 sets cells to active, 0 sets cells to inactive,
+            <0 sets cells to vertical passthrough
+        ignore_time_purge_empty: bool, default False
+            Whether to ignore time dimension when purging empty packages. Can
+            improve performance when masking models with many time steps.
+        """
+
+        for pkg in self.values():
+            if "x" in pkg.dataset.dims and "y" in pkg.dataset.dims:
+                data_dict = {
+                    key: pkg.dataset[key] for key in pkg.dataset.data_vars.keys()
+                }
+                masked_data = mask_and_broadcast_pkg_data(pkg, data_dict, msw_active)
+                for key, data in masked_data.items():
+                    pkg.dataset[key] = data
+        return
 
     def clip_box(
         self,

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -517,8 +517,7 @@ class MetaSwapModel(Model, IDict):
 
     def mask_all_packages(
         self,
-        msw_active: MetaSwapActive,
-        #       ignore_time_purge_empty: bool = False,
+        mask: GridDataArray,
     ):
         """
          This function applies a mask to all packages in a model. The mask must
@@ -555,6 +554,18 @@ class MetaSwapModel(Model, IDict):
          >>> msw_active = MetaSwapActive(mask_all, mask_per_subunit)
          >>> msw_model.mask_all_packages(msw_active)
         """
+
+        if "subunit" in mask.dims:
+            mask_all = mask.any(dim="subunit")
+            msw_active = MetaSwapActive(all=mask_all, per_subunit=mask)
+        else:
+            nsub = 1
+            for pkg in self.values():
+                if "subunit" in pkg.dataset.dims:
+                    nsub = pkg.dataset.dims["subunit"]
+                    break
+            mask_per_subunit = mask.expand_dims(dim={"subunit": nsub})
+            msw_active = MetaSwapActive(all=mask, per_subunit=mask_per_subunit)
 
         for pkg in self.values():
             if "x" in pkg.dataset.dims and "y" in pkg.dataset.dims:

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -521,18 +521,39 @@ class MetaSwapModel(Model, IDict):
         #       ignore_time_purge_empty: bool = False,
     ):
         """
-        This function applies a mask to all packages in a model. The mask must
-        be presented as an idomain-like integer array that has 0 (inactive) or
-        <0 (vertical passthrough) values in filtered cells and >0 in active
-        cells.
+         This function applies a mask to all packages in a model. The mask must
+         be presented as a MetaSwap Active object, which contains idomain-like integers. 
+         The mask is applied to all packages in the model, and the values in the mask determine which cells are active and which are inactive. The mask is applied to all packages, regardless of whether they have a subunit dimension or not.
 
-        Parameters
-        ----------
-        msw_active: MetaSwapActive, dictionary of xr.DataArray
-            idomain-like integers. >0 sets cells to active, 0 sets cells to inactive,
-            all: applies to all packages without a subunit dimension
-            subunit: applies to all packages with a subunit dimension on a per-subunit basis 
-                     (mask has a subunit dimension)
+         Parameters
+         ----------
+         msw_active: MetaSwapActive, dictionary of xr.DataArray
+             idomain-like integers. >0 sets cells to active, 0 sets cells to inactive,
+             all: applies to all packages without a subunit dimension
+             subunit: applies to all packages with a subunit dimension on a per-subunit basis
+                      (mask has a subunit dimension)
+
+        Example
+         -------
+         >>> mask_per_subunit = xr.DataArray(
+         >>>     np.array(
+         >>>         [
+         >>>             [[0, 0, 0], [0, 1, 1], [0, 0, 0]],
+         >>>             [[1, 1, 1], [0, 1, 1], [0, 0, 0]],
+         >>>         ]
+         >>>     ).astype(bool),
+         >>>     dims=("subunit", "y", "x"),
+         >>>     coords = {
+         >>>         "x" : [1.0, 2.0, 3.0],
+         >>>         "y" : [3.0, 2.0, 1.0],
+         >>>         "dx" : 1.0,
+         >>>         "dy" : 1.0,
+         >>>         "subunit" : [0, 1]
+         >>>     }
+         >>> )
+         >>> mask_all = mask_per_subunit.any(dim="subunit")
+         >>> msw_active = MetaSwapActive(mask_all, mask_per_subunit)
+         >>> msw_model.mask_all_packages(msw_active)
         """
 
         for pkg in self.values():

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -521,20 +521,19 @@ class MetaSwapModel(Model, IDict):
     ):
         """
          This function applies a mask to all packages in a model. The mask must
-         be presented as a MetaSwap Active object, which contains idomain-like integers.
+         be presented as a GridDataArray, which contains idomain-like integers.
          The mask is applied to all packages in the model, and the values in the mask determine which cells are active and which are inactive. The mask is applied to all packages, regardless of whether they have a subunit dimension or not.
 
          Parameters
          ----------
-         msw_active: MetaSwapActive, dictionary of xr.DataArray
+         mask: GridDataArray
              idomain-like integers. >0 sets cells to active, 0 sets cells to inactive,
-             all: applies to all packages without a subunit dimension
-             subunit: applies to all packages with a subunit dimension on a per-subunit basis
-                      (mask has a subunit dimension)
+             mask is applied on a per-subunit basis if the package has a subunit dimension.
+             If the package does not have a subunit dimension, the mask is applied to all subunits of the package.
 
         Example
          -------
-         >>> mask_per_subunit = xr.DataArray(
+         >>> mask = xr.DataArray(
          >>>     np.array(
          >>>         [
          >>>             [[0, 0, 0], [0, 1, 1], [0, 0, 0]],
@@ -550,9 +549,6 @@ class MetaSwapModel(Model, IDict):
          >>>         "subunit" : [0, 1]
          >>>     }
          >>> )
-         >>> mask_all = mask_per_subunit.any(dim="subunit")
-         >>> msw_active = MetaSwapActive(mask_all, mask_per_subunit)
-         >>> msw_model.mask_all_packages(msw_active)
         """
 
         if "subunit" in mask.dims:

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -522,7 +522,7 @@ class MetaSwapModel(Model, IDict):
     ):
         """
          This function applies a mask to all packages in a model. The mask must
-         be presented as a MetaSwap Active object, which contains idomain-like integers. 
+         be presented as a MetaSwap Active object, which contains idomain-like integers.
          The mask is applied to all packages in the model, and the values in the mask determine which cells are active and which are inactive. The mask is applied to all packages, regardless of whether they have a subunit dimension or not.
 
          Parameters

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -546,8 +546,9 @@ class MetaSwapModel(Model, IDict):
          ----------
          mask: GridDataArray
              idomain-like integers. >0 sets cells to active, 0 sets cells to inactive,
-             mask is applied on a per-subunit basis if the package has a subunit dimension.
-             If the package does not have a subunit dimension, the mask is applied to all subunits of the package.
+             mask is applied on a per-subunit basis if the mask grid has a subunit dimension.
+             If the package does not have a subunit dimension, the combined mask grid over all of its subunits is applied,
+             i.e. a cell is set to active if it is active in any of the subunits.
 
         Example
          -------

--- a/imod/msw/model.py
+++ b/imod/msw/model.py
@@ -264,6 +264,24 @@ class MetaSwapModel(Model, IDict):
         starttime = min(starttimes)
         return starttime
 
+    @property
+    def nsubunits(self) -> int:
+        """
+        Get the number of subunits in the model from the first dataset having a subunit dimension.
+        Defaults to 1 if no package has a subunit dimension.
+
+        Returns
+        -------
+        int
+            The number of subunits in the model.
+        """
+        nsub = 1
+        for pkg in self.values():
+            if "subunit" in pkg.dataset.dims:
+                nsub = pkg.dataset.dims["subunit"]
+                break
+        return nsub
+
     def get_pkgkey(
         self, pkg_type: type[MetaSwapPackage], optional_package: bool = False
     ) -> str | None:
@@ -555,12 +573,7 @@ class MetaSwapModel(Model, IDict):
             mask_all = mask.any(dim="subunit")
             msw_active = MetaSwapActive(all=mask_all, per_subunit=mask)
         else:
-            nsub = 1
-            for pkg in self.values():
-                if "subunit" in pkg.dataset.dims:
-                    nsub = pkg.dataset.dims["subunit"]
-                    break
-            mask_per_subunit = mask.expand_dims(dim={"subunit": nsub})
+            mask_per_subunit = mask.expand_dims(dim={"subunit": self.nsubunits})
             msw_active = MetaSwapActive(all=mask, per_subunit=mask_per_subunit)
 
         for pkg in self.values():

--- a/imod/tests/test_msw/test_model.py
+++ b/imod/tests/test_msw/test_model.py
@@ -47,6 +47,25 @@ def test_msw_pkgdump_zarrzip(msw_model, tmpdir_factory):
     roundtrip(msw_model, tmpdir_factory, name="testmodel", engine="zarr.zip")
 
 
+def test_msw_mask_all(msw_model, tmpdir_factory, mask_fixture):
+    # Apply the mask to all packages in the model
+    msw_model.mask_all_packages(mask_fixture)
+
+    # Check that the mask has been applied correctly to each package
+    for pkgname, pkg in msw_model.items():
+        if isinstance(pkg, msw.meteo_mapping.PrecipitationMapping):
+            continue  # Skip PrecipitationMapping package for this test
+        if isinstance(pkg, msw.meteo_mapping.EvapotranspirationMapping):
+            continue  # Skip EvapotranspirationMapping package for this test
+        for var in pkg.dataset.data_vars:
+            da = pkg.dataset[var]
+            if "y" in da.dims and "x" in da.dims:
+                assert (
+                    da.where(mask_fixture).equals(da)
+                    or da.where(~mask_fixture).isnull().all()
+                )
+
+
 def test_msw_model_write(msw_model, coupled_mf6_model, coupled_mf6wel, tmp_path):
     mf6_dis = coupled_mf6_model["GWF_1"]["dis"]
 

--- a/imod/tests/test_msw/test_model.py
+++ b/imod/tests/test_msw/test_model.py
@@ -22,7 +22,7 @@ from imod.util.spatial import empty_2d
 
 
 @pytest.fixture(scope="function")
-def mask_fixture() -> MetaSwapActive:
+def mask_fixture() -> xr.DataArray:
     mask_per_subunit = xr.DataArray(
         np.array(
             [
@@ -39,9 +39,7 @@ def mask_fixture() -> MetaSwapActive:
             "subunit": [0, 1],
         },
     )
-    mask_all = mask_per_subunit.any(dim="subunit")
-
-    return MetaSwapActive(mask_all, mask_per_subunit)
+    return mask_per_subunit
 
 
 def roundtrip(msw_model, tmpdir_factory, name, engine):
@@ -77,17 +75,15 @@ def test_msw_mask_all(msw_model, tmpdir_factory, mask_fixture):
     msw_model.mask_all_packages(mask_fixture)
 
     # Check that the mask has been applied correctly to each package
+    mask_all = mask_fixture.any(dim="subunit")
+    msw_active = MetaSwapActive(all=mask_all, per_subunit=mask_fixture)
     for pkgname, pkg in msw_model.items():
-        if isinstance(pkg, msw.meteo_mapping.PrecipitationMapping):
-            continue  # Skip PrecipitationMapping package for this test
-        if isinstance(pkg, msw.meteo_mapping.EvapotranspirationMapping):
-            continue  # Skip EvapotranspirationMapping package for this test
         for var in pkg.dataset.data_vars:
             da = pkg.dataset[var]
             if "y" in da.dims and "x" in da.dims:
                 assert (
-                    da.where(mask_fixture).equals(da)
-                    or da.where(~mask_fixture).isnull().all()
+                    da.where(msw_active).equals(da)
+                    or da.where(~msw_active).isnull().all()
                 )
 
 

--- a/imod/tests/test_msw/test_model.py
+++ b/imod/tests/test_msw/test_model.py
@@ -2,6 +2,7 @@ from copy import copy
 from pathlib import Path
 from typing import cast
 
+import numpy as np
 import pytest
 import xarray as xr
 from numpy.testing import assert_almost_equal, assert_equal
@@ -12,11 +13,35 @@ from imod.msw.copy_files import FileCopier
 from imod.msw.meteo_grid import MeteoGridCopy
 from imod.msw.meteo_mapping import MeteoMapping
 from imod.msw.model import DEFAULT_SETTINGS, MetaSwapModel
+from imod.msw.utilities.mask import MetaSwapActive
 from imod.msw.utilities.parse import read_para_sim
 from imod.typing import GridDataArray, Imod5DataDict
 from imod.typing.grid import zeros_like
 from imod.util.regrid import RegridderWeightsCache
 from imod.util.spatial import empty_2d
+
+
+@pytest.fixture(scope="function")
+def mask_fixture() -> MetaSwapActive:
+    mask_per_subunit = xr.DataArray(
+        np.array(
+            [
+                [[0, 0, 0], [0, 1, 1], [0, 0, 0]],
+                [[1, 1, 1], [0, 1, 1], [0, 0, 0]],
+            ]
+        ).astype(bool),
+        dims=("subunit", "y", "x"),
+        coords={
+            "x": [1.0, 2.0, 3.0],
+            "y": [3.0, 2.0, 1.0],
+            "dx": 1.0,
+            "dy": 1.0,
+            "subunit": [0, 1],
+        },
+    )
+    mask_all = mask_per_subunit.any(dim="subunit")
+
+    return MetaSwapActive(mask_all, mask_per_subunit)
 
 
 def roundtrip(msw_model, tmpdir_factory, name, engine):


### PR DESCRIPTION


Fixes #366

# Description
<!---
Existing functionality for applying masking to MetaSWAP packages disclosed as a method in the MetaSWAP model class.
A test was added, to the set of tests for this class, that calls the mask_all_packages method.
-->

# Checklist
- [*] Links to correct issue
- [-] Update changelog, if changes affect users
- [*] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [*] Unit test was added: 
- [*] **If feature added**: Added/extended example (in docstring)
- [*] **If feature added**: Added feature to API documentation
- [-] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
