### PR TITLE
Update docker building docs

### DIFF
--- a/.teamcity/Dockerfile/Dockerfile
+++ b/.teamcity/Dockerfile/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/windows/server:ltsc2022
 LABEL maintainer="sunny.titus@deltares.nl"
 
-ARG PIXI_VERSION=v0.59.0
+ARG PIXI_VERSION=v0.69.0
 
 ## Setup user
 USER "NT Authority\System"

--- a/.teamcity/_Self/MainProject.kt
+++ b/.teamcity/_Self/MainProject.kt
@@ -19,7 +19,7 @@ import jetbrains.buildServer.configs.kotlin.triggers.vcs
 object MainProject : Project({
     params {
         param("DockerContainer", "containers.deltares.nl/hydrology_product_line_imod/windows-pixi")
-        param("DockerVersion", "v0.59.0")
+        param("DockerVersion", "v0.69.0")
     }
 
     buildType(Lint)

--- a/docs/developing/docker.rst
+++ b/docs/developing/docker.rst
@@ -18,10 +18,12 @@ The dockerfile can be found at `.teamcity\\Dockerfile\\Dockerfile` and is displa
 
 How to build
 ------------
-A prerequisite of building the image is that you have `Docker Desktop`_ installed on your machine.
-Once installed open a console and navigate to the folder where the dockerfile resides.
 
-To build the image:
+A prerequisite of building the image is that you have `Docker Desktop`_
+installed on your machine. Make sure you are using a Windows builder, click the
+Docker tray icon (bottom right) and select "Switch to Windows containers". This
+will allow you to build the image on your local machine. Once installed open a
+console and navigate to the folder where the dockerfile resides.
 
 .. code-block:: console
 


### PR DESCRIPTION
Fixes #1874 

# Description
I build a new version of the Docker image and pushed it to the repository. This PR:

- Updates the dev docs with an important detail
- Use the recent docker image

This caused a stall of https://github.com/Deltares/imod-python/pull/1870

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
