### PR TITLE
Issue #1861 inconsistent ipf, report file name in the log

### DIFF
--- a/imod/formats/ipf.py
+++ b/imod/formats/ipf.py
@@ -50,14 +50,15 @@ def _read_ipf(path, kwargs=None) -> Tuple[pd.DataFrame, int, str]:
         if not has_expected_cols:
             log_message = (
                 f"Inconsistent IPF: header states {ncol} columns,"
-                + " first line of file:\n{f.name} \ncontains {len(line.split())} whitespace-delimited"
-                + " columns and {len(next(csv.reader([line])))} comma-delimited columns."
+                + f" first line of file [{f.name}] contains {len(line.split())} whitespace-delimited"
+                + f" columns and {len(next(csv.reader([line])))} comma-delimited columns."
             )
             imod.logging.logger.log(
                 loglevel=LogLevel.WARNING,
                 message=log_message,
                 additional_depth=2,
             )
+            warnings.warn(log_message)
         f.seek(position)
         sep = r"\s+" if delim_whitespace else ","
 
@@ -180,7 +181,7 @@ def read_associated(path, kwargs={}):
                 message=log_message,
                 additional_depth=2,
             )
-        warnings.warn(log_message)
+            warnings.warn(log_message)
         sep = r"\s+" if delim_whitespace else ","
         # Normally, this ought to work:
         # metadata = pd.read_csv(f, header=None, nrows=ncol).values
@@ -230,7 +231,7 @@ def read_associated(path, kwargs={}):
                 message=log_message,
                 additional_depth=2,
             )
-
+            warnings.warn(log_message)
         sep = r"\s+" if delim_whitespace else ","
 
         itype_kwargs = {

--- a/imod/formats/ipf.py
+++ b/imod/formats/ipf.py
@@ -173,8 +173,8 @@ def read_associated(path, kwargs={}):
         if not has_expected_cols:
             log_message = (
                 f"Inconsistent IPF: header states {ncol} columns,"
-                + " first line of file:\n{f.name} \ncontains {len(line.split())} whitespace-delimited"
-                + " columns and {len(next(csv.reader([line])))} comma-delimited columns."
+                + f" first line of file:\n{f.name} \ncontains {len(line.split())} whitespace-delimited"
+                + f" columns and {len(next(csv.reader([line])))} comma-delimited columns."
             )
             imod.logging.logger.log(
                 loglevel=LogLevel.WARNING,
@@ -223,8 +223,8 @@ def read_associated(path, kwargs={}):
         if not has_expected_cols:
             log_message = (
                 f"Inconsistent IPF: header states {ncol} columns,"
-                + " first datablock of file:\n{f.name} \ncontains {len(line.split())} whitespace-delimited"
-                + " columns and {len(next(csv.reader([line])))} comma-delimited columns."
+                + f" first datablock of file:\n{f.name} \ncontains {len(line.split())} whitespace-delimited"
+                + f" columns and {len(next(csv.reader([line])))} comma-delimited columns."
             )
             imod.logging.logger.log(
                 loglevel=LogLevel.WARNING,

--- a/imod/formats/ipf.py
+++ b/imod/formats/ipf.py
@@ -24,16 +24,7 @@ from imod.util.time import to_pandas_datetime_series
 
 def _infer_delimwhitespace(line, ncol):
     delimiter_info = infer_line_delimiter_info(line, ncol)
-
-    if not delimiter_info.has_expected_cols:
-        log_message = f"Inconsistent IPF: header states {ncol} columns, first line contains {len(line.split())} whitespace-delimited columns and {len(next(csv.reader([line])))} comma-delimited columns."
-        imod.logging.logger.log(
-            loglevel=LogLevel.WARNING,
-            message=log_message,
-            additional_depth=2,
-        )
-        warnings.warn(log_message)
-    return delimiter_info.has_whitespace
+    return delimiter_info.has_whitespace, delimiter_info.has_expected_cols
 
 
 def _read_ipf(path, kwargs=None) -> Tuple[pd.DataFrame, int, str]:
@@ -55,7 +46,18 @@ def _read_ipf(path, kwargs=None) -> Tuple[pd.DataFrame, int, str]:
 
         position = f.tell()
         line = f.readline()
-        delim_whitespace = _infer_delimwhitespace(line, ncol)
+        delim_whitespace, has_expected_cols = _infer_delimwhitespace(line, ncol)
+        if not has_expected_cols:
+            log_message = (
+                f"Inconsistent IPF: header states {ncol} columns,"
+                + " first line of file:\n{f.name} \ncontains {len(line.split())} whitespace-delimited"
+                + " columns and {len(next(csv.reader([line])))} comma-delimited columns."
+            )
+            imod.logging.logger.log(
+                loglevel=LogLevel.WARNING,
+                message=log_message,
+                additional_depth=2,
+            )
         f.seek(position)
         sep = r"\s+" if delim_whitespace else ","
 
@@ -166,7 +168,19 @@ def read_associated(path, kwargs={}):
         # this is a workaround for a pandas bug, probable related issue:
         # https://github.com/pandas-dev/pandas/issues/19827#issuecomment-398649163
         lines = [f.readline() for _ in range(ncol)]
-        delim_whitespace = _infer_delimwhitespace(lines[0], 2)
+        delim_whitespace, has_expected_cols = _infer_delimwhitespace(lines[0], 2)
+        if not has_expected_cols:
+            log_message = (
+                f"Inconsistent IPF: header states {ncol} columns,"
+                + " first line of file:\n{f.name} \ncontains {len(line.split())} whitespace-delimited"
+                + " columns and {len(next(csv.reader([line])))} comma-delimited columns."
+            )
+            imod.logging.logger.log(
+                loglevel=LogLevel.WARNING,
+                message=log_message,
+                additional_depth=2,
+            )
+        warnings.warn(log_message)
         sep = r"\s+" if delim_whitespace else ","
         # Normally, this ought to work:
         # metadata = pd.read_csv(f, header=None, nrows=ncol).values
@@ -204,7 +218,19 @@ def read_associated(path, kwargs={}):
         position = f.tell()
         line = f.readline()
         f.seek(position)
-        delim_whitespace = _infer_delimwhitespace(line, ncol)
+        delim_whitespace, has_expected_cols = _infer_delimwhitespace(line, ncol)
+        if not has_expected_cols:
+            log_message = (
+                f"Inconsistent IPF: header states {ncol} columns,"
+                + " first datablock of file:\n{f.name} \ncontains {len(line.split())} whitespace-delimited"
+                + " columns and {len(next(csv.reader([line])))} comma-delimited columns."
+            )
+            imod.logging.logger.log(
+                loglevel=LogLevel.WARNING,
+                message=log_message,
+                additional_depth=2,
+            )
+
         sep = r"\s+" if delim_whitespace else ","
 
         itype_kwargs = {

--- a/imod/tests/test_formats/test_ipf.py
+++ b/imod/tests/test_formats/test_ipf.py
@@ -2,7 +2,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import imod.logging
 from imod import ipf
+from imod.logging.config import LoggerType
+from imod.logging.loglevel import LogLevel
 from imod.testing import assert_frame_equal
 
 
@@ -104,6 +107,35 @@ def test_read_associated__itype1implicit(tmp_path):
         f.write(assoc_string.format(delim=delim))
     df = ipf.read_associated(path, {"sep": r"\s+"})
     assert df.shape == (2, 2)
+
+
+def test_read__comma_wrong(write_basic_ipf, tmp_path, monkeypatch):
+    # change working directory to tmp_path to ensure that the log file is created there
+    monkeypatch.chdir(tmp_path)
+    imod.logging.configure(
+        LoggerType.PYTHON,
+        LogLevel.WARNING,
+        add_default_stream_handler=False,
+        add_default_file_handler=True,
+    )
+    path = "basic_comma.ipf"
+    write_basic_ipf(path, ",")
+
+    # modify the ipf file to deliberatie create an error by adding a column
+    with open(path, "r") as f:
+        content = f.readlines()
+    content[1] = "5\n"
+    content.insert(6, "Provincie\n")
+    with open(path, "w") as f:
+        f.writelines(content)
+
+    # read the ipf file, which should trigger a warning due to the mismatch in number of columns
+    ipf.read(path)
+
+    # check if the raised warning contains at least the file name of interest
+    with open("imod-python.log", "r") as ff:
+        #    assert "["+path+"]" in ff.read()
+        assert f"[{path}]" in ff.read()
 
 
 def test_read__comma(write_basic_ipf, tmp_path):

--- a/imod/tests/test_formats/test_ipf.py
+++ b/imod/tests/test_formats/test_ipf.py
@@ -121,7 +121,7 @@ def test_read__comma_wrong(write_basic_ipf, tmp_path, monkeypatch):
     path = "basic_comma.ipf"
     write_basic_ipf(path, ",")
 
-    # modify the ipf file to deliberatie create an error by adding a column
+    # modify the ipf file to deliberately create an error by adding a column
     with open(path, "r") as f:
         content = f.readlines()
     content[1] = "5\n"


### PR DESCRIPTION
Fixes #1861 

# Description
<!---
Minor addition: when the number of columns in the ipf file is not as expected, now also the name of the file of interest is reported in the log warning message.  A test was added for this as well based on an existing test
-->

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [*] Links to correct issue
- [-] Update changelog, if changes affect users
- [*] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [*] Unit tests were added
- [-] **If feature added**: Added/extended example
- [-] **If feature added**: Added feature to API documentation
- [-] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
