### PR TITLE
Issue 1862 fix wel names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,6 @@ examples/data
 # pixi environments
 .pixi
 
-/imod/tests/mydask.png
+**/mydask.png
 /imod/tests/*_report.xml
 docs/sg_execution_times.rst

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -28,7 +28,8 @@ Added
 Fixed
 ~~~~~
 
-- Fixed bug where names of wels were duplicated by increasing the character limit to 40 
+- Fixed bug in :class:`imod.mf6.GroundwaterFlowModel` and :class:`imod.formats.prf.IpfResult` 
+  where names of wels were duplicated by increasing the character limit to 40
   and enumerating wel names.
 - Fixed bug where :class:`imod.mf6.Evapotranspiration` package would write files
   to binary, which could not be parsed by MODFLOW 6 when ``proportion_depth``

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -28,6 +28,8 @@ Added
 Fixed
 ~~~~~
 
+- Fixed bug where names of wels were duplicated by increasing the character limit to 40 
+  and enumerating wel names.
 - Fixed bug where :class:`imod.mf6.Evapotranspiration` package would write files
   to binary, which could not be parsed by MODFLOW 6 when ``proportion_depth``
   and ``proportion_rate`` were provided without segments.

--- a/imod/formats/prj/prj.py
+++ b/imod/formats/prj/prj.py
@@ -1119,8 +1119,8 @@ def open_projectfile_data(path: FilePath) -> tuple[dict[str, Any], dict[str, Any
 
         strippedkey = key.strip("(").strip(")")
         if strippedkey == "wel":
-            for key, d in data.items():
-                named_key = f"{strippedkey}-{key}"
+            for i, (key, d) in enumerate(data.items()):
+                named_key = f"{strippedkey}-{i + 1}-{key}"
                 prj_data[named_key] = d
                 repeat_stress[named_key] = repeats
         elif len(data) > 1:

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -331,7 +331,7 @@ class GroundwaterFlowModel(Modflow6Model):
         wel_times: StressPeriodTimesType = times if is_transient else "steady-state"
         wel_keys = [key for key in imod5_keys if key[0:3] == "wel"]
         for wel_key in wel_keys:
-            wel_key_truncated = wel_key[:16]
+            wel_key_truncated = wel_key[:40]
             if wel_key_truncated in result.keys():
                 # Remove this when https://github.com/Deltares/imod-python/issues/1167
                 # is resolved

--- a/imod/mf6/model_gwf.py
+++ b/imod/mf6/model_gwf.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import textwrap
 from datetime import datetime
 from typing import Optional, cast
 
@@ -332,18 +331,6 @@ class GroundwaterFlowModel(Modflow6Model):
         wel_keys = [key for key in imod5_keys if key[0:3] == "wel"]
         for wel_key in wel_keys:
             wel_key_truncated = wel_key[:40]
-            if wel_key_truncated in result.keys():
-                # Remove this when https://github.com/Deltares/imod-python/issues/1167
-                # is resolved
-                msg = textwrap.dedent(
-                    f"""Truncated key: '{wel_key_truncated}' already assigned to
-                    imported model, please rename wells so that unique names are
-                    formed after they are truncated to 16 characters for MODFLOW
-                    6.
-                    """
-                )
-                raise KeyError(msg)
-
             wel_layer = np.array(imod5_data[wel_key]["layer"])
             is_allocated = np.any(wel_layer == 0)
             wel_args = (wel_key, imod5_data, wel_times)

--- a/imod/tests/test_formats/test_prj.py
+++ b/imod/tests/test_formats/test_prj.py
@@ -586,8 +586,8 @@ class TestProjectFile:
         assert isinstance(
             content["cap"]["artificial_recharge_layer"], expected_sprinkling_type
         )
-        assert isinstance(content["wel-wells_l1"]["dataframe"][0], pd.DataFrame)
-        assert isinstance(content["wel-wells_l2"]["dataframe"][0], pd.DataFrame)
+        assert isinstance(content["wel-1-wells_l1"]["dataframe"][0], pd.DataFrame)
+        assert isinstance(content["wel-2-wells_l2"]["dataframe"][0], pd.DataFrame)
         assert isinstance(content["hfb-1"]["geodataframe"], gpd.GeoDataFrame)
         assert isinstance(content["hfb-2"]["geodataframe"], gpd.GeoDataFrame)
         assert isinstance(content["pcg"], dict)

--- a/imod/tests/test_formats/test_prj_wel.py
+++ b/imod/tests/test_formats/test_prj_wel.py
@@ -819,11 +819,8 @@ def test_open_projectfile_data_out_of_bounds_wells(
             assert field in actual
             assert actual[field] == wel_expected[field]
         if actual["has_associated"]:
-            timeseries = next(
-                data[name]["dataframe"][0]["time"]
-                for name in data
-                if "-associated" in name
-            )
+            pkg_name = next(name for name in data if "-associated" in name)
+            timeseries = data[pkg_name]["dataframe"][0]["time"]
             # Test if last element not NaT (since pandas 3, before it was NaT)
             assert timeseries.iloc[-1] == pd.Timestamp("2999-11-12 00:00:00")
 

--- a/imod/tests/test_formats/test_prj_wel.py
+++ b/imod/tests/test_formats/test_prj_wel.py
@@ -597,7 +597,6 @@ class WellReadCases:
                 "factor": [1.0],
                 "addition": [0.0],
             },
-
         }
 
 
@@ -630,12 +629,20 @@ class WellPackageCases:
 
     def case_simple__first(self):
         return {
-            "wel-1-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-1-simple1": (
+                False,
+                True,
+                [datetime(1982, 2, 1), datetime(1982, 3, 1)],
+            ),
         }
 
     def case_simple__first_multi_layer1(self):
         return {
-            "wel-1-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-1-simple1": (
+                False,
+                True,
+                [datetime(1982, 2, 1), datetime(1982, 3, 1)],
+            ),
         }
 
     def case_simple__first_multi_layer2(self):
@@ -660,7 +667,11 @@ class WellPackageCases:
 
     def case_simple__all_different1(self):
         return {
-            "wel-1-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-1-simple1": (
+                False,
+                True,
+                [datetime(1982, 2, 1), datetime(1982, 3, 1)],
+            ),
             "wel-2-simple2": (False, True, [datetime(1982, 3, 1)]),
             "wel-3-simple3": (False, True, []),
         }
@@ -693,7 +704,11 @@ class WellPackageCases:
 
     def case_mixed__first(self):
         return {
-            "wel-1-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-1-simple1": (
+                False,
+                True,
+                [datetime(1982, 2, 1), datetime(1982, 3, 1)],
+            ),
             "wel-2-associated": (False, True, []),
         }
 
@@ -705,7 +720,11 @@ class WellPackageCases:
 
     def case_mixed__associated_second(self):
         return {
-            "wel-1-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-1-simple1": (
+                False,
+                True,
+                [datetime(1982, 2, 1), datetime(1982, 3, 1)],
+            ),
             "wel-2-associated": (True, False, []),
         }
 

--- a/imod/tests/test_formats/test_prj_wel.py
+++ b/imod/tests/test_formats/test_prj_wel.py
@@ -289,7 +289,7 @@ class WellReadCases:
 
     def case_simple__steady_state(self):
         return {
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [None],
                 "layer": [1],
@@ -300,7 +300,7 @@ class WellReadCases:
 
     def case_associated__steady_state(self):
         return {
-            "wel-associated": {
+            "wel-1-associated": {
                 "has_associated": True,
                 "time": [None],
                 "layer": [1],
@@ -311,15 +311,15 @@ class WellReadCases:
 
     def case_mixed__steady_state(self):
         return {
-            "wel-simple1": {
-                "has_associated": False,
+            "wel-1-associated": {
+                "has_associated": True,
                 "time": [None],
                 "layer": [1],
                 "factor": [1.0],
                 "addition": [0.0],
             },
-            "wel-associated": {
-                "has_associated": True,
+            "wel-2-simple1": {
+                "has_associated": False,
                 "time": [None],
                 "layer": [1],
                 "factor": [1.0],
@@ -329,7 +329,7 @@ class WellReadCases:
 
     def case_simple__first(self):
         return {
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [datetime(1982, 1, 1)],
                 "layer": [1],
@@ -340,7 +340,7 @@ class WellReadCases:
 
     def case_simple__first_multi_layer1(self):
         return {
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [datetime(1982, 1, 1), datetime(1982, 1, 1)],
                 "layer": [1, 2],
@@ -351,7 +351,7 @@ class WellReadCases:
 
     def case_simple__first_multi_layer2(self):
         return {
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [datetime(1982, 1, 1), datetime(1982, 1, 1)],
                 "layer": [0, 1],
@@ -362,7 +362,7 @@ class WellReadCases:
 
     def case_simple__all_same(self):
         return {
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [
                     datetime(1982, 1, 1),
@@ -377,7 +377,7 @@ class WellReadCases:
 
     def case_simple__all_same_multi_layer1(self):
         return {
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [
                     datetime(1982, 1, 1),
@@ -395,7 +395,7 @@ class WellReadCases:
 
     def case_simple__all_same_multi_layer2(self):
         return {
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [
                     datetime(1982, 1, 1),
@@ -413,21 +413,21 @@ class WellReadCases:
 
     def case_simple__all_different1(self):
         return {
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [datetime(1982, 1, 1)],
                 "layer": [1],
                 "factor": [1.0],
                 "addition": [0.0],
             },
-            "wel-simple2": {
+            "wel-2-simple2": {
                 "has_associated": False,
                 "time": [datetime(1982, 2, 1)],
                 "layer": [1],
                 "factor": [1.0],
                 "addition": [0.0],
             },
-            "wel-simple3": {
+            "wel-3-simple3": {
                 "has_associated": False,
                 "time": [datetime(1982, 3, 1)],
                 "layer": [1],
@@ -438,21 +438,21 @@ class WellReadCases:
 
     def case_simple__all_different2(self):
         return {
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [datetime(1982, 1, 1), datetime(1982, 2, 1)],
                 "layer": [1, 1],
                 "factor": [1.0, 1.0],
                 "addition": [0.0, 0.0],
             },
-            "wel-simple2": {
+            "wel-2-simple2": {
                 "has_associated": False,
                 "time": [datetime(1982, 2, 1)],
                 "layer": [1],
                 "factor": [1.0],
                 "addition": [0.0],
             },
-            "wel-simple3": {
+            "wel-3-simple3": {
                 "has_associated": False,
                 "time": [datetime(1982, 3, 1)],
                 "layer": [1],
@@ -463,21 +463,21 @@ class WellReadCases:
 
     def case_simple__all_different3(self):
         return {
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [datetime(1982, 1, 1), datetime(1982, 3, 1)],
                 "layer": [1, 1],
                 "factor": [1.0, 1.0],
                 "addition": [0.0, 0.0],
             },
-            "wel-simple2": {
+            "wel-2-simple2": {
                 "has_associated": False,
                 "time": [datetime(1982, 2, 1)],
                 "layer": [1],
                 "factor": [1.0],
                 "addition": [0.0],
             },
-            "wel-simple3": {
+            "wel-3-simple3": {
                 "has_associated": False,
                 "time": [datetime(1982, 3, 1)],
                 "layer": [1],
@@ -488,7 +488,7 @@ class WellReadCases:
 
     def case_associated__first(self):
         return {
-            "wel-associated": {
+            "wel-1-associated": {
                 "has_associated": True,
                 "time": [datetime(1982, 1, 1)],
                 "layer": [1],
@@ -499,7 +499,7 @@ class WellReadCases:
 
     def case_associated__all(self):
         return {
-            "wel-associated": {
+            "wel-1-associated": {
                 "has_associated": True,
                 "time": [
                     datetime(1982, 1, 1),
@@ -514,7 +514,7 @@ class WellReadCases:
 
     def case_associated__all_varying_factors(self):
         return {
-            "wel-associated": {
+            "wel-1-associated": {
                 "has_associated": True,
                 "time": [
                     datetime(1982, 1, 1),
@@ -529,7 +529,7 @@ class WellReadCases:
 
     def case_associated__multiple_layers_different_factors(self):
         return {
-            "wel-associated": {
+            "wel-1-associated": {
                 "has_associated": True,
                 "time": [
                     datetime(1982, 1, 1),
@@ -543,14 +543,14 @@ class WellReadCases:
 
     def case_mixed__first(self):
         return {
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [datetime(1982, 1, 1)],
                 "layer": [1],
                 "factor": [1.0],
                 "addition": [0.0],
             },
-            "wel-associated": {
+            "wel-2-associated": {
                 "has_associated": True,
                 "time": [datetime(1982, 1, 1)],
                 "layer": [1],
@@ -561,7 +561,7 @@ class WellReadCases:
 
     def case_mixed__all(self):
         return {
-            "wel-associated": {
+            "wel-1-associated": {
                 "has_associated": True,
                 "time": [
                     datetime(1982, 1, 1),
@@ -572,7 +572,7 @@ class WellReadCases:
                 "factor": [1.0, 1.0, 1.0],
                 "addition": [0.0, 0.0, 0.0],
             },
-            "wel-simple1": {
+            "wel-2-simple1": {
                 "has_associated": False,
                 "time": [datetime(1982, 2, 1)],
                 "layer": [1],
@@ -583,20 +583,21 @@ class WellReadCases:
 
     def case_mixed__associated_second(self):
         return {
-            "wel-associated": {
-                "has_associated": True,
-                "time": [datetime(1982, 2, 1)],
-                "layer": [1],
-                "factor": [1.0],
-                "addition": [0.0],
-            },
-            "wel-simple1": {
+            "wel-1-simple1": {
                 "has_associated": False,
                 "time": [datetime(1982, 1, 1)],
                 "layer": [1],
                 "factor": [1.0],
                 "addition": [0.0],
             },
+            "wel-2-associated": {
+                "has_associated": True,
+                "time": [datetime(1982, 2, 1)],
+                "layer": [1],
+                "factor": [1.0],
+                "addition": [0.0],
+            },
+
         }
 
 
@@ -613,99 +614,99 @@ class WellPackageCases:
 
     def case_simple__steady_state(self):
         return {
-            "wel-simple1": (False, False, []),
+            "wel-1-simple1": (False, False, []),
         }
 
     def case_associated__steady_state(self):
         return {
-            "wel-associated": (False, True, []),
+            "wel-1-associated": (False, True, []),
         }
 
     def case_mixed__steady_state(self):
         return {
-            "wel-associated": (False, True, []),
-            "wel-simple1": (False, False, []),
+            "wel-1-associated": (False, True, []),
+            "wel-2-simple1": (False, False, []),
         }
 
     def case_simple__first(self):
         return {
-            "wel-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-1-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
         }
 
     def case_simple__first_multi_layer1(self):
         return {
-            "wel-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-1-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
         }
 
     def case_simple__first_multi_layer2(self):
         return {
-            "wel-simple1": (True, False, []),
+            "wel-1-simple1": (True, False, []),
         }
 
     def case_simple__all_same(self):
         return {
-            "wel-simple1": (False, True, []),
+            "wel-1-simple1": (False, True, []),
         }
 
     def case_simple__all_same_multi_layer1(self):
         return {
-            "wel-simple1": (False, True, []),
+            "wel-1-simple1": (False, True, []),
         }
 
     def case_simple__all_same_multi_layer2(self):
         return {
-            "wel-simple1": (True, False, []),
+            "wel-1-simple1": (True, False, []),
         }
 
     def case_simple__all_different1(self):
         return {
-            "wel-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
-            "wel-simple2": (False, True, [datetime(1982, 3, 1)]),
-            "wel-simple3": (False, True, []),
+            "wel-1-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-2-simple2": (False, True, [datetime(1982, 3, 1)]),
+            "wel-3-simple3": (False, True, []),
         }
 
     def case_simple__all_different2(self):
         return {
-            "wel-simple1": (False, True, [datetime(1982, 3, 1)]),
-            "wel-simple2": (False, True, [datetime(1982, 3, 1)]),
-            "wel-simple3": (False, True, []),
+            "wel-1-simple1": (False, True, [datetime(1982, 3, 1)]),
+            "wel-2-simple2": (False, True, [datetime(1982, 3, 1)]),
+            "wel-3-simple3": (False, True, []),
         }
 
     def case_simple__all_different3(self):
         return {
-            "wel-simple1": (False, True, [datetime(1982, 2, 1)]),
-            "wel-simple2": (False, True, [datetime(1982, 3, 1)]),
-            "wel-simple3": (False, True, []),
+            "wel-1-simple1": (False, True, [datetime(1982, 2, 1)]),
+            "wel-2-simple2": (False, True, [datetime(1982, 3, 1)]),
+            "wel-3-simple3": (False, True, []),
         }
 
     def case_associated__first(self):
-        return {"wel-associated": (False, True, [])}
+        return {"wel-1-associated": (False, True, [])}
 
     def case_associated__all(self):
-        return {"wel-associated": (False, True, [])}
+        return {"wel-1-associated": (False, True, [])}
 
     def case_associated__all_varying_factors(self):
-        return {"wel-associated": (True, False, [])}
+        return {"wel-1-associated": (True, False, [])}
 
     def case_associated__multiple_layers_different_factors(self):
-        return {"wel-associated": (True, False, [])}
+        return {"wel-1-associated": (True, False, [])}
 
     def case_mixed__first(self):
         return {
-            "wel-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
-            "wel-associated": (False, True, []),
+            "wel-1-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-2-associated": (False, True, []),
         }
 
     def case_mixed__all(self):
         return {
-            "wel-simple1": (False, True, [datetime(1982, 3, 1)]),
-            "wel-associated": (False, True, []),
+            "wel-1-associated": (False, True, []),
+            "wel-2-simple1": (False, True, [datetime(1982, 3, 1)]),
         }
 
     def case_mixed__associated_second(self):
         return {
-            "wel-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
-            "wel-associated": (True, False, []),
+            "wel-1-simple1": (False, True, [datetime(1982, 2, 1), datetime(1982, 3, 1)]),
+            "wel-2-associated": (True, False, []),
         }
 
 
@@ -799,7 +800,11 @@ def test_open_projectfile_data_out_of_bounds_wells(
             assert field in actual
             assert actual[field] == wel_expected[field]
         if actual["has_associated"]:
-            timeseries = data["wel-associated"]["dataframe"][0]["time"]
+            timeseries = next(
+                data[name]["dataframe"][0]["time"]
+                for name in data
+                if "-associated" in name
+            )
             # Test if last element not NaT (since pandas 3, before it was NaT)
             assert timeseries.iloc[-1] == pd.Timestamp("2999-11-12 00:00:00")
 

--- a/imod/tests/test_mf6/test_import_prj.py
+++ b/imod/tests/test_mf6/test_import_prj.py
@@ -174,34 +174,34 @@ def test_import_ipf(tmp_path):
     result_snippet_1 = open_projectfile_data(projects_file)
 
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L3"]["dataframe"][0]["rate"]
-        == 2 * result_snippet_0[0]["wel-WELLS_L3"]["dataframe"][0]["rate"] + 1.3
+        result_snippet_1[0]["wel-1-WELLS_L3"]["dataframe"][0]["rate"]
+        == 2 * result_snippet_0[0]["wel-1-WELLS_L3"]["dataframe"][0]["rate"] + 1.3
     )
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L4"]["dataframe"][0]["rate"]
-        == -1 * result_snippet_0[0]["wel-WELLS_L4"]["dataframe"][0]["rate"] + 0
+        result_snippet_1[0]["wel-2-WELLS_L4"]["dataframe"][0]["rate"]
+        == -1 * result_snippet_0[0]["wel-2-WELLS_L4"]["dataframe"][0]["rate"] + 0
     )
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L5"]["dataframe"][0]["rate"]
-        == 2 * result_snippet_0[0]["wel-WELLS_L4"]["dataframe"][0]["rate"] + 1.3
+        result_snippet_1[0]["wel-3-WELLS_L5"]["dataframe"][0]["rate"]
+        == 2 * result_snippet_0[0]["wel-3-WELLS_L5"]["dataframe"][0]["rate"] + 1.3
     )
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L3"]["dataframe"][0]["filt_top"] == 11.0
+        result_snippet_1[0]["wel-1-WELLS_L3"]["dataframe"][0]["filt_top"] == 11.0
     )
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L3"]["dataframe"][0]["filt_bot"] == 6.0
+        result_snippet_1[0]["wel-1-WELLS_L3"]["dataframe"][0]["filt_bot"] == 6.0
     )
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L4"]["dataframe"][0]["filt_top"] == 11.0
+        result_snippet_1[0]["wel-2-WELLS_L4"]["dataframe"][0]["filt_top"] == 11.0
     )
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L4"]["dataframe"][0]["filt_bot"] == 6.0
+        result_snippet_1[0]["wel-2-WELLS_L4"]["dataframe"][0]["filt_bot"] == 6.0
     )
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L5"]["dataframe"][0]["filt_top"] == 11.0
+        result_snippet_1[0]["wel-3-WELLS_L5"]["dataframe"][0]["filt_top"] == 11.0
     )
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L5"]["dataframe"][0]["filt_bot"] == 6.0
+        result_snippet_1[0]["wel-3-WELLS_L5"]["dataframe"][0]["filt_bot"] == 6.0
     )
 
 
@@ -243,13 +243,13 @@ def test_import_ipf_unique_id_and_logging(tmp_path):
     # test that id's were made unique
     # Assert
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L3"]["dataframe"][0]["id"] == "extractions"
+        result_snippet_1[0]["wel-1-WELLS_L3"]["dataframe"][0]["id"] == "extractions"
     )
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L4"]["dataframe"][0]["id"] == "extractions_1"
+        result_snippet_1[0]["wel-2-WELLS_L4"]["dataframe"][0]["id"] == "extractions_1"
     )
     assert np.all(
-        result_snippet_1[0]["wel-WELLS_L5"]["dataframe"][0]["id"] == "extractions_2"
+        result_snippet_1[0]["wel-3-WELLS_L5"]["dataframe"][0]["id"] == "extractions_2"
     )
 
     with open(logfile_path, "r") as log_file:

--- a/imod/tests/test_mf6/test_mf6_simulation.py
+++ b/imod/tests/test_mf6/test_mf6_simulation.py
@@ -682,8 +682,8 @@ def test_import_from_imod5__correct_well_type(imod5_dataset):
     period_data = imod5_dataset[1]
     # Temporarily change layer number to 0, to force Well object instead of
     # LayeredWell
-    original_wel_layer = imod5_data["wel-WELLS_L3"]["layer"]
-    imod5_data["wel-WELLS_L3"]["layer"] = [0] * len(original_wel_layer)
+    original_wel_layer = imod5_data["wel-1-WELLS_L3"]["layer"]
+    imod5_data["wel-1-WELLS_L3"]["layer"] = [0] * len(original_wel_layer)
     # Other arrangement
     datelist = pd.date_range(start="1/1/1989", end="1/1/2013", freq="W")
 
@@ -694,11 +694,11 @@ def test_import_from_imod5__correct_well_type(imod5_dataset):
         datelist,
     )
     # Set layer back to right value (before AssertionError might be thrown)
-    imod5_data["wel-WELLS_L3"]["layer"] = original_wel_layer
+    imod5_data["wel-1-WELLS_L3"]["layer"] = original_wel_layer
     # Assert
-    assert isinstance(simulation["imported_model"]["wel-WELLS_L3"], Well)
-    assert isinstance(simulation["imported_model"]["wel-WELLS_L4"], LayeredWell)
-    assert isinstance(simulation["imported_model"]["wel-WELLS_L5"], LayeredWell)
+    assert isinstance(simulation["imported_model"]["wel-1-WELLS_L3"], Well)
+    assert isinstance(simulation["imported_model"]["wel-2-WELLS_L4"], LayeredWell)
+    assert isinstance(simulation["imported_model"]["wel-3-WELLS_L5"], LayeredWell)
 
 
 @pytest.mark.unittest_jit
@@ -724,9 +724,9 @@ def test_import_from_imod5__well_steady_state(imod5_dataset):
     )
     # Assert
     gwf = simulation["imported_model"]
-    assert "time" not in gwf["wel-WELLS_L3"].dataset.coords
-    assert "time" not in gwf["wel-WELLS_L4"].dataset.coords
-    assert "time" not in gwf["wel-WELLS_L5"].dataset.coords
+    assert "time" not in gwf["wel-1-WELLS_L3"].dataset.coords
+    assert "time" not in gwf["wel-2-WELLS_L4"].dataset.coords
+    assert "time" not in gwf["wel-3-WELLS_L5"].dataset.coords
     # Teardown
     # Reassign storage package again
     imod5_data["sto"] = sto

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -880,7 +880,7 @@ def test_import_and_convert_to_mf6(imod5_dataset, tmp_path, wel_class):
     times = list(pd.date_range(datetime(1989, 1, 1), datetime(2013, 1, 1), 8400))
 
     # import grid-agnostic well from imod5 data (it contains 1 well)
-    wel = wel_class.from_imod5_data("wel-WELLS_L3", data, times, minimum_thickness=1.0)
+    wel = wel_class.from_imod5_data("wel-1-WELLS_L3", data, times, minimum_thickness=1.0)
     assert wel.dataset["x"].values[0] == 197910.0
     assert wel.dataset["y"].values[0] == 362860.0
     np.testing.assert_almost_equal(
@@ -911,7 +911,7 @@ def test_import__as_steady_state(imod5_dataset, wel_class):
     data = imod5_dataset[0]
     times = "steady-state"
     # Import grid-agnostic well from imod5 data (it contains 1 well)
-    wel = wel_class.from_imod5_data("wel-WELLS_L3", data, times)
+    wel = wel_class.from_imod5_data("wel-1-WELLS_L3", data, times)
 
     assert "time" not in wel.dataset.coords
     assert wel.dataset["rate"].shape == (1,)
@@ -928,7 +928,7 @@ def test_import_and_cleanup(imod5_dataset, wel_class: Well):
     times = list(pd.date_range(datetime(1989, 1, 1), datetime(2013, 1, 1), ntimes + 1))
 
     # Import grid-agnostic well from imod5 data (it contains 1 well)
-    wel = wel_class.from_imod5_data("wel-WELLS_L3", data, times)
+    wel = wel_class.from_imod5_data("wel-1-WELLS_L3", data, times)
     assert len(wel.dataset.coords["time"]) == ntimes
     # Cleanup
     wel.cleanup(target_dis)
@@ -946,11 +946,11 @@ def test_import_simple_wells__steady_state(
     imod5dict, _ = open_projectfile_data(well_simple_import_prj__steady_state)
     # Set layer to 1, to avoid validation error.
     if wel_class is LayeredWell:
-        imod5dict["wel-ipf1"]["layer"] = [1]
-        imod5dict["wel-ipf2"]["layer"] = [1]
+        imod5dict["wel-1-ipf1"]["layer"] = [1]
+        imod5dict["wel-2-ipf2"]["layer"] = [1]
 
-    wel1 = wel_class.from_imod5_data("wel-ipf1", imod5dict, "steady-state")
-    wel2 = wel_class.from_imod5_data("wel-ipf2", imod5dict, "steady-state")
+    wel1 = wel_class.from_imod5_data("wel-1-ipf1", imod5dict, "steady-state")
+    wel2 = wel_class.from_imod5_data("wel-2-ipf2", imod5dict, "steady-state")
 
     assert wel1.dataset["rate"].shape == (13,)
     assert wel2.dataset["rate"].shape == (2,)
@@ -965,19 +965,19 @@ def test_import_simple_wells__transient(well_simple_import_prj__transient, wel_c
     imod5dict, _ = open_projectfile_data(well_simple_import_prj__transient)
     # Set layer to 1, to avoid validation error.
     if wel_class is LayeredWell:
-        imod5dict["wel-ipf1"]["layer"] = [1]
-        imod5dict["wel-ipf2"]["layer"] = [1]
+        imod5dict["wel-1-ipf1"]["layer"] = [1]
+        imod5dict["wel-2-ipf2"]["layer"] = [1]
 
     with pytest.raises(ValueError):
-        wel_class.from_imod5_data("wel-ipf1", imod5dict, "steady-state")
+        wel_class.from_imod5_data("wel-1-ipf1", imod5dict, "steady-state")
 
     with pytest.raises(ValueError):
-        wel_class.from_imod5_data("wel-ipf2", imod5dict, "steady-state")
+        wel_class.from_imod5_data("wel-2-ipf2", imod5dict, "steady-state")
 
-    times = [imod5dict["wel-ipf2"]["time"][0], datetime(2001, 1, 1)]
+    times = [imod5dict["wel-2-ipf2"]["time"][0], datetime(2001, 1, 1)]
 
-    wel1 = wel_class.from_imod5_data("wel-ipf1", imod5dict, times)
-    wel2 = wel_class.from_imod5_data("wel-ipf2", imod5dict, times)
+    wel1 = wel_class.from_imod5_data("wel-1-ipf1", imod5dict, times)
+    wel2 = wel_class.from_imod5_data("wel-2-ipf2", imod5dict, times)
 
     assert wel1.dataset["rate"].shape == (1, 13)
     assert wel2.dataset["rate"].shape == (1, 2)
@@ -999,11 +999,11 @@ def test_import_multiple_wells(well_regular_import_prj, wel_class):
     ]
     # Set layer to 1, to avoid validation error.
     if wel_class is LayeredWell:
-        imod5dict["wel-ipf1"]["layer"] = [1]
-        imod5dict["wel-ipf2"]["layer"] = [1]
+        imod5dict["wel-1-ipf1"]["layer"] = [1]
+        imod5dict["wel-2-ipf2"]["layer"] = [1]
     # import grid-agnostic well from imod5 data (it contains 2 packages with 3 wells each)
-    wel1 = wel_class.from_imod5_data("wel-ipf1", imod5dict, times)
-    wel2 = wel_class.from_imod5_data("wel-ipf2", imod5dict, times)
+    wel1 = wel_class.from_imod5_data("wel-1-ipf1", imod5dict, times)
+    wel2 = wel_class.from_imod5_data("wel-2-ipf2", imod5dict, times)
 
     assert np.all(wel1.x == np.array([191112.11, 191171.96, 191231.52]))
     assert np.all(wel2.x == np.array([191112.11, 191171.96, 191231.52]))
@@ -1025,11 +1025,11 @@ def test_import_from_imod5_with_duplication(well_duplication_import_prj, wel_cla
     ]
     # Set layer to 1, to avoid validation error.
     if wel_class is LayeredWell:
-        imod5dict["wel-ipf1"]["layer"] = [1]
-        imod5dict["wel-ipf2"]["layer"] = [1]
+        imod5dict["wel-1-ipf1"]["layer"] = [1]
+        imod5dict["wel-2-ipf2"]["layer"] = [1]
     # import grid-agnostic well from imod5 data (it contains 2 packages with 3 wells each)
-    wel1 = wel_class.from_imod5_data("wel-ipf1", imod5dict, times)
-    wel2 = wel_class.from_imod5_data("wel-ipf2", imod5dict, times)
+    wel1 = wel_class.from_imod5_data("wel-1-ipf1", imod5dict, times)
+    wel2 = wel_class.from_imod5_data("wel-2-ipf2", imod5dict, times)
 
     assert np.all(wel1.x == np.array([191171.96, 191231.52, 191231.52]))
     assert np.all(wel2.x == np.array([191112.11, 191171.96, 191231.52]))
@@ -1044,7 +1044,7 @@ def test_logmessage_for_layer_assignment_import_imod5(
     imod5dict = open_projectfile_data(well_regular_import_prj)
 
     logfile_path = tmp_path / "logfile.txt"
-    imod5dict[0]["wel-ipf1"]["layer"] = [layer] * len(imod5dict[0]["wel-ipf1"]["layer"])
+    imod5dict[0]["wel-1-ipf1"]["layer"] = [layer] * len(imod5dict[0]["wel-1-ipf1"]["layer"])
 
     try:
         with open(logfile_path, "w") as sys.stdout:
@@ -1056,7 +1056,7 @@ def test_logmessage_for_layer_assignment_import_imod5(
                 add_default_stream_handler=True,
             )
 
-            _ = imod.mf6.Well.from_imod5_data("wel-ipf1", imod5dict[0], times)
+            _ = imod.mf6.Well.from_imod5_data("wel-1-ipf1", imod5dict[0], times)
 
     finally:
         # turn the logger off again
@@ -1072,7 +1072,7 @@ def test_logmessage_for_layer_assignment_import_imod5(
         log = log_file.read()
         message_required = layer != 0
         message_present = (
-            "In well wel-ipf1 a layer was assigned, but this is not\nsupported" in log
+            "In well wel-1-ipf1 a layer was assigned, but this is not\nsupported" in log
         )
         assert message_required == message_present
 
@@ -1085,7 +1085,7 @@ def test_logmessage_for_missing_filter_settings(
     imod5dict = open_projectfile_data(well_regular_import_prj)
     logfile_path = tmp_path / "logfile.txt"
     if remove is not None:
-        imod5dict[0]["wel-ipf1"]["dataframe"][0] = imod5dict[0]["wel-ipf1"][
+        imod5dict[0]["wel-1-ipf1"]["dataframe"][0] = imod5dict[0]["wel-1-ipf1"][
             "dataframe"
         ][0].drop(remove, axis=1)
 
@@ -1099,7 +1099,7 @@ def test_logmessage_for_missing_filter_settings(
                 add_default_stream_handler=True,
             )
 
-            _ = imod.mf6.Well.from_imod5_data("wel-ipf1", imod5dict[0], times)
+            _ = imod.mf6.Well.from_imod5_data("wel-1-ipf1", imod5dict[0], times)
     except Exception:
         assert remove is not None
 
@@ -1117,7 +1117,7 @@ def test_logmessage_for_missing_filter_settings(
         log = log_file.read()
         message_required = remove is not None
         message_present = (
-            "In well wel-ipf1 the 'filt_top' and 'filt_bot' columns were\nnot both found;"
+            "In well wel-1-ipf1 the 'filt_top' and 'filt_bot' columns were\nnot both found;"
             in log
         )
         assert message_required == message_present

--- a/imod/tests/test_mf6/test_mf6_wel.py
+++ b/imod/tests/test_mf6/test_mf6_wel.py
@@ -880,7 +880,9 @@ def test_import_and_convert_to_mf6(imod5_dataset, tmp_path, wel_class):
     times = list(pd.date_range(datetime(1989, 1, 1), datetime(2013, 1, 1), 8400))
 
     # import grid-agnostic well from imod5 data (it contains 1 well)
-    wel = wel_class.from_imod5_data("wel-1-WELLS_L3", data, times, minimum_thickness=1.0)
+    wel = wel_class.from_imod5_data(
+        "wel-1-WELLS_L3", data, times, minimum_thickness=1.0
+    )
     assert wel.dataset["x"].values[0] == 197910.0
     assert wel.dataset["y"].values[0] == 362860.0
     np.testing.assert_almost_equal(
@@ -1044,7 +1046,9 @@ def test_logmessage_for_layer_assignment_import_imod5(
     imod5dict = open_projectfile_data(well_regular_import_prj)
 
     logfile_path = tmp_path / "logfile.txt"
-    imod5dict[0]["wel-1-ipf1"]["layer"] = [layer] * len(imod5dict[0]["wel-1-ipf1"]["layer"])
+    imod5dict[0]["wel-1-ipf1"]["layer"] = [layer] * len(
+        imod5dict[0]["wel-1-ipf1"]["layer"]
+    )
 
     try:
         with open(logfile_path, "w") as sys.stdout:


### PR DESCRIPTION
Fixes #1862 and #1167 

# Description
Increased the character limit to 40 in line with MODFLOW6 and added enumeration to the naming of wells so that names aren't duplicated. 

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [x] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [x] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
