### PR TITLE
Issue 1882 - Fix rolling out of character limit update

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -93,6 +93,8 @@ Fixed
 Changed
 ~~~~~~~
 
+- Increased the character limit to 40 in :class:`imod.mf6.Modflow6Model` for all 
+  keys assigned to a Modflow6 model.
 - ``proportion_depth`` and ``proportion_rate`` in
   :class:`imod.mf6.Evapotranspiration` are now optional variables. If provided,
   now require ``"segment"`` dimension when ``proportion_depth`` and

--- a/imod/mf6/model.py
+++ b/imod/mf6/model.py
@@ -181,10 +181,10 @@ class Modflow6Model(collections.UserDict[str, Package], IModel, abc.ABC):
         )
 
     def __setitem__(self, key, value):
-        if len(key) > 16:
+        if len(key) > 40:
             raise KeyError(
-                f"Received key with more than 16 characters: '{key}'"
-                "Modflow 6 has a character limit of 16."
+                f"Received key with more than 40 characters: '{key}'"
+                "Modflow 6 has a character limit of 40 characters."
             )
 
         super().__setitem__(key, value)

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -87,7 +87,9 @@ def test_key_assign():
     gwf_model["ic"] = imod.mf6.InitialConditions(start=0.0)
 
     with pytest.raises(KeyError):
-        gwf_model["it-is-an-even-longer-way-too-long-key-name"] = imod.mf6.InitialConditions(start=0.0)
+        gwf_model["it-is-an-even-longer-way-too-long-key-name"] = (
+            imod.mf6.InitialConditions(start=0.0)
+        )
 
 
 def roundtrip(model, tmp_path):

--- a/imod/tests/test_mf6/test_mf6_model.py
+++ b/imod/tests/test_mf6/test_mf6_model.py
@@ -87,7 +87,7 @@ def test_key_assign():
     gwf_model["ic"] = imod.mf6.InitialConditions(start=0.0)
 
     with pytest.raises(KeyError):
-        gwf_model["way-too-long-key-name"] = imod.mf6.InitialConditions(start=0.0)
+        gwf_model["it-is-an-even-longer-way-too-long-key-name"] = imod.mf6.InitialConditions(start=0.0)
 
 
 def roundtrip(model, tmp_path):

--- a/imod/tests/test_mf6/test_mf6_transport_model.py
+++ b/imod/tests/test_mf6/test_mf6_transport_model.py
@@ -17,9 +17,9 @@ def test_long_package_name():
     m = imod.mf6.GroundwaterTransportModel()
     with pytest.raises(
         KeyError,
-        match="Received key with more than 16 characters: 'my_very_long_package_name'Modflow 6 has a character limit of 16.",
+        match="Received key with more than 40 characters: 'my_extremely_long_and_verbose_package_name'Modflow 6 has a character limit of 40.",
     ):
-        m["my_very_long_package_name"] = imod.mf6.AdvectionCentral()
+        m["my_extremely_long_and_verbose_package_name"] = imod.mf6.AdvectionCentral()
 
 
 def test_transport_model_rendering():


### PR DESCRIPTION
Fixes #1882 

# Description
We now only raise an error if a key is longer than 40 characters and updated the relevant tests that were still looking for 16. After checking, we already truncate the names after the numbers are added (so the logic was already correct). 

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
