### PR TITLE
Issue #1896 Move the pixi environment folder out of the mounted source folder.

### DIFF
--- a/.teamcity/Pixi/PixiProject.kt
+++ b/.teamcity/Pixi/PixiProject.kt
@@ -38,6 +38,9 @@ object UpdateDependencies : BuildType({
                     git remote set-url origin https://%GH_USER%:%env.GH_TOKEN%@github.com/Deltares/imod-python.git
                     git checkout -b pixi_update_%build.counter%
                     
+                    echo "Set environment location for detached environments" 
+                    pixi config set --local detached-environments "C:\pixi_envs"
+
                     echo "Update dependencies" 
                     pixi run -e pixi-update update
                     


### PR DESCRIPTION
Fixes #1896 

# Description
The Pixi update build step has been failing for several weeks now.
A file is being accessed by multiple processes.
My suspicion is that the host system is also accessing the pixi environment (virus scanner?)

In this PR is move the pixi environment location out of the source folder (The source folder lives on the host system and is mounted into the docker container). After this change only the container has access to the environment.
If it still fails then the issue is somewhere in the container

As an added benefit this will also bring some performance improvements. We already use this setting in the main pipeline.

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
