### PR TITLE
Fail the build when one of the commands in the script fail

### DIFF
--- a/.teamcity/Pixi/PixiProject.kt
+++ b/.teamcity/Pixi/PixiProject.kt
@@ -4,6 +4,7 @@ import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerSupport
+import jetbrains.buildServer.configs.kotlin.buildSteps.PowerShellStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.powerShell
 import jetbrains.buildServer.configs.kotlin.triggers.schedule
 
@@ -31,9 +32,14 @@ object UpdateDependencies : BuildType({
         powerShell {
             name = "Update dependencies"
             id = "Update_dependencies"
+            edition = PowerShellStep.Edition.Core
             workingDir = "imod-python"
             scriptMode = script {
                 content = """
+                    # Fail the build when any command returns a non-zero exit code.
+                    ${'$'}ErrorActionPreference = "Stop"
+                    ${'$'}PSNativeCommandUseErrorActionPreference = ${'$'}true
+
                     echo "Create update branch"
                     git remote set-url origin https://%GH_USER%:%env.GH_TOKEN%@github.com/Deltares/imod-python.git
                     git checkout -b pixi_update_%build.counter%


### PR DESCRIPTION
Fixes #1900

# Description
The pixi update pipeline doesnt handle errors produced by any of the commands called in the script correctly.
Instead it just continue with the next lines of the script which results in the pipeline being green while actually it failed.

In this PR the same fix is applied to imod-python as has been done in imod_coupler.
https://github.com/Deltares/imod_coupler/pull/495

As a result an error is now handled correctly:
https://dpcbuild.deltares.nl/buildConfiguration/iMOD6_Coupler_UpdateDependencies/7684833?buildTab=log&linesState=524&logView=flowAware

<img width="695" height="400" alt="image" src="https://github.com/user-attachments/assets/4ed64b7d-df62-4b93-9871-21cbff7abc3c" />
 

# Checklist
<!---
Before requesting review, please go through this checklist:
-->

- [x] Links to correct issue
- [ ] Update changelog, if changes affect users
- [x] PR title starts with ``Issue #nr``, e.g. ``Issue #737``
- [ ] Unit tests were added
- [ ] **If feature added**: Added/extended example
- [ ] **If feature added**: Added feature to API documentation
- [ ] **If pixi.lock was changed**: Ran `pixi run generate-sbom` and committed changes
